### PR TITLE
test(rules): #941 — negative UNKNOWN corpus, loud intake failures, sweep exclusion for mutating tests, platform-keyed ratchet, timestamp-aware pruner (#929)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,15 @@
 .cxx
 local.properties
 /app/src/test/resources/snapshots/INBOX/
-# UNKNOWN is staging too (unrecognized captures) — never commit; it is the inbox.
-/app/src/test/resources/snapshots/UNKNOWN/
+# UNKNOWN is staging too (unrecognized captures) — never commit raw triage drops.
+# ONE exception: `UNKNOWN/negative/` is the COMMITTED must-stay-UNKNOWN corpus (#941).
+# The pattern ignores the folder's CONTENTS (`/*`) rather than the folder itself, because
+# git cannot re-include anything under an excluded directory — that is what makes the
+# negation below reachable. The flat staging loaders (InboxProcessorTest /
+# UnknownScreenAnalysisTest) list files, not directories, so they never see `negative/`
+# and can never graduate/prune a committed negative frame.
+/app/src/test/resources/snapshots/UNKNOWN/*
+!/app/src/test/resources/snapshots/UNKNOWN/negative/
 
 # Release keystore — never commit
 *.jks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -867,6 +867,42 @@ Tests are data-driven using captured UI hierarchy JSON files under
 6. New corpus changes the parse-output golden — regenerate it deliberately (next section, step 4)
    and commit `snapshots/approved-parse-output.json` together with the new snapshots.
 
+**The intake tools MUTATE the corpus, and are excluded from a plain sweep (#941).**
+`InboxProcessorTest` and `UnknownScreenAnalysisTest` redact/move/prune/delete files under
+`snapshots/` as their normal operation. Since #941 `app/build.gradle.kts` excludes them from an
+UNFILTERED `testDebugUnitTest` run (alongside the pre-existing `*Suite` exclusion) — "a sweep
+never rewrites the corpus" is now structural, not a side effect of `INBOX/` happening to be empty
+on CI. Run them deliberately by name:
+`./gradlew :app:testDebugUnitTest --tests "*InboxProcessorTest"`. Naming a test sets Gradle's
+`commandLineIncludePatterns`, which turns the whole exclusion block off.
+
+**Corpus reads fail LOUD (#941).** `TestResourceLoader.loadSnapshots` used to `println` and skip
+an unparseable file — a corrupt committed fixture then sat in git looking like coverage while no
+test read it. It now throws for every directory except the two *staging* areas (`INBOX/`,
+`UNKNOWN/`), where a malformed raw pull is expected traffic and the triage tool's job is to
+survive the batch. Note `snapshots/UNKNOWN/negative/` is committed corpus and therefore strict —
+the leaf directory name decides.
+
+**The pruner keeps the NEWEST, and never evicts an incumbent to admit a newcomer (#929/#941).**
+`SnapshotLibrarian.pruneFolder` caps a folder at 15 distinct content variants. It sorts by the
+capture timestamp *parsed out of the filename* (both conventions: legacy `20260128_155954_491_…`
+and current `2026-07-17_18-08-53-720__…`, whose lexical orders are inverted against their real
+chronology — the PR #926 pass deleted 9 fixtures because of exactly that). And when the folder was
+already at cap **before** the run, the file the run just added is the one dropped: incumbents are
+never evicted to make room (PR #800's capped-additions-only discipline). Below cap, a fresher
+capture of identical content still replaces the stale one — that is the retention policy working.
+
+**The negative corpus (`snapshots/UNKNOWN/negative/`, #941).** Over-match is the dangerous
+recognition failure: under-match only drops a frame to UNKNOWN, but over-match *forges state*
+(#857/#874/#875 claimed `modeHint: offline` from absence and split live dashes; #858 minted an
+offer named "This request is no longer available"). `NegativeCorpusStaysUnknownTest` (an
+`AllMatchersSuite` member) asserts every committed frame there still classifies UNKNOWN under its
+own platform partition, with a minimum-count floor so an emptied folder fails instead of
+green-passing. To add one: sweep it for PII, keep the `__<platformWire>__` capture-naming token,
+and drop it in. The parent `snapshots/UNKNOWN/` stays gitignored staging; `negative/` is
+un-ignored by an explicit negation, and the subfolder placement is load-bearing — the flat
+staging loaders list files, so they can never graduate or prune a committed negative frame.
+
 **Adding or changing a recognition rule** (there are no matcher classes to register — rules are data):
 
 1. Edit the platform's JSON5 rule source — the flat `matchers/rules/<platform>.json5` (uber) or the
@@ -882,7 +918,10 @@ Tests are data-driven using captured UI hierarchy JSON files under
    -DupdateParseGolden=true`, then **review the diff of `approved-parse-output.json`** — that
    review is the regression gate — and commit it with the rule change. The same test also
    ratchets corpus coverage (new intents should ship with corpus) and lints dedupeKey
-   `{field}` templates against fields the rule actually parses.
+   `{field}` templates against fields the rule actually parses. The coverage ratchet is keyed
+   by **platform + intent** (#941) and measured by classifying the corpus inside each
+   platform's rule partition — not by "a folder with that intent's name exists" — so a
+   DoorDash-populated folder can no longer mark the same-named Uber intent covered.
 
 ### Session replay (capture sequence → recognition → state machine)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,18 +90,33 @@ android {
                 test.systemProperty("updateParseGolden", it)
             }
 
-            // JUnit @Suite aggregators (e.g. AllMatchersSuite) re-run their member
-            // classes, so during a broad sweep the members would run twice — once
-            // directly, once via the suite. Exclude suites from an unfiltered sweep;
-            // a suite stays runnable explicitly via --tests "*AllMatchersSuite*"
-            // (which sets commandLineIncludePatterns, so the exclude is skipped).
-            // Done in doFirst because --tests is only applied to the filter at
-            // execution time.
+            // Two families are excluded from an UNFILTERED sweep. Both stay runnable by
+            // name (`--tests "*Foo*"` sets commandLineIncludePatterns, so the whole block
+            // is skipped). Done in doFirst because --tests is only applied to the filter
+            // at execution time.
+            //
+            // 1. JUnit @Suite aggregators (e.g. AllMatchersSuite) re-run their member
+            //    classes, so during a broad sweep the members would run twice — once
+            //    directly, once via the suite.
+            // 2. Corpus-MUTATING intake tools (#941, review §4.4 item 5). InboxProcessorTest
+            //    and UnknownScreenAnalysisTest redact/move/prune/delete files under
+            //    `src/test/resources/snapshots/` as their normal operation — they are the
+            //    documented triage workflow, not verification. On CI they are no-ops only
+            //    because INBOX/ is gitignored and therefore empty there; that is luck, not a
+            //    guarantee, and a developer's local sweep DOES hit a populated INBOX and
+            //    silently rewrites the corpus mid-sweep. The exclusion makes "a sweep never
+            //    mutates the corpus" structural. Run them deliberately:
+            //      ./gradlew :app:testDebugUnitTest --tests "*InboxProcessorTest"
+            val corpusMutatingIntakeTests = listOf(
+                "*InboxProcessorTest",
+                "*UnknownScreenAnalysisTest",
+            )
             test.doFirst {
                 val filter = test.filter as
                     org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
                 if (filter.commandLineIncludePatterns.isEmpty()) {
                     filter.excludeTestsMatching("*Suite")
+                    corpusMutatingIntakeTests.forEach(filter::excludeTestsMatching)
                 }
             }
         }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/InboxProcessorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/InboxProcessorTest.kt
@@ -108,7 +108,8 @@ class InboxProcessorTest(
                 targetFolder = screenName
             )
             println("     MOVED: snapshots/$screenName/$filename")
-            SnapshotLibrarian.pruneFolder(targetFolder)
+            // Name the newcomer so the prune's at-cap safe can protect the incumbents (#929).
+            SnapshotLibrarian.pruneFolder(targetFolder, addedFilename = filename)
 
         } catch (e: Exception) {
             println("     ERROR: ${e.message}")

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/NegativeCorpusStaysUnknownTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/NegativeCorpusStaysUnknownTest.kt
@@ -1,0 +1,174 @@
+package cloud.trotter.dashbuddy.core.pipeline.recognition.matchers
+
+import cloud.trotter.dashbuddy.core.pipeline.rules.Ruleset
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.test.util.SnapshotSecurityScanner
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
+
+/**
+ * The **negative** half of the corpus regression (#941, from the 2026-07-30 ground-up
+ * adversarial review §4.4 item 4).
+ *
+ * Over-match is the dangerous failure direction. Under-match only drops a frame to UNKNOWN
+ * (the pipeline's own fail-safe); over-match *forges state* — the #857/#874/#875 class claimed
+ * `modeHint: offline` from ABSENCE on partially-rendered Uber home frames, splitting live
+ * dashes into phantom `session_records`, and #858's expiry overlay minted an offer named
+ * "This request is no longer available". Yet the must-stay-UNKNOWN discipline was, until this
+ * test, a handful of frames hard-wired into three rule-specific evidence tests. This is the
+ * *general* mechanism: a committed folder of frames that must classify UNKNOWN, checked
+ * against the live production rulesets on every run.
+ *
+ * ### Where the corpus lives, and why there
+ *
+ * `snapshots/UNKNOWN/negative/`. The parent `snapshots/UNKNOWN/` is gitignored *staging* (raw,
+ * unsorted device captures a triage pass drops there — never committed, since they are
+ * un-swept for PII), so the committed corpus lives one level down behind an explicit
+ * `.gitignore` negation. That subfolder placement is also load-bearing, not cosmetic: the
+ * corpus-MUTATING triage tools ([InboxProcessorTest], [UnknownScreenAnalysisTest]) enumerate
+ * `.json` *files* in a flat directory listing, so they cannot see — and therefore cannot
+ * graduate, move, or prune — anything under `negative/`.
+ *
+ * ### Adding a frame
+ *
+ * Drop a sanitized capture in and bump nothing: the floor below is a *minimum*, not an equality
+ * pin, so the corpus only grows. A frame must (a) be PII-swept — it is committed, so it is held
+ * to the same bar as the golden corpus — and (b) carry the device capture naming convention's
+ * `__<platformWire>__` token, so this test can scope classification to that platform's rule
+ * partition exactly as production does.
+ *
+ * ### Relationship to the rule-specific evidence tests
+ *
+ * [cloud.trotter.dashbuddy.core.pipeline.rules.UberIdleMapOfflineEvidenceTest],
+ * [cloud.trotter.dashbuddy.core.pipeline.rules.UberHomeDashboardOfflineEvidenceTest] and
+ * [cloud.trotter.dashbuddy.core.pipeline.rules.UberOfferExpiryOverlayTest] stay exactly as they
+ * are — their fixtures were COPIED here, not moved. They assert something this test cannot:
+ * that each frame is still a *specimen of its specific bug* (it carries
+ * `home_screen_overlay_container` / `glide_bottom_nav_home` / `image_message_text`). This test
+ * is the platform for frames that have no such dedicated home.
+ */
+@RunWith(Parameterized::class)
+class NegativeCorpusStaysUnknownTest(
+    private val filename: String,
+    private val node: UiNode,
+) {
+
+    companion object {
+        /** Committed must-stay-UNKNOWN corpus. See the class KDoc for why it lives here. */
+        const val FOLDER = "snapshots/UNKNOWN/negative"
+
+        /**
+         * Floor, not an equality pin — the corpus may only GROW. Its job is to make an
+         * empty/vanished folder fail: before #941 the negative half green-passed on an empty
+         * set, so deleting the whole corpus was indistinguishable from a clean run.
+         *
+         * Seeded at 10 = the frames the three rule-specific evidence tests already owned
+         * (4 × `uber_idle_map_partial` + 4 × `uber_home_dashboard_partial` +
+         * 2 × `uber_offer_expiry_overlay`).
+         */
+        const val MINIMUM_FRAMES = 10
+
+        /** `2026-07-23_19-35-44-857__uber__accessibility.window__idle_map__4571c6.json` → `uber`. */
+        private val PLATFORM_TOKEN = Regex("""__([a-z0-9_]+)__""")
+
+        private val screenRuleset: Ruleset<UiNode> by lazy { TestRulesetFactory.screenRuleset }
+
+        /**
+         * The wire prefix this frame's platform partition is keyed by, or null when the
+         * filename carries no resolvable token (then the assertion runs unscoped — a strictly
+         * BROADER bar, so it can never silently weaken).
+         */
+        fun platformWireOf(filename: String): String? = PLATFORM_TOKEN
+            .findAll(filename)
+            .map { it.groupValues[1] }
+            .firstOrNull { Platform.fromWire(it) != null }
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data(): Collection<Array<Any>> {
+            val loaded = TestResourceLoader.loadSnapshots(FOLDER)
+            assertTrue(
+                "$FOLDER holds ${loaded.size} frames, below the ${MINIMUM_FRAMES}-frame floor. " +
+                    "The negative corpus is the only guard against the over-match direction " +
+                    "(#857/#874/#875/#858) — do not shrink it to make a rule change pass; fix " +
+                    "the rule. If a frame legitimately stopped being a negative specimen, " +
+                    "replace it and lower the floor deliberately, in review.",
+                loaded.size >= MINIMUM_FRAMES,
+            )
+            return loaded.map { (filename, node, _) -> arrayOf(filename, node) }
+        }
+    }
+
+    /**
+     * The whole point: the production rulesets must not claim this frame.
+     *
+     * Scoped to the frame's own platform partition because that is what production does —
+     * `ObservationClassifier` partitions by wire at all three call sites, so an unscoped
+     * assertion would fail on cross-platform `allText` folding that can never happen at
+     * runtime (#900 / #898 review F5).
+     */
+    @Test
+    fun `committed negative frame still classifies UNKNOWN`() {
+        val wire = platformWireOf(filename)
+        val intent = screenRuleset.matchFirst(node, platformWire = wire)?.intent ?: "UNKNOWN"
+        assertEquals(
+            "$filename classified '$intent' — a rule now OVER-matches a frame committed as " +
+                "must-stay-UNKNOWN. Over-match forges state (a false mode edge, a phantom " +
+                "offer); UNKNOWN is the safe direction. Tighten the rule's `require` to demand " +
+                "POSITIVE evidence rather than absence.",
+            "UNKNOWN",
+            intent,
+        )
+    }
+
+    /**
+     * Naming discipline: without a resolvable platform token the assertion above silently
+     * widens to the unscoped partition, so pin the convention rather than let it drift.
+     */
+    @Test
+    fun `negative frame names its platform`() {
+        assertTrue(
+            "$filename carries no `__<platformWire>__` token, so its classification cannot be " +
+                "scoped to a platform partition the way production scopes it. Commit negative " +
+                "frames under the device capture naming convention.",
+            platformWireOf(filename) != null,
+        )
+    }
+
+    /** Committed corpus — held to the same PII bar as every golden folder. */
+    @Test
+    fun `negative frame carries no dasher-sensitive content`() {
+        assertFalse(
+            "$filename tripped the security scanner — redact or drop it",
+            SnapshotSecurityScanner.scan(node).isToxic,
+        )
+    }
+
+    /**
+     * Structural guard on the corpus itself: the flat staging loaders must never be able to
+     * reach these files. A stray `.json` dropped directly into `snapshots/UNKNOWN/` is
+     * gitignored staging and is fine; a `negative/` frame promoted UP into the staging folder
+     * would become graduate-able by [UnknownScreenAnalysisTest] and silently leave the corpus.
+     */
+    @Test
+    fun `negative corpus is not reachable from the flat staging listing`() {
+        val staged = TestResourceLoader.loadSnapshots("snapshots/UNKNOWN").map { it.first }
+        assertFalse(
+            "$filename is ALSO present directly in snapshots/UNKNOWN/, where the mutating " +
+                "triage tools can graduate or delete it. Keep negative frames under negative/.",
+            filename in staged,
+        )
+        assertTrue(
+            "$FOLDER must be a real directory",
+            File("src/test/resources/$FOLDER").isDirectory,
+        )
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/UnknownScreenAnalysisTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/UnknownScreenAnalysisTest.kt
@@ -61,7 +61,8 @@ class UnknownScreenAnalysisTest(filename: String, node: UiNode) {
             println("   GRADUATED: now recognized as '$identifiedScreen' (was UNKNOWN).")
             try {
                 val target = SnapshotLibrarian.archiveSnapshot(myFilename, FOLDER, identifiedScreen)
-                SnapshotLibrarian.pruneFolder(target)
+                // Name the newcomer so the prune's at-cap safe can protect the incumbents (#929).
+                SnapshotLibrarian.pruneFolder(target, addedFilename = myFilename)
                 println("   MOVED → snapshots/$identifiedScreen/$myFilename")
             } catch (e: Exception) {
                 println("   ERROR graduating $myFilename: ${e.message}")

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -164,21 +164,33 @@ class ParseOutputGoldenTest {
     // =========================================================================
 
     /**
-     * Screen-rule intents with no golden corpus folder yet (#433 noted 13 DD
-     * intents + all of Uber). This set may only SHRINK: when you add corpus
-     * for one of these, delete it here; a NEW intent must ship with corpus
-     * (or be added here deliberately, in review).
+     * Screen-rule `platform:intent` pairs with no golden corpus behind them (#433 noted 13 DD
+     * intents + all of Uber). This set may only SHRINK: when you add corpus for one of these,
+     * delete it here; a NEW intent must ship with corpus (or be added here deliberately, in
+     * review).
+     *
+     * ### Keyed by PLATFORM, not intent alone (#941, review §4.4 item 4)
+     *
+     * The gap used to be "intent has no folder named after it". Intent names are shared across
+     * platforms (`idle_map`, `offer`, `home_dashboard`, `earnings_activity`…), and the folders
+     * are intent-named, not platform-named — so a folder populated entirely by DoorDash
+     * captures marked the same-named UBER intent covered. With Uber at a fraction of DoorDash's
+     * corpus depth, a meaningful share of its thinness was invisible to this gate, which is
+     * precisely the gate that decides whether the dedupeKey / effect-arg lints below have
+     * anything to look at.
+     *
+     * Coverage is now measured the way production classifies: a pair is covered iff SOME corpus
+     * snapshot classifies to that intent *within that platform's rule partition*
+     * (`matchFirst(node, platformWire = …)` — `ObservationClassifier` partitions by wire at all
+     * three call sites). Folder names no longer participate.
      */
     private val knownUncoveredIntents = setOf(
-        // DoorDash — rules added from triage/synthetic fixtures, no capture yet
-        "dropoff_pre_arrival_completion",
-        "earnings",
-        "photo_capture",
-        "pickup_picked_up",
-        "pickup_pre_arrival_multi",
-        "pickup_verification_info",
-        "pickup_verification_pin",
-        "pickup_verify",
+        // ---- DoorDash — rules added from triage/synthetic fixtures, no capture yet ----
+        "doordash:dropoff_pre_arrival_completion",
+        "doordash:earnings",
+        "doordash:pickup_picked_up",
+        "doordash:pickup_pre_arrival_multi",
+        "doordash:pickup_verify",
         // #501 item 3 — GoPuff (Drive) zone-arrival, recognize-only (dev decision 2026-07-07).
         // Anchor strings are grounded (verbatim from issue #501's 2026-06-15 deep-dive over the
         // real 06-14 captures), but the raw capture JSON itself was never committed to
@@ -186,37 +198,74 @@ class ParseOutputGoldenTest {
         // covers it today. NOTE the anchors are NOT GoPuff-unique (every regular
         // pickup_pre_arrival tree carries them); the rule leans on priority order + its rejects,
         // so a real capture matters doubly here. Shrink this when one lands in the corpus.
-        "pickup_zone_arrival",
-        "safety",
-        "shop_and_pay_checkout",
-        "shop_and_pay_list",
-        "shopping_checkout",
-        // Uber — first captures landed 2026-07-18/19 (home_dashboard, splash); active_trip +
+        "doordash:pickup_zone_arrival",
+        "doordash:safety",
+        "doordash:shopping_checkout",
+        // ---- Uber ----
+        // First captures landed 2026-07-18/19 (home_dashboard, splash); active_trip +
         // awaiting_offer landed 2026-07-19. The 2026-07-21 dash (second Uber attempt) closed the
         // rest: offer, earnings_activity, session_summary, customer_chat, delivery_confirmation,
         // and pickup_verification_items all landed corpus. The uber.screen.offer "Offer -
         // {storeName}" effect template was a dead effect-arg on the fielded frames; #813 gave the
         // rule a top-level storeName parse so it now interpolates (pin removed from
-        // knownDeadArgTemplates). Only post_trip still has zero snapshots in the corpus (#433).
-        "post_trip",
+        // knownDeadArgTemplates).
+        //
+        // #941 note: platform-keying corrected the ATTRIBUTION of six of these. The pre-#941
+        // intent-only pin listed `photo_capture`, `pickup_verification_info`,
+        // `pickup_verification_pin`, `shop_and_pay_checkout` and `shop_and_pay_list` under a
+        // "DoorDash" comment header; they are declared by the UBER ruleset, and DoorDash's own
+        // same-named surfaces are covered. The gap's SIZE is unchanged (14 → 14): no
+        // cross-platform folder was masking a real gap today, so nothing was added to this pin.
+        // What changed is that it can no longer happen silently — the next Uber rule that
+        // borrows a DoorDash-covered intent name will show up here.
+        "uber:photo_capture",
+        "uber:pickup_verification_info",
+        "uber:pickup_verification_pin",
+        "uber:post_trip",
+        "uber:shop_and_pay_checkout",
+        "uber:shop_and_pay_list",
     )
 
     @Test
     fun `screen-rule intent corpus coverage only ratchets up`() {
-        val intents = compileProductionScreenRules()
-            .flatMap { r -> r.branches.mapNotNull { it.intent } }
-            .filterNot { it.startsWith("sensitive") } // blocked, never parsed — no goldens by design
+        val rules = compileProductionScreenRules()
+
+        // Declared: every (platform, intent) the shipped screen rules can produce.
+        val declared = rules
+            .flatMap { rule ->
+                val wire = rule.id.substringBefore('.')
+                rule.branches.mapNotNull { it.intent }
+                    // blocked, never parsed — no goldens by design
+                    .filterNot { it.startsWith("sensitive") }
+                    .map { "$wire:$it" }
+            }
             .toSet()
-        val folders = File("src/test/resources/snapshots")
-            .listFiles { f -> f.isDirectory && f.name !in SKIP }
-            ?.map { it.name }?.toSet() ?: emptySet()
+
+        // Covered: what the corpus actually demonstrates, per platform partition.
+        val wires = rules.map { it.id.substringBefore('.') }.toSet()
+        val covered = mutableSetOf<String>()
+        val base = File("src/test/resources/snapshots")
+        val dirs = base.listFiles { f -> f.isDirectory && f.name !in SKIP }
+            ?.sortedBy { it.name } ?: emptyList()
+        for (dir in dirs) {
+            for ((_, node, _) in TestResourceLoader.loadSnapshots("snapshots/${dir.name}")) {
+                TransformRegistry.withClock(FIXED_NOW_MS, FIXED_ZONE) {
+                    for (wire in wires) {
+                        val intent = screenRuleset.matchFirst(node, platformWire = wire)?.intent
+                        if (intent != null) covered += "$wire:$intent"
+                    }
+                }
+            }
+        }
 
         assertEquals(
-            "Corpus coverage gap changed. Intents without a golden folder must only shrink — " +
-                "add corpus for closed gaps (and delete them from knownUncoveredIntents), and " +
-                "ship corpus with new intents instead of growing the pin.",
+            "Corpus coverage gap changed. platform:intent pairs with no corpus behind them must " +
+                "only shrink — add corpus for closed gaps (and delete them from " +
+                "knownUncoveredIntents), and ship corpus with new intents instead of growing " +
+                "the pin. NOTE the key is platform-scoped (#941): a DoorDash-populated folder " +
+                "no longer marks the same-named Uber intent covered.",
             knownUncoveredIntents,
-            intents - folders,
+            declared - covered,
         )
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
@@ -6,6 +6,7 @@ import cloud.trotter.dashbuddy.core.pipeline.SensitiveMarkerAssetCoverageTest
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.view.clicked.ClickClassifierTest
 import cloud.trotter.dashbuddy.core.pipeline.notification.NotificationClassifierTest
 import cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.GoldenSnapshotRegressionTest
+import cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.NegativeCorpusStaysUnknownTest
 import cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.OfferPipelineTest
 import cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.PickupNoCustomerIdentityTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.CaptureRedactionCorpusTest
@@ -42,6 +43,12 @@ import org.junit.runners.Suite
  *
  * - [GoldenSnapshotRegressionTest] — positive guard: every snapshot in an intent
  *   folder still classifies as that folder (SENSITIVE: sensitive rule or scanner).
+ * - [NegativeCorpusStaysUnknownTest] — #941, the general NEGATIVE guard: every frame in the
+ *   committed `snapshots/UNKNOWN/negative/` corpus must still classify UNKNOWN under its own
+ *   platform partition, with a minimum-count floor so an emptied folder fails instead of
+ *   green-passing. Over-match is the dangerous direction (it forges state — #857/#874/#875/#858);
+ *   the three Uber evidence tests below are the rule-SPECIFIC instances of the same guard and
+ *   their fixtures are copied, not moved, into this corpus.
  * - [ParseOutputGoldenTest] — parse-OUTPUT guard (#433): every snapshot's typed
  *   fields match `snapshots/approved-parse-output.json` (regen deliberately with
  *   `-DupdateParseGolden=true` and review the diff); plus the corpus-coverage
@@ -101,7 +108,10 @@ import org.junit.runners.Suite
  * These also compile the production ruleset via `TestRulesetFactory` but are NOT suite members:
  *  - [cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.InboxProcessorTest] /
  *    [cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.UnknownScreenAnalysisTest] —
- *    corpus-*mutating* intake tools (see above); this suite is pure verification.
+ *    corpus-*mutating* intake tools (see above); this suite is pure verification. Since #941
+ *    they are also excluded from an unfiltered `testDebugUnitTest` sweep at the BUILD level
+ *    (`app/build.gradle.kts`, alongside the `*Suite` exclusion), so suite membership is no
+ *    longer the only thing keeping a broad run from rewriting the corpus. Run them by name.
  *  - [cloud.trotter.dashbuddy.core.pipeline.notification.NotificationPipelineSensitiveOrderingTest]
  *    — a `RobolectricTestRunner` pipeline-ORDERING integration test (the sensitive gate must run
  *    before `CaptureWriter`), not a ruleset/corpus regression; every other suite member is a plain
@@ -121,6 +131,7 @@ import org.junit.runners.Suite
 @RunWith(Suite::class)
 @Suite.SuiteClasses(
     GoldenSnapshotRegressionTest::class,
+    NegativeCorpusStaysUnknownTest::class,
     ParseOutputGoldenTest::class,
     OfferPipelineTest::class,
     ScreenRulesetTest::class,

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotLibrarian.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotLibrarian.kt
@@ -45,18 +45,52 @@ object SnapshotLibrarian {
      * while Chipotle + Subway + Wendy's each count as distinct and are all kept.
      *
      * Distinct content naturally protects itself — no manual golden marking needed.
+     *
+     * ### "Newest" means the CAPTURE timestamp, not the filename (#929)
+     *
+     * This used to sort by raw filename descending, and the corpus carries two capture
+     * naming conventions whose lexical order is INVERTED against their real chronology:
+     * legacy `20260128_155954_491_…` sorts ABOVE current `2026-07-17_18-08-53-720__…`
+     * (`'0'` > `'-'`), and a handful of bare-hash files (`c46728d0.json`) sort above both.
+     * So on a saturated folder the prune kept the OLDEST representatives and evicted the
+     * newest ones. The PR #926 corpus pass deleted 8 `dropoff_pre_arrival` + 1 `ratings`
+     * fixture before it was caught by hand. [captureTimestampOf] parses both conventions,
+     * so the "keep the newest" invariant now holds regardless of naming.
+     *
+     * ### The at-cap safe (#941/#929)
+     *
+     * [addedFilename] names the file the CURRENT run just archived in. When the folder was
+     * already at [RETENTION_LIMIT] distinct variants BEFORE that file arrived, there is no
+     * room for it and something must go — and the only safe answer is the newcomer. Evicting
+     * an incumbent to admit it would silently drop a committed representative in exchange for
+     * one that has not earned its place (the "capped-additions-only, never evict an existing
+     * representative" discipline from PR #800). So in that case the newcomer, and ONLY the
+     * newcomer, is deleted. Below cap, the normal newest-per-fingerprint dedup still runs and
+     * may replace an incumbent with a fresher capture of the same content — that is the
+     * intended refresh, not an eviction.
+     *
+     * Passing `addedFilename = null` (a bare cleanup pass) disables the safe and prunes by
+     * policy alone.
+     *
+     * @param addedFilename the file this run just added to [folder], if any.
      */
-    fun pruneFolder(folder: File) {
+    fun pruneFolder(folder: File, addedFilename: String? = null) {
         val files = folder.listFiles { _, name -> name.endsWith(".json") } ?: return
 
-        // Newest first — within a fingerprint group we always keep the newest
-        val sorted = files.sortedByDescending { it.name }
+        // Newest first — within a fingerprint group we always keep the newest.
+        // Filename is the tie-break so the order is total and reproducible.
+        val sorted = files.sortedWith(
+            compareByDescending<File> { captureTimestampOf(it.name) }.thenByDescending { it.name },
+        )
+
+        // One parse per file — the at-cap safe below needs the same fingerprints.
+        val fingerprints = sorted.associateWith { contentFingerprint(it) }
 
         val seenFingerprints = mutableSetOf<String>()
         val toDelete = mutableListOf<File>()
 
         for (file in sorted) {
-            val fingerprint = contentFingerprint(file)
+            val fingerprint = fingerprints[file]
 
             when {
                 fingerprint == null -> {
@@ -76,13 +110,62 @@ object SnapshotLibrarian {
             }
         }
 
-        if (toDelete.isNotEmpty()) {
-            println("     🧹 CLEANUP: Pruning ${toDelete.size} redundant/overflow snapshots...")
-            toDelete.forEach {
+        val guarded = addedFilename != null && wasAtCapBefore(fingerprints, addedFilename)
+        val effective = if (guarded && toDelete.isNotEmpty()) {
+            println(
+                "     🛡️ AT CAP: folder already held $RETENTION_LIMIT distinct variants before " +
+                    "$addedFilename arrived — dropping the newcomer, keeping every incumbent.",
+            )
+            sorted.filter { it.name == addedFilename }
+        } else {
+            toDelete
+        }
+
+        if (effective.isNotEmpty()) {
+            println("     🧹 CLEANUP: Pruning ${effective.size} redundant/overflow snapshots...")
+            effective.forEach {
                 it.delete()
                 println("        🗑️ Deleted: ${it.name}")
             }
         }
+    }
+
+    /**
+     * True when the folder held [RETENTION_LIMIT] or more distinct content variants
+     * *excluding* [addedFilename] — i.e. it was full before this run.
+     */
+    private fun wasAtCapBefore(fingerprints: Map<File, String?>, addedFilename: String): Boolean =
+        fingerprints.entries
+            .filterNot { it.key.name == addedFilename }
+            .mapNotNull { it.value }
+            .toSet()
+            .size >= RETENTION_LIMIT
+
+    /** `2026-07-17_18-08-53-720__doordash__…` — the current device capture convention. */
+    private val CURRENT_NAME_PATTERN =
+        Regex("""^(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})-(\d{3})""")
+
+    /** `20260128_155954_491_MAIN_MAP_IDLE.json` — the legacy DiskCaptureBus convention. */
+    private val LEGACY_NAME_PATTERN =
+        Regex("""^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})_(\d{3})""")
+
+    /**
+     * Capture instant embedded in a snapshot filename, as a sortable comparable, or
+     * [Long.MIN_VALUE] when the name embeds none.
+     *
+     * Both conventions encode the same `yyyy MM dd HH mm ss SSS` fields in the same order,
+     * so once the separators are stripped the digits concatenate into a directly comparable
+     * number — no date parsing, no zone, no locale.
+     *
+     * Un-timestamped names (the bare-hash `c46728d0.json` files) sort as OLDEST, which is the
+     * honest reading: they predate both conventions. That makes them eviction-preferred, which
+     * only matters below cap (where losing one means a fresher capture of *identical* content
+     * took its place) — at cap the safe in [pruneFolder] protects every incumbent, dated or not.
+     */
+    internal fun captureTimestampOf(filename: String): Long {
+        val m = CURRENT_NAME_PATTERN.find(filename) ?: LEGACY_NAME_PATTERN.find(filename)
+        ?: return Long.MIN_VALUE
+        return m.groupValues.drop(1).joinToString("").toLongOrNull() ?: Long.MIN_VALUE
     }
 
     /**

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotLibrarianPruneTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotLibrarianPruneTest.kt
@@ -1,0 +1,125 @@
+package cloud.trotter.dashbuddy.test.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Guards [SnapshotLibrarian.pruneFolder] — the one piece of test infrastructure that
+ * **deletes committed corpus** (#929).
+ *
+ * It had no test of its own, and the two footguns it shipped with were only caught by a
+ * human noticing a suspicious `git status`: PR #926's pass deleted 8 `dropoff_pre_arrival`
+ * + 1 `ratings` fixture because the corpus carries two capture naming conventions whose
+ * lexical order is inverted against their chronology.
+ */
+class SnapshotLibrarianPruneTest {
+
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    // A snapshot file distinct only in its text content — that is what the
+    // fingerprint keys on (dynamic price/time tokens are stripped).
+    private fun write(name: String, content: String): File =
+        temp.root.resolve(name).apply {
+            writeText(
+                """{"text":"$content","bounds":{"left":0,"top":0,"right":1,"bottom":1}}""",
+            )
+        }
+
+    /** A well-formed current-convention name whose capture day is [day]. */
+    private fun dayName(day: Int): String =
+        "2026-07-%02d_10-00-00-000__doordash__accessibility.window__idle_map__%06x.json"
+            .format(day, day)
+
+    private fun surviving(): Set<String> =
+        temp.root.listFiles()!!.map { it.name }.toSet()
+
+    // =========================================================================
+    // Timestamp ordering (the #929 sighting)
+    // =========================================================================
+
+    @Test
+    fun `the newer capture survives a duplicate pair spanning both naming conventions`() {
+        // Legacy `yyyyMMdd_HHmmss_SSS` sorts ABOVE current `yyyy-MM-dd_HH-mm-ss-SSS`
+        // lexically ('0' > '-'), so a filename sort kept the January file and deleted the
+        // July one. Same content ⇒ exactly one survives; it must be the newer capture.
+        val legacyJan = write("20260128_155954_491_MAIN_MAP_IDLE.json", "Chipotle")
+        val currentJul = write(
+            "2026-07-17_18-08-53-720__doordash__accessibility.window__idle_map__81c084.json",
+            "Chipotle",
+        )
+
+        SnapshotLibrarian.pruneFolder(temp.root)
+
+        assertEquals(setOf(currentJul.name), surviving())
+        assertTrue("the older legacy-named capture should have been pruned", !legacyJan.exists())
+    }
+
+    @Test
+    fun `capture timestamps parse from both conventions and are ordered chronologically`() {
+        val legacy = SnapshotLibrarian.captureTimestampOf("20260128_155954_491_MAIN_MAP_IDLE.json")
+        val current = SnapshotLibrarian.captureTimestampOf(
+            "2026-07-17_18-08-53-720__doordash__accessibility.window__idle_map__81c084.json",
+        )
+        val undated = SnapshotLibrarian.captureTimestampOf("c46728d0.json")
+
+        assertTrue("July 2026 must sort after January 2026", current > legacy)
+        assertEquals("an un-timestamped name sorts as oldest", Long.MIN_VALUE, undated)
+    }
+
+    // =========================================================================
+    // The at-cap safe
+    // =========================================================================
+
+    @Test
+    fun `a full folder keeps every incumbent and drops the newcomer`() {
+        val incumbents = (1..15).map { write(dayName(it), "store$it") }
+        val newcomer = write(dayName(30), "brand-new-store")
+
+        SnapshotLibrarian.pruneFolder(temp.root, addedFilename = newcomer.name)
+
+        assertEquals(
+            "every incumbent must survive — the newcomer is the one that has not earned a slot",
+            incumbents.map { it.name }.toSet(),
+            surviving(),
+        )
+    }
+
+    @Test
+    fun `a full folder drops the newcomer even when it duplicates an incumbent`() {
+        val incumbents = (1..15).map { write(dayName(it), "store$it") }
+        val newcomer = write(dayName(30), "store1")
+
+        SnapshotLibrarian.pruneFolder(temp.root, addedFilename = newcomer.name)
+
+        assertEquals(incumbents.map { it.name }.toSet(), surviving())
+    }
+
+    @Test
+    fun `below cap the newcomer is admitted and nothing is deleted`() {
+        val incumbents = (1..3).map { write(dayName(it), "store$it") }
+        val newcomer = write(dayName(30), "brand-new-store")
+
+        SnapshotLibrarian.pruneFolder(temp.root, addedFilename = newcomer.name)
+
+        assertEquals((incumbents + newcomer).map { it.name }.toSet(), surviving())
+    }
+
+    @Test
+    fun `below cap a fresher capture of identical content still replaces the incumbent`() {
+        // The safe is scoped to the at-cap case on purpose: the newest-per-fingerprint
+        // refresh is the retention policy's whole point and must survive #929's fix.
+        val stale = write(dayName(1), "store1")
+        val other = write(dayName(2), "store2")
+        val fresh = write(dayName(30), "store1")
+
+        SnapshotLibrarian.pruneFolder(temp.root, addedFilename = fresh.name)
+
+        assertEquals(setOf(other.name, fresh.name), surviving())
+        assertTrue("the stale duplicate should have been pruned", !stale.exists())
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/TestResourceLoader.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/TestResourceLoader.kt
@@ -19,12 +19,32 @@ object TestResourceLoader {
     }
 
     /**
+     * Directory names that hold **staging** captures rather than committed corpus: raw,
+     * unsorted device pulls a human is triaging. A malformed file there is expected traffic
+     * (a truncated pull, a click envelope pasted in by hand), so it is skipped with a warning
+     * — the triage tool's whole job is to survive the batch and report.
+     *
+     * Everything else is COMMITTED corpus, where the same skip is a silently lost regression
+     * guard (#941, review §4.4 item 5): the file stays in git looking like coverage while no
+     * test ever reads it. There, a parse failure is a test failure.
+     *
+     * Note `snapshots/UNKNOWN/negative/` is committed and therefore strict — the leaf
+     * directory name is what decides, and it is `negative`, not `UNKNOWN`.
+     */
+    private val TOLERANT_STAGING_DIRS = setOf("INBOX", "UNKNOWN")
+
+    /**
      * Loads snapshots and returns Triple: (Filename, Node, Breadcrumbs)
+     *
+     * Fails LOUD on an unparseable file under committed corpus; tolerates one under a
+     * staging directory (see [TOLERANT_STAGING_DIRS]).
      */
     fun loadSnapshots(pathFromResources: String): List<Triple<String, UiNode, List<String>>> {
         val resourceDir = File("src/test/resources/$pathFromResources")
 
         if (!resourceDir.exists() || !resourceDir.isDirectory) return emptyList()
+
+        val staging = resourceDir.name in TOLERANT_STAGING_DIRS
 
         return resourceDir.listFiles { _, name -> name.endsWith(".json") }
             ?.sorted()
@@ -32,8 +52,16 @@ object TestResourceLoader {
                 try {
                     val (node, breadcrumbs) = parseFlexibleJson(file.readText())
                     Triple(file.name, node, breadcrumbs)
-                } catch (_: Exception) {
-                    println("⚠️  Skipping unparseable file: ${file.name}")
+                } catch (e: Exception) {
+                    if (!staging) {
+                        throw IllegalStateException(
+                            "Unparseable committed corpus file $pathFromResources/${file.name} " +
+                                "— it is silently contributing NO coverage while sitting in git " +
+                                "looking like it does (#941). Fix or delete it.",
+                            e,
+                        )
+                    }
+                    println("⚠️  Skipping unparseable staging file: ${file.name}")
                     null
                 }
             }

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-19_13-32-02-456__uber__accessibility.window__home_dashboard__5a3613.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-19_13-32-02-456__uber__accessibility.window__home_dashboard__5a3613.json
@@ -1,0 +1,857 @@
+{
+    "captureId": "ecb41de8-7012-4033-a7d1-98834f4b73ef",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784485922375,
+    "platform": "uber",
+    "ruleId": "uber.screen.home_dashboard",
+    "classificationName": "home_dashboard",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_tabs_content_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/loading_background",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_inbox_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_inbox_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_earnings_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_earnings_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_opportunities_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_opportunities_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_home_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/glide_home_screen_stack_container",
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2275
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2275
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/content_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2275
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2275
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2275
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_go_online_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2168,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2275
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_menu_root_layout",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/bottom_container",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2220,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2220,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2222
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_navigation_view_v2",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2222,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2222,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2347
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "Home",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_home",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 216,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 85,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 130,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 85,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 130,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 70,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 146,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Home",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_large_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 70,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 146,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Discover",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_opportunities",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 216,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 432,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 301,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 346,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 301,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 346,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 268,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 379,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Discover",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 268,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 379,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Earnings",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_earnings",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 432,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 648,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 517,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 562,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 517,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 562,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 483,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 596,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Earnings",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 483,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 596,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Inbox",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_inbox",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 648,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 864,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 733,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 778,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 733,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 778,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 719,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 792,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Inbox",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 719,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 791,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Menu",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_menu",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 864,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 949,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 994,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 949,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 994,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 935,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Menu",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 935,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-21_20-22-17-778__uber__accessibility.window__home_dashboard__d50161.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-21_20-22-17-778__uber__accessibility.window__home_dashboard__d50161.json
@@ -1,0 +1,1776 @@
+{
+    "captureId": "f46ab299-e0f4-4530-8834-0e3929fe78a6",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784683337762,
+    "platform": "uber",
+    "ruleId": "uber.screen.home_dashboard",
+    "classificationName": "home_dashboard",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_tabs_content_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_opportunities_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_opportunities_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_menu_root_layout",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_inbox_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_earnings_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 136,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2222
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/appbar",
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 136,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 278
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/toolbar",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 136,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 278
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "desc": "Back",
+                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 144,
+                                                                                                                                                                    "right": 125,
+                                                                                                                                                                    "bottom": 269
+                                                                                                                                                                }
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Trip Details",
+                                                                                                                                                                "desc": "Trip Details Header",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 133,
+                                                                                                                                                                    "top": 172,
+                                                                                                                                                                    "right": 424,
+                                                                                                                                                                    "bottom": 242
+                                                                                                                                                                }
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                    "top": 207,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 207
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/trip_details_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 278,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2222
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 278,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2222
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/browser",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 414,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2169
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/webview_root_layout",
+                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 414,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2169
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/webview_frame",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 414,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2169
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/webview_loading_animation",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 414,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2169
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/swipe_refresh",
+                                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 414,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2169
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.webkit.WebView",
+                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 414,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2169
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_home_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/bottom_container",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2220,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2220,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2222
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_navigation_view_v2",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2222,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2222,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2347
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "Home",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_home",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 216,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 85,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 130,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 85,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 130,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 70,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 146,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Home",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 70,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 146,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Discover, New notification",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_opportunities",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 216,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 432,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 301,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 346,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 301,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 346,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 268,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 379,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Discover",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 268,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 379,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Earnings",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_earnings",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 432,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 648,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 517,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 562,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 517,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 562,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 483,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 596,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Earnings",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_large_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 483,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 596,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Inbox, 20 new notifications",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_inbox",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 648,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 864,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 733,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 778,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 733,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 778,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 719,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 792,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Inbox",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 719,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 791,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Menu, 1 new notification",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_menu",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 864,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 949,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 994,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 949,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 994,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 935,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Menu",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 935,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 5,
+                                                                                                                                            "top": 763,
+                                                                                                                                            "right": 58,
+                                                                                                                                            "bottom": 816
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 5,
+                                                                                                                                                    "top": 763,
+                                                                                                                                                    "right": 58,
+                                                                                                                                                    "bottom": 816
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 776,
+                                                                                                                                                            "right": 45,
+                                                                                                                                                            "bottom": 803
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 27,
+                                                                                                                                                    "top": 813,
+                                                                                                                                                    "right": 36,
+                                                                                                                                                    "bottom": 813
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 647,
+                                                                                                                                            "top": 1390,
+                                                                                                                                            "right": 700,
+                                                                                                                                            "bottom": 1443
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 647,
+                                                                                                                                                    "top": 1390,
+                                                                                                                                                    "right": 700,
+                                                                                                                                                    "bottom": 1443
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 660,
+                                                                                                                                                            "top": 1403,
+                                                                                                                                                            "right": 687,
+                                                                                                                                                            "bottom": 1430
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 669,
+                                                                                                                                                    "top": 1440,
+                                                                                                                                                    "right": 678,
+                                                                                                                                                    "bottom": 1440
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 751,
+                                                                                                                                            "top": 2142,
+                                                                                                                                            "right": 804,
+                                                                                                                                            "bottom": 2195
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 751,
+                                                                                                                                                    "top": 2142,
+                                                                                                                                                    "right": 804,
+                                                                                                                                                    "bottom": 2195
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 764,
+                                                                                                                                                            "top": 2155,
+                                                                                                                                                            "right": 791,
+                                                                                                                                                            "bottom": 2182
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 773,
+                                                                                                                                                    "top": 2192,
+                                                                                                                                                    "right": 782,
+                                                                                                                                                    "bottom": 2192
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 305,
+                                                                                                                                            "top": 696,
+                                                                                                                                            "right": 358,
+                                                                                                                                            "bottom": 749
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 305,
+                                                                                                                                                    "top": 696,
+                                                                                                                                                    "right": 358,
+                                                                                                                                                    "bottom": 749
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 318,
+                                                                                                                                                            "top": 709,
+                                                                                                                                                            "right": 345,
+                                                                                                                                                            "bottom": 736
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 327,
+                                                                                                                                                    "top": 746,
+                                                                                                                                                    "right": 336,
+                                                                                                                                                    "bottom": 746
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 289,
+                                                                                                                                            "top": 1453,
+                                                                                                                                            "right": 342,
+                                                                                                                                            "bottom": 1506
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 289,
+                                                                                                                                                    "top": 1453,
+                                                                                                                                                    "right": 342,
+                                                                                                                                                    "bottom": 1506
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 302,
+                                                                                                                                                            "top": 1466,
+                                                                                                                                                            "right": 329,
+                                                                                                                                                            "bottom": 1493
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 311,
+                                                                                                                                                    "top": 1503,
+                                                                                                                                                    "right": 320,
+                                                                                                                                                    "bottom": 1503
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1159,
+                                                                                                                                            "top": 2065,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2118
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1159,
+                                                                                                                                                    "top": 2065,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2118
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1172,
+                                                                                                                                                            "top": 2078,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2105
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1181,
+                                                                                                                                                    "top": 2115,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2115
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 15,
+                                                                                                                                            "top": 2289,
+                                                                                                                                            "right": 68,
+                                                                                                                                            "bottom": 2342
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 15,
+                                                                                                                                                    "top": 2289,
+                                                                                                                                                    "right": 68,
+                                                                                                                                                    "bottom": 2342
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 28,
+                                                                                                                                                            "top": 2302,
+                                                                                                                                                            "right": 55,
+                                                                                                                                                            "bottom": 2329
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 37,
+                                                                                                                                                    "top": 2339,
+                                                                                                                                                    "right": 46,
+                                                                                                                                                    "bottom": 2339
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 382,
+                                                                                                                                            "top": 1310,
+                                                                                                                                            "right": 435,
+                                                                                                                                            "bottom": 1363
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 382,
+                                                                                                                                                    "top": 1310,
+                                                                                                                                                    "right": 435,
+                                                                                                                                                    "bottom": 1363
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 395,
+                                                                                                                                                            "top": 1323,
+                                                                                                                                                            "right": 422,
+                                                                                                                                                            "bottom": 1350
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 404,
+                                                                                                                                                    "top": 1360,
+                                                                                                                                                    "right": 413,
+                                                                                                                                                    "bottom": 1360
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 22,
+                                                                                                                                            "top": 2383,
+                                                                                                                                            "right": 75,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 22,
+                                                                                                                                                    "top": 2383,
+                                                                                                                                                    "right": 75,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 35,
+                                                                                                                                                            "top": 2396,
+                                                                                                                                                            "right": 62,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 44,
+                                                                                                                                                    "top": 2433,
+                                                                                                                                                    "right": 53,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 430,
+                                                                                                                                            "top": 2020,
+                                                                                                                                            "right": 483,
+                                                                                                                                            "bottom": 2073
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 430,
+                                                                                                                                                    "top": 2020,
+                                                                                                                                                    "right": 483,
+                                                                                                                                                    "bottom": 2073
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 443,
+                                                                                                                                                            "top": 2033,
+                                                                                                                                                            "right": 470,
+                                                                                                                                                            "bottom": 2060
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 452,
+                                                                                                                                                    "top": 2070,
+                                                                                                                                                    "right": 461,
+                                                                                                                                                    "bottom": 2070
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1450,
+                                                                                                                                            "right": 27,
+                                                                                                                                            "bottom": 1503
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1450,
+                                                                                                                                                    "right": 27,
+                                                                                                                                                    "bottom": 1503
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 1463,
+                                                                                                                                                            "right": 14,
+                                                                                                                                                            "bottom": 1490
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1500,
+                                                                                                                                                    "right": 5,
+                                                                                                                                                    "bottom": 1500
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1869,
+                                                                                                                                            "right": -38,
+                                                                                                                                            "bottom": 1922
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1869,
+                                                                                                                                                    "right": -38,
+                                                                                                                                                    "bottom": 1922
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 1882,
+                                                                                                                                                            "right": -51,
+                                                                                                                                                            "bottom": 1909
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1919,
+                                                                                                                                                    "right": -60,
+                                                                                                                                                    "bottom": 1919
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 493,
+                                                                                                                                            "top": 2455,
+                                                                                                                                            "right": 546,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 493,
+                                                                                                                                                    "top": 2455,
+                                                                                                                                                    "right": 546,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 506,
+                                                                                                                                                            "top": 2468,
+                                                                                                                                                            "right": 533,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 515,
+                                                                                                                                                    "top": 2505,
+                                                                                                                                                    "right": 524,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 320,
+                                                                                                                                            "top": 2279,
+                                                                                                                                            "right": 373,
+                                                                                                                                            "bottom": 2332
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 320,
+                                                                                                                                                    "top": 2279,
+                                                                                                                                                    "right": 373,
+                                                                                                                                                    "bottom": 2332
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 333,
+                                                                                                                                                            "top": 2292,
+                                                                                                                                                            "right": 360,
+                                                                                                                                                            "bottom": 2319
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 342,
+                                                                                                                                                    "top": 2329,
+                                                                                                                                                    "right": 351,
+                                                                                                                                                    "bottom": 2329
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 218,
+                                                                                                                                            "top": 1961,
+                                                                                                                                            "right": 271,
+                                                                                                                                            "bottom": 2014
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 218,
+                                                                                                                                                    "top": 1961,
+                                                                                                                                                    "right": 271,
+                                                                                                                                                    "bottom": 2014
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 231,
+                                                                                                                                                            "top": 1974,
+                                                                                                                                                            "right": 258,
+                                                                                                                                                            "bottom": 2001
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 240,
+                                                                                                                                                    "top": 2011,
+                                                                                                                                                    "right": 249,
+                                                                                                                                                    "bottom": 2011
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 476,
+                                                                                                                                            "top": 877,
+                                                                                                                                            "right": 529,
+                                                                                                                                            "bottom": 930
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 476,
+                                                                                                                                                    "top": 877,
+                                                                                                                                                    "right": 529,
+                                                                                                                                                    "bottom": 930
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 489,
+                                                                                                                                                            "top": 890,
+                                                                                                                                                            "right": 516,
+                                                                                                                                                            "bottom": 917
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 498,
+                                                                                                                                                    "top": 927,
+                                                                                                                                                    "right": 507,
+                                                                                                                                                    "bottom": 927
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 312,
+                                                                                                                                            "top": 1550,
+                                                                                                                                            "right": 348,
+                                                                                                                                            "bottom": 1586
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 145,
+                                                                                                                                            "top": 1922,
+                                                                                                                                            "right": 181,
+                                                                                                                                            "bottom": 1958
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 934,
+                                                                                                                                            "top": 1201,
+                                                                                                                                            "right": 970,
+                                                                                                                                            "bottom": 1237
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 757,
+                                                                                                                                            "top": 2033,
+                                                                                                                                            "right": 793,
+                                                                                                                                            "bottom": 2069
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 81,
+                                                                                                                                            "top": 2159,
+                                                                                                                                            "right": 117,
+                                                                                                                                            "bottom": 2195
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 377,
+                                                                                                                                            "top": 1354,
+                                                                                                                                            "right": 413,
+                                                                                                                                            "bottom": 1390
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-23_18-48-34-589__uber__accessibility.window__offer__5a0d26.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-23_18-48-34-589__uber__accessibility.window__offer__5a0d26.json
@@ -1,0 +1,1020 @@
+{
+    "captureId": "ff72e437-76fc-4671-855e-5722eb3bebf3",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784850514579,
+    "platform": "uber",
+    "ruleId": "uber.screen.offer",
+    "classificationName": "offer",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 716,
+                                                                                                                                            "top": 833,
+                                                                                                                                            "right": 796,
+                                                                                                                                            "bottom": 978
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 716,
+                                                                                                                                                    "top": 833,
+                                                                                                                                                    "right": 796,
+                                                                                                                                                    "bottom": 913
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_custom_view",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 738,
+                                                                                                                                                            "top": 833,
+                                                                                                                                                            "right": 774,
+                                                                                                                                                            "bottom": 913
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 738,
+                                                                                                                                                                    "top": 833,
+                                                                                                                                                                    "right": 774,
+                                                                                                                                                                    "bottom": 913
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 752,
+                                                                                                                                                    "top": 911,
+                                                                                                                                                    "right": 761,
+                                                                                                                                                    "bottom": 940
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_anchor",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 738,
+                                                                                                                                                    "top": 938,
+                                                                                                                                                    "right": 774,
+                                                                                                                                                    "bottom": 974
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 471,
+                                                                                                                                            "top": 1104,
+                                                                                                                                            "right": 551,
+                                                                                                                                            "bottom": 1249
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 471,
+                                                                                                                                                    "top": 1104,
+                                                                                                                                                    "right": 551,
+                                                                                                                                                    "bottom": 1184
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_custom_view",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 493,
+                                                                                                                                                            "top": 1104,
+                                                                                                                                                            "right": 529,
+                                                                                                                                                            "bottom": 1184
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 493,
+                                                                                                                                                                    "top": 1104,
+                                                                                                                                                                    "right": 529,
+                                                                                                                                                                    "bottom": 1184
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 507,
+                                                                                                                                                    "top": 1182,
+                                                                                                                                                    "right": 516,
+                                                                                                                                                    "bottom": 1211
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_anchor",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 493,
+                                                                                                                                                    "top": 1209,
+                                                                                                                                                    "right": 529,
+                                                                                                                                                    "bottom": 1245
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 11,
+                                                                                                                                            "top": 595,
+                                                                                                                                            "right": 91,
+                                                                                                                                            "bottom": 740
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 11,
+                                                                                                                                                    "top": 595,
+                                                                                                                                                    "right": 91,
+                                                                                                                                                    "bottom": 675
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_custom_view",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 33,
+                                                                                                                                                            "top": 595,
+                                                                                                                                                            "right": 69,
+                                                                                                                                                            "bottom": 675
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 33,
+                                                                                                                                                                    "top": 595,
+                                                                                                                                                                    "right": 69,
+                                                                                                                                                                    "bottom": 675
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 47,
+                                                                                                                                                    "top": 673,
+                                                                                                                                                    "right": 56,
+                                                                                                                                                    "bottom": 702
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_anchor",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 33,
+                                                                                                                                                    "top": 700,
+                                                                                                                                                    "right": 69,
+                                                                                                                                                    "bottom": 736
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1477,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 1509,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 2307
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 1509,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 2307
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/primary_touch_area",
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 1509,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 2307
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.cardview.widget.CardView",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1509,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2307
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1509,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2307
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/message_content_overlay",
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 107,
+                                                                                                                                                    "top": 1840,
+                                                                                                                                                    "right": 973,
+                                                                                                                                                    "bottom": 1976
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "This request is no longer available",
+                                                                                                                                                        "id": "com.ubercab.driver:id/image_message_text",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 143,
+                                                                                                                                                            "top": 1876,
+                                                                                                                                                            "right": 937,
+                                                                                                                                                            "bottom": 1940
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1509,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2307
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1509,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1856
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 72,
+                                                                                                                                                            "top": 1545,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 1829
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 72,
+                                                                                                                                                                    "top": 1545,
+                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                    "bottom": 1829
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1545,
+                                                                                                                                                                            "right": 1008,
+                                                                                                                                                                            "bottom": 1623
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 1545,
+                                                                                                                                                                                    "right": 379,
+                                                                                                                                                                                    "bottom": 1623
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 90,
+                                                                                                                                                                                            "top": 1566,
+                                                                                                                                                                                            "right": 126,
+                                                                                                                                                                                            "bottom": 1602
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "text": "Delivery (2)",
+                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 144,
+                                                                                                                                                                                            "top": 1545,
+                                                                                                                                                                                            "right": 379,
+                                                                                                                                                                                            "bottom": 1623
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1623,
+                                                                                                                                                                            "right": 354,
+                                                                                                                                                                            "bottom": 1751
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "text": "$13.31",
+                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 1623,
+                                                                                                                                                                                    "right": 354,
+                                                                                                                                                                                    "bottom": 1751
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1751,
+                                                                                                                                                                            "right": 1008,
+                                                                                                                                                                            "bottom": 1829
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 1751,
+                                                                                                                                                                                    "right": 513,
+                                                                                                                                                                                    "bottom": 1829
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "text": "Includes expected tip",
+                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 72,
+                                                                                                                                                                                            "top": 1751,
+                                                                                                                                                                                            "right": 513,
+                                                                                                                                                                                            "bottom": 1829
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1856,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1858
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1858,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1967
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 72,
+                                                                                                                                                            "top": 1885,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 1949
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 72,
+                                                                                                                                                                    "top": 1885,
+                                                                                                                                                                    "right": 555,
+                                                                                                                                                                    "bottom": 1949
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1890,
+                                                                                                                                                                            "right": 125,
+                                                                                                                                                                            "bottom": 1943
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "text": "27 min (5.9 mi) total",
+                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 143,
+                                                                                                                                                                            "top": 1885,
+                                                                                                                                                                            "right": 555,
+                                                                                                                                                                            "bottom": 1949
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1967,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1969
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1969,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 2147
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 72,
+                                                                                                                                                            "top": 1987,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 2129
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 72,
+                                                                                                                                                                    "top": 1987,
+                                                                                                                                                                    "right": 871,
+                                                                                                                                                                    "bottom": 2129
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 1987,
+                                                                                                                                                                            "right": 871,
+                                                                                                                                                                            "bottom": 2058
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 1996,
+                                                                                                                                                                                    "right": 125,
+                                                                                                                                                                                    "bottom": 2049
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 143,
+                                                                                                                                                                                    "top": 1994,
+                                                                                                                                                                                    "right": 871,
+                                                                                                                                                                                    "bottom": 2050
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 143,
+                                                                                                                                                                                            "top": 1994,
+                                                                                                                                                                                            "right": 574,
+                                                                                                                                                                                            "bottom": 2050
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Po Po Trattoria Pizzeria",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 143,
+                                                                                                                                                                                                    "top": 1994,
+                                                                                                                                                                                                    "right": 574,
+                                                                                                                                                                                                    "bottom": 2050
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 72,
+                                                                                                                                                                            "top": 2058,
+                                                                                                                                                                            "right": 871,
+                                                                                                                                                                            "bottom": 2129
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                    "top": 2067,
+                                                                                                                                                                                    "right": 125,
+                                                                                                                                                                                    "bottom": 2120
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 143,
+                                                                                                                                                                                    "top": 2065,
+                                                                                                                                                                                    "right": 871,
+                                                                                                                                                                                    "bottom": 2121
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 143,
+                                                                                                                                                                                            "top": 2065,
+                                                                                                                                                                                            "right": 871,
+                                                                                                                                                                                            "bottom": 2121
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "[redacted:19c9]",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 143,
+                                                                                                                                                                                                    "top": 2065,
+                                                                                                                                                                                                    "right": 871,
+                                                                                                                                                                                                    "bottom": 2121
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Match",
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 72,
+                                                                                                                                                    "top": 2165,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 2271
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 902,
+                                                                                                                                            "top": 1545,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 1651
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 902,
+                                                                                                                                            "top": 1545,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 1651
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-23_19-04-05-812__uber__accessibility.window__home_dashboard__3d869a.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-23_19-04-05-812__uber__accessibility.window__home_dashboard__3d869a.json
@@ -1,0 +1,857 @@
+{
+    "captureId": "34e594d9-acf9-492f-bfec-decc862e7f2d",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784851445732,
+    "platform": "uber",
+    "ruleId": "uber.screen.home_dashboard",
+    "classificationName": "home_dashboard",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_tabs_content_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/loading_background",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_inbox_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_inbox_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_earnings_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_earnings_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_opportunities_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_opportunities_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_home_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2275
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/glide_home_screen_stack_container",
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2275
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2275
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/content_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2275
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2275
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.GridView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2275
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_go_online_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2168,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2275
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_menu_root_layout",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2275
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/bottom_container",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2220,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2220,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2222
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_navigation_view_v2",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2222,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2222,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2347
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "Home",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_home",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 216,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 85,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 130,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 85,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 130,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 70,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 146,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Home",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_large_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 70,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 146,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Discover",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_opportunities",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 216,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 432,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 301,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 346,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 301,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 346,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 268,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 379,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Discover",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 268,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 379,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Earnings",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_earnings",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 432,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 648,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 517,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 562,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 517,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 562,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 483,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 596,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Earnings",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 483,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 596,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Inbox",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_inbox",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 648,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 864,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 733,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 778,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 733,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 778,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 719,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 792,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Inbox",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 719,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 791,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Menu",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_menu",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 864,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 949,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 994,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 949,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 994,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 935,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Menu",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 935,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-23_19-35-44-857__uber__accessibility.window__idle_map__4571c6.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-23_19-35-44-857__uber__accessibility.window__idle_map__4571c6.json
@@ -1,0 +1,2494 @@
+{
+    "captureId": "b761862c-95bc-4363-8f05-5bad11d1109f",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784853344836,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_overlay_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_background_view",
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Unable to go offline",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_overlay_text",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_online_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_padding_container",
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_chevron",
+                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 53,
+                                                                                                                                                                                                    "top": 2231,
+                                                                                                                                                                                                    "right": 106,
+                                                                                                                                                                                                    "bottom": 2284
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 159,
+                                                                                                                                                                                                    "top": 2169,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2347
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Recommended for you",
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content_override",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 159,
+                                                                                                                                                                                                            "top": 2169,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 2347
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_content",
+                                                                                                                                                                                                        "class": "android.widget.RelativeLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 159,
+                                                                                                                                                                                                            "top": 2196,
+                                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                                            "bottom": 2320
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "text": "Loading…",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_label_leading",
+                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 159,
+                                                                                                                                                                                                                    "top": 2196,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2267
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/key_info_container",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 159,
+                                                                                                                                                                                                                    "top": 2267,
+                                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                                    "bottom": 2320
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2400,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2402,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 4486,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 143,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 261,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 819,
+                                                                                                                                                                            "bottom": 353
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                            "bottom": 353
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                            "bottom": 353
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                                    "top": 149,
+                                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                                    "bottom": 229
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 457,
+                                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                                            "right": 623,
+                                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 431,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 648,
+                                                                                                                                                                                                                    "bottom": 353
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_public_label_container",
+                                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 449,
+                                                                                                                                                                                                                            "top": 261,
+                                                                                                                                                                                                                            "right": 630,
+                                                                                                                                                                                                                            "bottom": 335
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "text": "TODAY",
+                                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_label_text",
+                                                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 467,
+                                                                                                                                                                                                                                    "top": 270,
+                                                                                                                                                                                                                                    "right": 612,
+                                                                                                                                                                                                                                    "bottom": 326
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 353,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 353
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 136
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 172
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2016,
+                                                                                                                                                                                    "right": 179,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 2034,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 2177
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                            "top": 2052,
+                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                            "bottom": 2159
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                                            "top": 2052,
+                                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                                            "bottom": 2159
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1873,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                            "top": 1891,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 2195
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1891,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2034
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1891,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 2034
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1909,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 2016
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_earnings_trends_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 2034,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2177
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 2034,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 2177
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Earnings Trends",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/map_control_earnings_trends",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 2052,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 2159
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 1062,
+                                                                                                                                                                                                    "top": 2177,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 2195
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 1062,
+                                                                                                                                                                                                            "top": 2177,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 2177
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 299,
+                                                                                                                                            "top": 3598,
+                                                                                                                                            "right": 709,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "La Siberia De Monterrey Mexican Bar And Grill",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 299,
+                                                                                                                                                    "top": 3598,
+                                                                                                                                                    "right": 709,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 614,
+                                                                                                                                            "top": 3429,
+                                                                                                                                            "right": 1024,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Capparelli's Italian Food & Pizza",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 614,
+                                                                                                                                                    "top": 3429,
+                                                                                                                                                    "right": 1024,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 215,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 268,
+                                                                                                                                            "bottom": -291
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 215,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 268,
+                                                                                                                                                    "bottom": -291
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 228,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 255,
+                                                                                                                                                            "bottom": -304
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 237,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 246,
+                                                                                                                                                    "bottom": -294
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1676,
+                                                                                                                                            "right": -945,
+                                                                                                                                            "bottom": 1729
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1676,
+                                                                                                                                                    "right": -945,
+                                                                                                                                                    "bottom": 1729
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 1689,
+                                                                                                                                                            "right": -958,
+                                                                                                                                                            "bottom": 1716
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 1726,
+                                                                                                                                                    "right": -967,
+                                                                                                                                                    "bottom": 1726
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 8,
+                                                                                                                                            "top": 495,
+                                                                                                                                            "right": 61,
+                                                                                                                                            "bottom": 548
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 6,
+                                                                                                                                                    "top": 492,
+                                                                                                                                                    "right": 59,
+                                                                                                                                                    "bottom": 545
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 21,
+                                                                                                                                                            "top": 508,
+                                                                                                                                                            "right": 48,
+                                                                                                                                                            "bottom": 535
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 30,
+                                                                                                                                                    "top": 545,
+                                                                                                                                                    "right": 39,
+                                                                                                                                                    "bottom": 545
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 173,
+                                                                                                                                            "right": -992,
+                                                                                                                                            "bottom": 226
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 173,
+                                                                                                                                                    "right": -992,
+                                                                                                                                                    "bottom": 226
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 186,
+                                                                                                                                                            "right": -1005,
+                                                                                                                                                            "bottom": 213
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 223,
+                                                                                                                                                    "right": -1014,
+                                                                                                                                                    "bottom": 223
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1080,
+                                                                                                                                            "top": 2543,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1092,
+                                                                                                                                                    "top": 2569,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1105,
+                                                                                                                                                            "top": 2582,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1124,
+                                                                                                                                                    "top": 2642,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 873,
+                                                                                                                                            "top": 1629,
+                                                                                                                                            "right": 926,
+                                                                                                                                            "bottom": 1682
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 873,
+                                                                                                                                                    "top": 1629,
+                                                                                                                                                    "right": 926,
+                                                                                                                                                    "bottom": 1682
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 886,
+                                                                                                                                                            "top": 1642,
+                                                                                                                                                            "right": 913,
+                                                                                                                                                            "bottom": 1669
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 895,
+                                                                                                                                                    "top": 1679,
+                                                                                                                                                    "right": 904,
+                                                                                                                                                    "bottom": 1679
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1194,
+                                                                                                                                            "top": 1592,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1645
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1194,
+                                                                                                                                                    "top": 1592,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1645
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1207,
+                                                                                                                                                            "top": 1605,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1632
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1216,
+                                                                                                                                                    "top": 1642,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1642
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1295,
+                                                                                                                                            "top": 1123,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1176
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1295,
+                                                                                                                                                    "top": 1123,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1176
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1308,
+                                                                                                                                                            "top": 1136,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1163
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1317,
+                                                                                                                                                    "top": 1173,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1173
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 822,
+                                                                                                                                            "right": -1322,
+                                                                                                                                            "bottom": 875
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 812,
+                                                                                                                                                    "right": -1361,
+                                                                                                                                                    "bottom": 865
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 835,
+                                                                                                                                                            "right": -1335,
+                                                                                                                                                            "bottom": 862
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 872,
+                                                                                                                                                    "right": -1344,
+                                                                                                                                                    "bottom": 872
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2535,
+                                                                                                                                            "right": -654,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2585,
+                                                                                                                                                    "right": -676,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1094,
+                                                                                                                                            "top": 1048,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1101
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1098,
+                                                                                                                                                    "top": 1046,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1099
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1107,
+                                                                                                                                                            "top": 1061,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1088
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1116,
+                                                                                                                                                    "top": 1098,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1098
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1119,
+                                                                                                                                            "top": 1650,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1703
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1122,
+                                                                                                                                                    "top": 1652,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1705
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1132,
+                                                                                                                                                            "top": 1663,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1690
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1141,
+                                                                                                                                                    "top": 1700,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1700
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1103,
+                                                                                                                                            "top": 2315,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2368
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1103,
+                                                                                                                                                    "top": 2315,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2368
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1116,
+                                                                                                                                                            "top": 2328,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2355
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1125,
+                                                                                                                                                    "top": 2365,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2365
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 430,
+                                                                                                                                            "top": 2251,
+                                                                                                                                            "right": 483,
+                                                                                                                                            "bottom": 2304
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 430,
+                                                                                                                                                    "top": 2251,
+                                                                                                                                                    "right": 483,
+                                                                                                                                                    "bottom": 2304
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 442,
+                                                                                                                                                            "top": 2270,
+                                                                                                                                                            "right": 469,
+                                                                                                                                                            "bottom": 2297
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 451,
+                                                                                                                                                    "top": 2314,
+                                                                                                                                                    "right": 460,
+                                                                                                                                                    "bottom": 2314
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 343,
+                                                                                                                                            "top": 1629,
+                                                                                                                                            "right": 396,
+                                                                                                                                            "bottom": 1682
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 342,
+                                                                                                                                                    "top": 1631,
+                                                                                                                                                    "right": 395,
+                                                                                                                                                    "bottom": 1684
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 355,
+                                                                                                                                                            "top": 1644,
+                                                                                                                                                            "right": 382,
+                                                                                                                                                            "bottom": 1671
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 365,
+                                                                                                                                                    "top": 1679,
+                                                                                                                                                    "right": 374,
+                                                                                                                                                    "bottom": 1679
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 657,
+                                                                                                                                            "top": 1994,
+                                                                                                                                            "right": 710,
+                                                                                                                                            "bottom": 2047
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 658,
+                                                                                                                                                    "top": 1996,
+                                                                                                                                                    "right": 711,
+                                                                                                                                                    "bottom": 2049
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 671,
+                                                                                                                                                            "top": 2009,
+                                                                                                                                                            "right": 698,
+                                                                                                                                                            "bottom": 2036
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 680,
+                                                                                                                                                    "top": 2049,
+                                                                                                                                                    "right": 689,
+                                                                                                                                                    "bottom": 2049
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 413,
+                                                                                                                                            "top": 1590,
+                                                                                                                                            "right": 466,
+                                                                                                                                            "bottom": 1643
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 413,
+                                                                                                                                                    "top": 1591,
+                                                                                                                                                    "right": 466,
+                                                                                                                                                    "bottom": 1644
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 426,
+                                                                                                                                                            "top": 1604,
+                                                                                                                                                            "right": 453,
+                                                                                                                                                            "bottom": 1631
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 435,
+                                                                                                                                                    "top": 1642,
+                                                                                                                                                    "right": 444,
+                                                                                                                                                    "bottom": 1642
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 267,
+                                                                                                                                            "top": 447,
+                                                                                                                                            "right": 320,
+                                                                                                                                            "bottom": 500
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 267,
+                                                                                                                                                    "top": 446,
+                                                                                                                                                    "right": 320,
+                                                                                                                                                    "bottom": 499
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 280,
+                                                                                                                                                            "top": 460,
+                                                                                                                                                            "right": 307,
+                                                                                                                                                            "bottom": 487
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 289,
+                                                                                                                                                    "top": 497,
+                                                                                                                                                    "right": 298,
+                                                                                                                                                    "bottom": 497
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 973,
+                                                                                                                                            "top": 1727,
+                                                                                                                                            "right": 1026,
+                                                                                                                                            "bottom": 1780
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 973,
+                                                                                                                                                    "top": 1727,
+                                                                                                                                                    "right": 1026,
+                                                                                                                                                    "bottom": 1780
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 986,
+                                                                                                                                                            "top": 1740,
+                                                                                                                                                            "right": 1013,
+                                                                                                                                                            "bottom": 1767
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 995,
+                                                                                                                                                    "top": 1777,
+                                                                                                                                                    "right": 1004,
+                                                                                                                                                    "bottom": 1777
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 567,
+                                                                                                                                            "top": 250,
+                                                                                                                                            "right": 620,
+                                                                                                                                            "bottom": 303
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 567,
+                                                                                                                                                    "top": 250,
+                                                                                                                                                    "right": 620,
+                                                                                                                                                    "bottom": 303
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 580,
+                                                                                                                                                            "top": 262,
+                                                                                                                                                            "right": 607,
+                                                                                                                                                            "bottom": 289
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 589,
+                                                                                                                                                    "top": 300,
+                                                                                                                                                    "right": 598,
+                                                                                                                                                    "bottom": 300
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 240,
+                                                                                                                                            "top": 623,
+                                                                                                                                            "right": 293,
+                                                                                                                                            "bottom": 676
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 240,
+                                                                                                                                                    "top": 623,
+                                                                                                                                                    "right": 293,
+                                                                                                                                                    "bottom": 676
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 253,
+                                                                                                                                                            "top": 636,
+                                                                                                                                                            "right": 280,
+                                                                                                                                                            "bottom": 663
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 262,
+                                                                                                                                                    "top": 673,
+                                                                                                                                                    "right": 271,
+                                                                                                                                                    "bottom": 673
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 499,
+                                                                                                                                            "top": 1174,
+                                                                                                                                            "right": 552,
+                                                                                                                                            "bottom": 1227
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 499,
+                                                                                                                                                    "top": 1174,
+                                                                                                                                                    "right": 552,
+                                                                                                                                                    "bottom": 1227
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 512,
+                                                                                                                                                            "top": 1187,
+                                                                                                                                                            "right": 539,
+                                                                                                                                                            "bottom": 1214
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 521,
+                                                                                                                                                    "top": 1224,
+                                                                                                                                                    "right": 530,
+                                                                                                                                                    "bottom": 1224
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 339,
+                                                                                                                                            "top": 2411,
+                                                                                                                                            "right": 392,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 339,
+                                                                                                                                                    "top": 2411,
+                                                                                                                                                    "right": 392,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 352,
+                                                                                                                                                            "top": 2424,
+                                                                                                                                                            "right": 379,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 361,
+                                                                                                                                                    "top": 2461,
+                                                                                                                                                    "right": 370,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 68,
+                                                                                                                                            "top": 1565,
+                                                                                                                                            "right": 104,
+                                                                                                                                            "bottom": 1601
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 906,
+                                                                                                                                            "top": 980,
+                                                                                                                                            "right": 942,
+                                                                                                                                            "bottom": 1016
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 199,
+                                                                                                                                            "top": 2222,
+                                                                                                                                            "right": 235,
+                                                                                                                                            "bottom": 2258
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 713,
+                                                                                                                                            "top": 2008,
+                                                                                                                                            "right": 749,
+                                                                                                                                            "bottom": 2044
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1103,
+                                                                                                                                            "top": 2471,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 985,
+                                                                                                                                            "top": 1634,
+                                                                                                                                            "right": 1021,
+                                                                                                                                            "bottom": 1670
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 586,
+                                                                                                                                            "top": 990,
+                                                                                                                                            "right": 622,
+                                                                                                                                            "bottom": 1026
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-23_19-39-59-512__uber__accessibility.window__UNKNOWN__894217.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-23_19-39-59-512__uber__accessibility.window__UNKNOWN__894217.json
@@ -1,0 +1,2588 @@
+{
+    "captureId": "c0644ac0-37cb-4032-a1e2-6d2b45eeb567",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784853599498,
+    "platform": "uber",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 410,
+                                                                                                                                            "top": 2390,
+                                                                                                                                            "right": 820,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Bayseas Seafood - Jones Maltsberger",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 410,
+                                                                                                                                                    "top": 2390,
+                                                                                                                                                    "right": 820,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 236,
+                                                                                                                                            "top": 2010,
+                                                                                                                                            "right": 646,
+                                                                                                                                            "bottom": 2105
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Full House Chinese Restaurant",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 236,
+                                                                                                                                                    "top": 2010,
+                                                                                                                                                    "right": 646,
+                                                                                                                                                    "bottom": 2105
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 703,
+                                                                                                                                            "top": 901,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 996
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Taziki's Mediterranean Cafe",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 703,
+                                                                                                                                                    "top": 901,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 996
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 50,
+                                                                                                                                            "top": 1074,
+                                                                                                                                            "right": 103,
+                                                                                                                                            "bottom": 1127
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 50,
+                                                                                                                                                    "top": 1074,
+                                                                                                                                                    "right": 103,
+                                                                                                                                                    "bottom": 1127
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 63,
+                                                                                                                                                            "top": 1087,
+                                                                                                                                                            "right": 90,
+                                                                                                                                                            "bottom": 1114
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 72,
+                                                                                                                                                    "top": 1124,
+                                                                                                                                                    "right": 81,
+                                                                                                                                                    "bottom": 1124
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 847,
+                                                                                                                                            "top": 2183,
+                                                                                                                                            "right": 900,
+                                                                                                                                            "bottom": 2236
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 847,
+                                                                                                                                                    "top": 2183,
+                                                                                                                                                    "right": 900,
+                                                                                                                                                    "bottom": 2236
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 860,
+                                                                                                                                                            "top": 2196,
+                                                                                                                                                            "right": 887,
+                                                                                                                                                            "bottom": 2223
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 869,
+                                                                                                                                                    "top": 2233,
+                                                                                                                                                    "right": 878,
+                                                                                                                                                    "bottom": 2233
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 607,
+                                                                                                                                            "top": 900,
+                                                                                                                                            "right": 660,
+                                                                                                                                            "bottom": 953
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 607,
+                                                                                                                                                    "top": 900,
+                                                                                                                                                    "right": 660,
+                                                                                                                                                    "bottom": 953
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 620,
+                                                                                                                                                            "top": 913,
+                                                                                                                                                            "right": 647,
+                                                                                                                                                            "bottom": 940
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 629,
+                                                                                                                                                    "top": 950,
+                                                                                                                                                    "right": 638,
+                                                                                                                                                    "bottom": 950
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 410,
+                                                                                                                                            "top": 1600,
+                                                                                                                                            "right": 463,
+                                                                                                                                            "bottom": 1653
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 410,
+                                                                                                                                                    "top": 1600,
+                                                                                                                                                    "right": 463,
+                                                                                                                                                    "bottom": 1653
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 423,
+                                                                                                                                                            "top": 1613,
+                                                                                                                                                            "right": 450,
+                                                                                                                                                            "bottom": 1640
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 432,
+                                                                                                                                                    "top": 1650,
+                                                                                                                                                    "right": 441,
+                                                                                                                                                    "bottom": 1650
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 548,
+                                                                                                                                            "top": 1896,
+                                                                                                                                            "right": 601,
+                                                                                                                                            "bottom": 1949
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 548,
+                                                                                                                                                    "top": 1896,
+                                                                                                                                                    "right": 601,
+                                                                                                                                                    "bottom": 1949
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 561,
+                                                                                                                                                            "top": 1909,
+                                                                                                                                                            "right": 588,
+                                                                                                                                                            "bottom": 1936
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 570,
+                                                                                                                                                    "top": 1946,
+                                                                                                                                                    "right": 579,
+                                                                                                                                                    "bottom": 1946
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 882,
+                                                                                                                                            "top": 1019,
+                                                                                                                                            "right": 935,
+                                                                                                                                            "bottom": 1072
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 882,
+                                                                                                                                                    "top": 1019,
+                                                                                                                                                    "right": 935,
+                                                                                                                                                    "bottom": 1072
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 895,
+                                                                                                                                                            "top": 1032,
+                                                                                                                                                            "right": 922,
+                                                                                                                                                            "bottom": 1059
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 904,
+                                                                                                                                                    "top": 1069,
+                                                                                                                                                    "right": 913,
+                                                                                                                                                    "bottom": 1069
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 301,
+                                                                                                                                            "top": 1768,
+                                                                                                                                            "right": 354,
+                                                                                                                                            "bottom": 1821
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 301,
+                                                                                                                                                    "top": 1768,
+                                                                                                                                                    "right": 354,
+                                                                                                                                                    "bottom": 1821
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 314,
+                                                                                                                                                            "top": 1781,
+                                                                                                                                                            "right": 341,
+                                                                                                                                                            "bottom": 1808
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 323,
+                                                                                                                                                    "top": 1818,
+                                                                                                                                                    "right": 332,
+                                                                                                                                                    "bottom": 1818
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 677,
+                                                                                                                                            "top": 1645,
+                                                                                                                                            "right": 730,
+                                                                                                                                            "bottom": 1698
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 677,
+                                                                                                                                                    "top": 1645,
+                                                                                                                                                    "right": 730,
+                                                                                                                                                    "bottom": 1698
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 690,
+                                                                                                                                                            "top": 1658,
+                                                                                                                                                            "right": 717,
+                                                                                                                                                            "bottom": 1685
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 699,
+                                                                                                                                                    "top": 1695,
+                                                                                                                                                    "right": 708,
+                                                                                                                                                    "bottom": 1695
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 665,
+                                                                                                                                            "top": 2031,
+                                                                                                                                            "right": 718,
+                                                                                                                                            "bottom": 2084
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 665,
+                                                                                                                                                    "top": 2031,
+                                                                                                                                                    "right": 718,
+                                                                                                                                                    "bottom": 2084
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 678,
+                                                                                                                                                            "top": 2044,
+                                                                                                                                                            "right": 705,
+                                                                                                                                                            "bottom": 2071
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 687,
+                                                                                                                                                    "top": 2081,
+                                                                                                                                                    "right": 696,
+                                                                                                                                                    "bottom": 2081
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 201,
+                                                                                                                                            "top": 1068,
+                                                                                                                                            "right": 254,
+                                                                                                                                            "bottom": 1121
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 201,
+                                                                                                                                                    "top": 1068,
+                                                                                                                                                    "right": 254,
+                                                                                                                                                    "bottom": 1121
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 214,
+                                                                                                                                                            "top": 1081,
+                                                                                                                                                            "right": 241,
+                                                                                                                                                            "bottom": 1108
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 223,
+                                                                                                                                                    "top": 1118,
+                                                                                                                                                    "right": 232,
+                                                                                                                                                    "bottom": 1118
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 263,
+                                                                                                                                            "top": 434,
+                                                                                                                                            "right": 316,
+                                                                                                                                            "bottom": 487
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 263,
+                                                                                                                                                    "top": 434,
+                                                                                                                                                    "right": 316,
+                                                                                                                                                    "bottom": 487
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 276,
+                                                                                                                                                            "top": 447,
+                                                                                                                                                            "right": 303,
+                                                                                                                                                            "bottom": 474
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 285,
+                                                                                                                                                    "top": 484,
+                                                                                                                                                    "right": 294,
+                                                                                                                                                    "bottom": 484
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 240,
+                                                                                                                                            "top": 623,
+                                                                                                                                            "right": 293,
+                                                                                                                                            "bottom": 676
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 240,
+                                                                                                                                                    "top": 623,
+                                                                                                                                                    "right": 293,
+                                                                                                                                                    "bottom": 676
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 253,
+                                                                                                                                                            "top": 636,
+                                                                                                                                                            "right": 280,
+                                                                                                                                                            "bottom": 663
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 262,
+                                                                                                                                                    "top": 673,
+                                                                                                                                                    "right": 271,
+                                                                                                                                                    "bottom": 673
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 333,
+                                                                                                                                            "top": 1651,
+                                                                                                                                            "right": 386,
+                                                                                                                                            "bottom": 1704
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 333,
+                                                                                                                                                    "top": 1651,
+                                                                                                                                                    "right": 386,
+                                                                                                                                                    "bottom": 1704
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 346,
+                                                                                                                                                            "top": 1664,
+                                                                                                                                                            "right": 373,
+                                                                                                                                                            "bottom": 1691
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 355,
+                                                                                                                                                    "top": 1701,
+                                                                                                                                                    "right": 364,
+                                                                                                                                                    "bottom": 1701
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1153,
+                                                                                                                                            "top": 811,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 864
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1153,
+                                                                                                                                                    "top": 811,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 864
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1166,
+                                                                                                                                                            "top": 824,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 851
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1175,
+                                                                                                                                                    "top": 861,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 861
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 423,
+                                                                                                                                            "top": 2327,
+                                                                                                                                            "right": 476,
+                                                                                                                                            "bottom": 2380
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 423,
+                                                                                                                                                    "top": 2327,
+                                                                                                                                                    "right": 476,
+                                                                                                                                                    "bottom": 2380
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 436,
+                                                                                                                                                            "top": 2340,
+                                                                                                                                                            "right": 463,
+                                                                                                                                                            "bottom": 2367
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 445,
+                                                                                                                                                    "top": 2377,
+                                                                                                                                                    "right": 454,
+                                                                                                                                                    "bottom": 2377
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 242,
+                                                                                                                                            "top": 1907,
+                                                                                                                                            "right": 295,
+                                                                                                                                            "bottom": 1960
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 242,
+                                                                                                                                                    "top": 1907,
+                                                                                                                                                    "right": 295,
+                                                                                                                                                    "bottom": 1960
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 255,
+                                                                                                                                                            "top": 1920,
+                                                                                                                                                            "right": 282,
+                                                                                                                                                            "bottom": 1947
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 264,
+                                                                                                                                                    "top": 1957,
+                                                                                                                                                    "right": 273,
+                                                                                                                                                    "bottom": 1957
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 262,
+                                                                                                                                            "top": 1415,
+                                                                                                                                            "right": 315,
+                                                                                                                                            "bottom": 1468
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 262,
+                                                                                                                                                    "top": 1415,
+                                                                                                                                                    "right": 315,
+                                                                                                                                                    "bottom": 1468
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 275,
+                                                                                                                                                            "top": 1428,
+                                                                                                                                                            "right": 302,
+                                                                                                                                                            "bottom": 1455
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 284,
+                                                                                                                                                    "top": 1465,
+                                                                                                                                                    "right": 293,
+                                                                                                                                                    "bottom": 1465
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 339,
+                                                                                                                                            "top": 2411,
+                                                                                                                                            "right": 392,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 339,
+                                                                                                                                                    "top": 2411,
+                                                                                                                                                    "right": 392,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 352,
+                                                                                                                                                            "top": 2424,
+                                                                                                                                                            "right": 379,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 361,
+                                                                                                                                                    "top": 2461,
+                                                                                                                                                    "right": 370,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 813,
+                                                                                                                                            "right": -17,
+                                                                                                                                            "bottom": 866
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 813,
+                                                                                                                                                    "right": -17,
+                                                                                                                                                    "bottom": 866
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 826,
+                                                                                                                                                            "right": -30,
+                                                                                                                                                            "bottom": 853
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 863,
+                                                                                                                                                    "right": -39,
+                                                                                                                                                    "bottom": 863
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 567,
+                                                                                                                                            "top": 249,
+                                                                                                                                            "right": 620,
+                                                                                                                                            "bottom": 302
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 567,
+                                                                                                                                                    "top": 249,
+                                                                                                                                                    "right": 620,
+                                                                                                                                                    "bottom": 302
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 580,
+                                                                                                                                                            "top": 262,
+                                                                                                                                                            "right": 607,
+                                                                                                                                                            "bottom": 289
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 589,
+                                                                                                                                                    "top": 299,
+                                                                                                                                                    "right": 598,
+                                                                                                                                                    "bottom": 299
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1152,
+                                                                                                                                            "top": 2400,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1152,
+                                                                                                                                                    "top": 2400,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1165,
+                                                                                                                                                            "top": 2413,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1174,
+                                                                                                                                                    "top": 2450,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 499,
+                                                                                                                                            "top": 1174,
+                                                                                                                                            "right": 552,
+                                                                                                                                            "bottom": 1227
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 499,
+                                                                                                                                                    "top": 1174,
+                                                                                                                                                    "right": 552,
+                                                                                                                                                    "bottom": 1227
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 512,
+                                                                                                                                                            "top": 1187,
+                                                                                                                                                            "right": 539,
+                                                                                                                                                            "bottom": 1214
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 521,
+                                                                                                                                                    "top": 1224,
+                                                                                                                                                    "right": 530,
+                                                                                                                                                    "bottom": 1224
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 314,
+                                                                                                                                            "top": 1907,
+                                                                                                                                            "right": 713,
+                                                                                                                                            "bottom": 1959
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Willie's Grill & Icehouse",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 314,
+                                                                                                                                                    "top": 1907,
+                                                                                                                                                    "right": 713,
+                                                                                                                                                    "bottom": 1959
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 134,
+                                                                                                                                            "top": 1688,
+                                                                                                                                            "right": 520,
+                                                                                                                                            "bottom": 1740
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Saltgrass Steak House",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 134,
+                                                                                                                                                    "top": 1688,
+                                                                                                                                                    "right": 520,
+                                                                                                                                                    "bottom": 1740
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 751,
+                                                                                                                                            "top": 811,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 863
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Ravello Italian Cuisine",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 751,
+                                                                                                                                                    "top": 811,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 863
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 40,
+                                                                                                                                            "top": 988,
+                                                                                                                                            "right": 415,
+                                                                                                                                            "bottom": 1040
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Smokey MO'S TX BBQ",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 40,
+                                                                                                                                                    "top": 988,
+                                                                                                                                                    "right": 415,
+                                                                                                                                                    "bottom": 1040
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 334,
+                                                                                                                                            "top": 1415,
+                                                                                                                                            "right": 616,
+                                                                                                                                            "bottom": 1467
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Tacos Carnivoro",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 334,
+                                                                                                                                                    "top": 1415,
+                                                                                                                                                    "right": 616,
+                                                                                                                                                    "bottom": 1467
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 122,
+                                                                                                                                            "top": 1074,
+                                                                                                                                            "right": 395,
+                                                                                                                                            "bottom": 1126
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Curry Boys BBQ",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 122,
+                                                                                                                                                    "top": 1074,
+                                                                                                                                                    "right": 395,
+                                                                                                                                                    "bottom": 1126
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 872,
+                                                                                                                                            "top": 2400,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Longhorn Cafe",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 872,
+                                                                                                                                                    "top": 2400,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 576,
+                                                                                                                                            "top": 2183,
+                                                                                                                                            "right": 827,
+                                                                                                                                            "bottom": 2235
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Dollar General",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 576,
+                                                                                                                                                    "top": 2183,
+                                                                                                                                                    "right": 827,
+                                                                                                                                                    "bottom": 2235
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 165,
+                                                                                                                                            "top": 354,
+                                                                                                                                            "right": 414,
+                                                                                                                                            "bottom": 406
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Sonic Drive-In",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 165,
+                                                                                                                                                    "top": 354,
+                                                                                                                                                    "right": 414,
+                                                                                                                                                    "bottom": 406
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 2,
+                                                                                                                                            "top": 813,
+                                                                                                                                            "right": 237,
+                                                                                                                                            "bottom": 865
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Whataburger",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 2,
+                                                                                                                                                    "top": 813,
+                                                                                                                                                    "right": 237,
+                                                                                                                                                    "bottom": 865
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 256,
+                                                                                                                                            "top": 1174,
+                                                                                                                                            "right": 479,
+                                                                                                                                            "bottom": 1226
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "McDonald's®",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 256,
+                                                                                                                                                    "top": 1174,
+                                                                                                                                                    "right": 479,
+                                                                                                                                                    "bottom": 1226
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 466,
+                                                                                                                                            "top": 1816,
+                                                                                                                                            "right": 683,
+                                                                                                                                            "bottom": 1868
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Dairy Queen",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 466,
+                                                                                                                                                    "top": 1816,
+                                                                                                                                                    "right": 683,
+                                                                                                                                                    "bottom": 1868
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 200,
+                                                                                                                                            "top": 2327,
+                                                                                                                                            "right": 402,
+                                                                                                                                            "bottom": 2379
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Gogi Street",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 200,
+                                                                                                                                                    "top": 2327,
+                                                                                                                                                    "right": 402,
+                                                                                                                                                    "bottom": 2379
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 313,
+                                                                                                                                            "top": 623,
+                                                                                                                                            "right": 515,
+                                                                                                                                            "bottom": 675
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Laurel Cafe",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 313,
+                                                                                                                                                    "top": 623,
+                                                                                                                                                    "right": 515,
+                                                                                                                                                    "bottom": 675
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 609,
+                                                                                                                                            "top": 1565,
+                                                                                                                                            "right": 798,
+                                                                                                                                            "bottom": 1617
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Cheba Hut",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 609,
+                                                                                                                                                    "top": 1565,
+                                                                                                                                                    "right": 798,
+                                                                                                                                                    "bottom": 1617
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 406,
+                                                                                                                                            "top": 900,
+                                                                                                                                            "right": 586,
+                                                                                                                                            "bottom": 952
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Grimaldi's",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 406,
+                                                                                                                                                    "top": 900,
+                                                                                                                                                    "right": 586,
+                                                                                                                                                    "bottom": 952
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 388,
+                                                                                                                                            "top": 249,
+                                                                                                                                            "right": 546,
+                                                                                                                                            "bottom": 301
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "7-Eleven",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 388,
+                                                                                                                                                    "top": 249,
+                                                                                                                                                    "right": 546,
+                                                                                                                                                    "bottom": 301
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 369,
+                                                                                                                                            "top": 1520,
+                                                                                                                                            "right": 503,
+                                                                                                                                            "bottom": 1572
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Pei Wei",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 369,
+                                                                                                                                                    "top": 1520,
+                                                                                                                                                    "right": 503,
+                                                                                                                                                    "bottom": 1572
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 189,
+                                                                                                                                            "top": 1651,
+                                                                                                                                            "right": 311,
+                                                                                                                                            "bottom": 1703
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Chuy's",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 189,
+                                                                                                                                                    "top": 1651,
+                                                                                                                                                    "right": 311,
+                                                                                                                                                    "bottom": 1703
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 68,
+                                                                                                                                            "top": 1565,
+                                                                                                                                            "right": 104,
+                                                                                                                                            "bottom": 1601
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 586,
+                                                                                                                                            "top": 1009,
+                                                                                                                                            "right": 622,
+                                                                                                                                            "bottom": 1045
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1103,
+                                                                                                                                            "top": 2488,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 713,
+                                                                                                                                            "top": 2020,
+                                                                                                                                            "right": 749,
+                                                                                                                                            "bottom": 2056
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 985,
+                                                                                                                                            "top": 1651,
+                                                                                                                                            "right": 1021,
+                                                                                                                                            "bottom": 1687
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 199,
+                                                                                                                                            "top": 2232,
+                                                                                                                                            "right": 235,
+                                                                                                                                            "bottom": 2268
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/driver_offers_job_board_content_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/driver_offers_job_board_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 250,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 305,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 537
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "More trip requests",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 35,
+                                                                                                                                            "top": 340,
+                                                                                                                                            "right": 510,
+                                                                                                                                            "bottom": 411
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "Some may be outside your preferences",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 35,
+                                                                                                                                            "top": 428,
+                                                                                                                                            "right": 752,
+                                                                                                                                            "bottom": 484
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 18,
+                                                                                                                                    "top": 546,
+                                                                                                                                    "right": 1062,
+                                                                                                                                    "bottom": 1344
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "androidx.cardview.widget.CardView",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 18,
+                                                                                                                                            "top": 546,
+                                                                                                                                            "right": 1062,
+                                                                                                                                            "bottom": 1344
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 18,
+                                                                                                                                                    "top": 546,
+                                                                                                                                                    "right": 1062,
+                                                                                                                                                    "bottom": 1344
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/message_content_overlay",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 89,
+                                                                                                                                                            "top": 877,
+                                                                                                                                                            "right": 991,
+                                                                                                                                                            "bottom": 1013
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "This request is no longer available",
+                                                                                                                                                                "id": "com.ubercab.driver:id/image_message_text",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 125,
+                                                                                                                                                                    "top": 913,
+                                                                                                                                                                    "right": 955,
+                                                                                                                                                                    "bottom": 977
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 18,
+                                                                                                                                                    "top": 546,
+                                                                                                                                                    "right": 1062,
+                                                                                                                                                    "bottom": 1344
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 546,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 893
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 54,
+                                                                                                                                                                    "top": 582,
+                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                    "bottom": 866
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 54,
+                                                                                                                                                                            "top": 582,
+                                                                                                                                                                            "right": 1026,
+                                                                                                                                                                            "bottom": 866
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 582,
+                                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                                    "bottom": 660
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 582,
+                                                                                                                                                                                            "right": 299,
+                                                                                                                                                                                            "bottom": 660
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 72,
+                                                                                                                                                                                                    "top": 603,
+                                                                                                                                                                                                    "right": 108,
+                                                                                                                                                                                                    "bottom": 639
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Delivery",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 126,
+                                                                                                                                                                                                    "top": 582,
+                                                                                                                                                                                                    "right": 299,
+                                                                                                                                                                                                    "bottom": 660
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 660,
+                                                                                                                                                                                    "right": 309,
+                                                                                                                                                                                    "bottom": 788
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "text": "$6.09",
+                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 660,
+                                                                                                                                                                                            "right": 309,
+                                                                                                                                                                                            "bottom": 788
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 788,
+                                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                                    "bottom": 866
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 788,
+                                                                                                                                                                                            "right": 495,
+                                                                                                                                                                                            "bottom": 866
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Includes expected tip",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                                    "top": 788,
+                                                                                                                                                                                                    "right": 495,
+                                                                                                                                                                                                    "bottom": 866
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 893,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 895
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 895,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 1004
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 54,
+                                                                                                                                                                    "top": 922,
+                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                    "bottom": 986
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 54,
+                                                                                                                                                                            "top": 922,
+                                                                                                                                                                            "right": 541,
+                                                                                                                                                                            "bottom": 986
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 927,
+                                                                                                                                                                                    "right": 107,
+                                                                                                                                                                                    "bottom": 980
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "text": "24 min (8.9 mi) total",
+                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 125,
+                                                                                                                                                                                    "top": 922,
+                                                                                                                                                                                    "right": 541,
+                                                                                                                                                                                    "bottom": 986
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 1004,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 1006
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 1006,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 1184
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 54,
+                                                                                                                                                                    "top": 1024,
+                                                                                                                                                                    "right": 1026,
+                                                                                                                                                                    "bottom": 1166
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 54,
+                                                                                                                                                                            "top": 1024,
+                                                                                                                                                                            "right": 997,
+                                                                                                                                                                            "bottom": 1166
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 1024,
+                                                                                                                                                                                    "right": 997,
+                                                                                                                                                                                    "bottom": 1095
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 1033,
+                                                                                                                                                                                            "right": 107,
+                                                                                                                                                                                            "bottom": 1086
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 125,
+                                                                                                                                                                                            "top": 1031,
+                                                                                                                                                                                            "right": 997,
+                                                                                                                                                                                            "bottom": 1087
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 125,
+                                                                                                                                                                                                    "top": 1031,
+                                                                                                                                                                                                    "right": 658,
+                                                                                                                                                                                                    "bottom": 1087
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Sonic (2314 Thousand Oaks)",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 125,
+                                                                                                                                                                                                            "top": 1031,
+                                                                                                                                                                                                            "right": 658,
+                                                                                                                                                                                                            "bottom": 1087
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 54,
+                                                                                                                                                                                    "top": 1095,
+                                                                                                                                                                                    "right": 997,
+                                                                                                                                                                                    "bottom": 1166
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 54,
+                                                                                                                                                                                            "top": 1104,
+                                                                                                                                                                                            "right": 107,
+                                                                                                                                                                                            "bottom": 1157
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 125,
+                                                                                                                                                                                            "top": 1102,
+                                                                                                                                                                                            "right": 997,
+                                                                                                                                                                                            "bottom": 1158
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 125,
+                                                                                                                                                                                                    "top": 1102,
+                                                                                                                                                                                                    "right": 997,
+                                                                                                                                                                                                    "bottom": 1158
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Sample St & Sample Ave, San Antonio",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 125,
+                                                                                                                                                                                                            "top": 1102,
+                                                                                                                                                                                                            "right": 997,
+                                                                                                                                                                                                            "bottom": 1158
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "text": "Match",
+                                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                                        "isClickable": true,
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 54,
+                                                                                                                                                            "top": 1202,
+                                                                                                                                                            "right": 1026,
+                                                                                                                                                            "bottom": 1308
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 946,
+                                                                                                                                                    "top": 582,
+                                                                                                                                                    "right": 1026,
+                                                                                                                                                    "bottom": 662
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 946,
+                                                                                                                                                    "top": 582,
+                                                                                                                                                    "right": 1026,
+                                                                                                                                                    "bottom": 662
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1353,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2347
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/driver_offers_job_board_toolbar_background",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 278
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/driver_offers_job_board_toolbar",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 278
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "desc": "Back",
+                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 144,
+                                                                                                                            "right": 125,
+                                                                                                                            "bottom": 269
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Trip Radar",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 133,
+                                                                                                                            "top": 179,
+                                                                                                                            "right": 347,
+                                                                                                                            "bottom": 235
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-24_17-21-25-307__uber__accessibility.window__home_dashboard__cf1e83.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-24_17-21-25-307__uber__accessibility.window__home_dashboard__cf1e83.json
@@ -1,0 +1,870 @@
+{
+    "captureId": "98eb2641-8d1d-419b-8e33-aa9c44bcea71",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784931685291,
+    "platform": "uber",
+    "ruleId": "uber.screen.home_dashboard",
+    "classificationName": "home_dashboard",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 0,
+                                                                                                    "bottom": 0
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 0,
+                                                                                                            "bottom": 0
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_tabs_content_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 0,
+                                                                                                                    "bottom": 0
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 0,
+                                                                                                                            "bottom": 0
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 0,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 0,
+                                                                                                                                                    "bottom": 0
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 0,
+                                                                                                                                                    "bottom": 0
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/loading_background",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_inbox_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 0,
+                                                                                                                            "bottom": 0
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_inbox_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_menu_root_layout",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 0,
+                                                                                                                            "bottom": 0
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_menu_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_home_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 0,
+                                                                                                                            "bottom": 0
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 0,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_go_online_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 0,
+                                                                                                                                                    "bottom": 0
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/content_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 0,
+                                                                                                                                                    "bottom": 0
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 0,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 0,
+                                                                                                                                                                    "bottom": 0
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/glide_home_screen_stack_container",
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 0,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_earnings_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 0,
+                                                                                                                            "bottom": 0
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_earnings_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/glide_opportunities_root",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 0,
+                                                                                                                            "bottom": 0
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_opportunities_screen_stack_container",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.ubercab.driver:id/bottom_container",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2220,
+                                                                                                                            "right": 0,
+                                                                                                                            "bottom": 0
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2220,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_navigation_view_v2",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2222,
+                                                                                                                                    "right": 0,
+                                                                                                                                    "bottom": 0
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2222,
+                                                                                                                                            "right": 0,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "Home",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_home",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 0,
+                                                                                                                                                    "bottom": 0
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 85,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 130,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 85,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 130,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 70,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 146,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Home",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_large_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 70,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 146,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Discover",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_opportunities",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 216,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 432,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 301,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 346,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 301,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 346,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 268,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 379,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Discover",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 268,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 379,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Earnings",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_earnings",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 432,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 648,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 517,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 562,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 517,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 562,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 483,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 596,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Earnings",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 483,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 596,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Inbox",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_inbox",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 648,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 864,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 733,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 778,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 733,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 778,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 719,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 792,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Inbox",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 719,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 791,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "desc": "Menu",
+                                                                                                                                                "id": "com.ubercab.driver:id/glide_bottom_nav_menu",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 864,
+                                                                                                                                                    "top": 2222,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_icon_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 949,
+                                                                                                                                                            "top": 2240,
+                                                                                                                                                            "right": 994,
+                                                                                                                                                            "bottom": 2285
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_icon_view",
+                                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 949,
+                                                                                                                                                                    "top": 2240,
+                                                                                                                                                                    "right": 994,
+                                                                                                                                                                    "bottom": 2285
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/navigation_bar_item_labels_group",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 935,
+                                                                                                                                                            "top": 2298,
+                                                                                                                                                            "right": 1008,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "text": "Menu",
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_bar_item_small_label_view",
+                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 935,
+                                                                                                                                                                    "top": 2298,
+                                                                                                                                                                    "right": 1008,
+                                                                                                                                                                    "bottom": 2333
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-24_19-33-56-577__uber__accessibility.window__idle_map__2c28dc.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-24_19-33-56-577__uber__accessibility.window__idle_map__2c28dc.json
@@ -1,0 +1,1415 @@
+{
+    "captureId": "b57f7fe0-c408-4371-b677-bd9116af1871",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784939636565,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1154,
+                                                                                                                                            "top": 740,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 793
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1154,
+                                                                                                                                                    "top": 740,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 793
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1167,
+                                                                                                                                                            "top": 753,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 780
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1176,
+                                                                                                                                                    "top": 790,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 790
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 568,
+                                                                                                                                            "top": 866,
+                                                                                                                                            "right": 621,
+                                                                                                                                            "bottom": 919
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 568,
+                                                                                                                                                    "top": 866,
+                                                                                                                                                    "right": 621,
+                                                                                                                                                    "bottom": 919
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 581,
+                                                                                                                                                            "top": 879,
+                                                                                                                                                            "right": 608,
+                                                                                                                                                            "bottom": 906
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 590,
+                                                                                                                                                    "top": 916,
+                                                                                                                                                    "right": 599,
+                                                                                                                                                    "bottom": 916
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1096,
+                                                                                                                                            "top": 2458,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1096,
+                                                                                                                                                    "top": 2458,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1109,
+                                                                                                                                                            "top": 2471,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1118,
+                                                                                                                                                    "top": 2508,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 556,
+                                                                                                                                            "top": 257,
+                                                                                                                                            "right": 609,
+                                                                                                                                            "bottom": 310
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 556,
+                                                                                                                                                    "top": 257,
+                                                                                                                                                    "right": 609,
+                                                                                                                                                    "bottom": 310
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 569,
+                                                                                                                                                            "top": 270,
+                                                                                                                                                            "right": 596,
+                                                                                                                                                            "bottom": 297
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 578,
+                                                                                                                                                    "top": 307,
+                                                                                                                                                    "right": 587,
+                                                                                                                                                    "bottom": 307
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 265,
+                                                                                                                                            "top": 363,
+                                                                                                                                            "right": 318,
+                                                                                                                                            "bottom": 416
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 265,
+                                                                                                                                                    "top": 363,
+                                                                                                                                                    "right": 318,
+                                                                                                                                                    "bottom": 416
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 278,
+                                                                                                                                                            "top": 376,
+                                                                                                                                                            "right": 305,
+                                                                                                                                                            "bottom": 403
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 287,
+                                                                                                                                                    "top": 413,
+                                                                                                                                                    "right": 296,
+                                                                                                                                                    "bottom": 413
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 659,
+                                                                                                                                            "top": 1567,
+                                                                                                                                            "right": 712,
+                                                                                                                                            "bottom": 1620
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 659,
+                                                                                                                                                    "top": 1567,
+                                                                                                                                                    "right": 712,
+                                                                                                                                                    "bottom": 1620
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 672,
+                                                                                                                                                            "top": 1580,
+                                                                                                                                                            "right": 699,
+                                                                                                                                                            "bottom": 1607
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 681,
+                                                                                                                                                    "top": 1617,
+                                                                                                                                                    "right": 690,
+                                                                                                                                                    "bottom": 1617
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 900,
+                                                                                                                                            "top": 901,
+                                                                                                                                            "right": 953,
+                                                                                                                                            "bottom": 954
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 900,
+                                                                                                                                                    "top": 901,
+                                                                                                                                                    "right": 953,
+                                                                                                                                                    "bottom": 954
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 913,
+                                                                                                                                                            "top": 914,
+                                                                                                                                                            "right": 940,
+                                                                                                                                                            "bottom": 941
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 922,
+                                                                                                                                                    "top": 951,
+                                                                                                                                                    "right": 931,
+                                                                                                                                                    "bottom": 951
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 425,
+                                                                                                                                            "top": 2257,
+                                                                                                                                            "right": 478,
+                                                                                                                                            "bottom": 2310
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 425,
+                                                                                                                                                    "top": 2257,
+                                                                                                                                                    "right": 478,
+                                                                                                                                                    "bottom": 2310
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 438,
+                                                                                                                                                            "top": 2270,
+                                                                                                                                                            "right": 465,
+                                                                                                                                                            "bottom": 2297
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 447,
+                                                                                                                                                    "top": 2307,
+                                                                                                                                                    "right": 456,
+                                                                                                                                                    "bottom": 2307
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 138,
+                                                                                                                                            "top": 1416,
+                                                                                                                                            "right": 191,
+                                                                                                                                            "bottom": 1469
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 138,
+                                                                                                                                                    "top": 1416,
+                                                                                                                                                    "right": 191,
+                                                                                                                                                    "bottom": 1469
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 151,
+                                                                                                                                                            "top": 1429,
+                                                                                                                                                            "right": 178,
+                                                                                                                                                            "bottom": 1456
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 160,
+                                                                                                                                                    "top": 1466,
+                                                                                                                                                    "right": 169,
+                                                                                                                                                    "bottom": 1466
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 365,
+                                                                                                                                            "top": 1461,
+                                                                                                                                            "right": 418,
+                                                                                                                                            "bottom": 1514
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 365,
+                                                                                                                                                    "top": 1461,
+                                                                                                                                                    "right": 418,
+                                                                                                                                                    "bottom": 1514
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 378,
+                                                                                                                                                            "top": 1474,
+                                                                                                                                                            "right": 405,
+                                                                                                                                                            "bottom": 1501
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 387,
+                                                                                                                                                    "top": 1511,
+                                                                                                                                                    "right": 396,
+                                                                                                                                                    "bottom": 1511
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 711,
+                                                                                                                                            "top": 423,
+                                                                                                                                            "right": 764,
+                                                                                                                                            "bottom": 476
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 711,
+                                                                                                                                                    "top": 423,
+                                                                                                                                                    "right": 764,
+                                                                                                                                                    "bottom": 476
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 724,
+                                                                                                                                                            "top": 436,
+                                                                                                                                                            "right": 751,
+                                                                                                                                                            "bottom": 463
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 733,
+                                                                                                                                                    "top": 473,
+                                                                                                                                                    "right": 742,
+                                                                                                                                                    "bottom": 473
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 549,
+                                                                                                                                            "top": 1826,
+                                                                                                                                            "right": 602,
+                                                                                                                                            "bottom": 1879
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 549,
+                                                                                                                                                    "top": 1826,
+                                                                                                                                                    "right": 602,
+                                                                                                                                                    "bottom": 1879
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 562,
+                                                                                                                                                            "top": 1839,
+                                                                                                                                                            "right": 589,
+                                                                                                                                                            "bottom": 1866
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 571,
+                                                                                                                                                    "top": 1876,
+                                                                                                                                                    "right": 580,
+                                                                                                                                                    "bottom": 1876
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 529,
+                                                                                                                                            "top": 1063,
+                                                                                                                                            "right": 582,
+                                                                                                                                            "bottom": 1116
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 529,
+                                                                                                                                                    "top": 1063,
+                                                                                                                                                    "right": 582,
+                                                                                                                                                    "bottom": 1116
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 542,
+                                                                                                                                                            "top": 1076,
+                                                                                                                                                            "right": 569,
+                                                                                                                                                            "bottom": 1103
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 551,
+                                                                                                                                                    "top": 1113,
+                                                                                                                                                    "right": 560,
+                                                                                                                                                    "bottom": 1113
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 694,
+                                                                                                                                            "top": 1973,
+                                                                                                                                            "right": 747,
+                                                                                                                                            "bottom": 2026
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 694,
+                                                                                                                                                    "top": 1973,
+                                                                                                                                                    "right": 747,
+                                                                                                                                                    "bottom": 2026
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 707,
+                                                                                                                                                            "top": 1986,
+                                                                                                                                                            "right": 734,
+                                                                                                                                                            "bottom": 2013
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 716,
+                                                                                                                                                    "top": 2023,
+                                                                                                                                                    "right": 725,
+                                                                                                                                                    "bottom": 2023
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 344,
+                                                                                                                                            "top": 2328,
+                                                                                                                                            "right": 397,
+                                                                                                                                            "bottom": 2381
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 344,
+                                                                                                                                                    "top": 2328,
+                                                                                                                                                    "right": 397,
+                                                                                                                                                    "bottom": 2381
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 357,
+                                                                                                                                                            "top": 2341,
+                                                                                                                                                            "right": 384,
+                                                                                                                                                            "bottom": 2368
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 366,
+                                                                                                                                                    "top": 2378,
+                                                                                                                                                    "right": 375,
+                                                                                                                                                    "bottom": 2378
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 302,
+                                                                                                                                            "top": 1698,
+                                                                                                                                            "right": 355,
+                                                                                                                                            "bottom": 1751
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 302,
+                                                                                                                                                    "top": 1698,
+                                                                                                                                                    "right": 355,
+                                                                                                                                                    "bottom": 1751
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 315,
+                                                                                                                                                            "top": 1711,
+                                                                                                                                                            "right": 342,
+                                                                                                                                                            "bottom": 1738
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 324,
+                                                                                                                                                    "top": 1748,
+                                                                                                                                                    "right": 333,
+                                                                                                                                                    "bottom": 1748
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 742,
+                                                                                                                                            "right": -15,
+                                                                                                                                            "bottom": 795
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 742,
+                                                                                                                                                    "right": -15,
+                                                                                                                                                    "bottom": 795
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 755,
+                                                                                                                                                            "right": -28,
+                                                                                                                                                            "bottom": 782
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 792,
+                                                                                                                                                    "right": -37,
+                                                                                                                                                    "bottom": 792
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 52,
+                                                                                                                                            "top": 1003,
+                                                                                                                                            "right": 105,
+                                                                                                                                            "bottom": 1056
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 52,
+                                                                                                                                                    "top": 1003,
+                                                                                                                                                    "right": 105,
+                                                                                                                                                    "bottom": 1056
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 65,
+                                                                                                                                                            "top": 1016,
+                                                                                                                                                            "right": 92,
+                                                                                                                                                            "bottom": 1043
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 74,
+                                                                                                                                                    "top": 1053,
+                                                                                                                                                    "right": 83,
+                                                                                                                                                    "bottom": 1053
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 261,
+                                                                                                                                            "top": 1807,
+                                                                                                                                            "right": 297,
+                                                                                                                                            "bottom": 1843
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 856,
+                                                                                                                                            "top": 2120,
+                                                                                                                                            "right": 892,
+                                                                                                                                            "bottom": 2156
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 279,
+                                                                                                                                            "top": 1476,
+                                                                                                                                            "right": 315,
+                                                                                                                                            "bottom": 1512
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 420,
+                                                                                                                                            "top": 1537,
+                                                                                                                                            "right": 456,
+                                                                                                                                            "bottom": 1573
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-24_19-35-56-545__uber__accessibility.window__idle_map__a4bfa3.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-24_19-35-56-545__uber__accessibility.window__idle_map__a4bfa3.json
@@ -1,0 +1,1089 @@
+{
+    "captureId": "a3472c45-318b-4cbb-aab1-d0902e7c0eda",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784939756530,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 143,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 261,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 819,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                                    "top": 149,
+                                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                                    "bottom": 229
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 457,
+                                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                                            "right": 623,
+                                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 522,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 558,
+                                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 279,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 136
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 172
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 1820,
+                                                                                                                                                                                    "right": 179,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 1838,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1677,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                            "top": 1695,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 1999
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1695,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1838
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1695,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1838
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1713,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1820
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_earnings_trends_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1838,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1981
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1838,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Earnings Trends",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/map_control_earnings_trends",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 1062,
+                                                                                                                                                                                                    "top": 1981,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1999
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 1062,
+                                                                                                                                                                                                            "top": 1981,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2168
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_overlay_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_background_view",
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2168
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Unable to go offline",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant_overlay_text",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                                    "bottom": 2168
+                                                                                                                                                                                                }
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_online_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_padding_container",
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2168,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2170
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2170,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 4424,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-24_19-37-07-910__uber__accessibility.window__idle_map__992e80.json
+++ b/app/src/test/resources/snapshots/UNKNOWN/negative/2026-07-24_19-37-07-910__uber__accessibility.window__idle_map__992e80.json
@@ -1,0 +1,2462 @@
+{
+    "captureId": "d93d04bc-a575-4f7b-8268-90352b7bd3df",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1784939827875,
+    "platform": "uber",
+    "ruleId": "uber.screen.idle_map",
+    "classificationName": "idle_map",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:17/CP2A.260705.006/15641320:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "id": "com.ubercab.driver:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.ubercab.driver:id/rootView",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 0,
+                                                                            "right": 1080,
+                                                                            "bottom": 2400
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.ubercab.driver:id/online_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 0,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2400
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 0
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.ubercab.driver:id/glide_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 0,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2400
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/glide_screen_stack_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/glide_active_view_container",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/system_banner_container",
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 0
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/active_container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 0,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/background_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/screen_stack_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 0,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/ub__top_banner_container",
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 0
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/home_screen_overlay_container",
+                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 0,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 0,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 0,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_left_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 143,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "desc": "Home",
+                                                                                                                                                                                "id": "com.ubercab.driver:id/profile_entry",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_icon",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    },
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/profile_entry_photo",
+                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/earnings_tracker_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 261,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 819,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__tracker_entry_content_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_entry_public_mode_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__earnings_tracker_indicator_card",
+                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 421,
+                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                            "right": 659,
+                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                        },
+                                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                                            {
+                                                                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                                    "left": 421,
+                                                                                                                                                                                                                                    "top": 149,
+                                                                                                                                                                                                                                    "right": 659,
+                                                                                                                                                                                                                                    "bottom": 229
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                                        "text": "$0.00",
+                                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__earnings_tracker_counter_content_status",
+                                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                                            "left": 457,
+                                                                                                                                                                                                                                            "top": 149,
+                                                                                                                                                                                                                                            "right": 623,
+                                                                                                                                                                                                                                            "bottom": 229
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                ]
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                        ]
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            },
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 522,
+                                                                                                                                                                                                                    "top": 243,
+                                                                                                                                                                                                                    "right": 558,
+                                                                                                                                                                                                                    "bottom": 279
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/my_hub_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 937,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                    "bottom": 243
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "desc": "Search for places",
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/search_entry_button",
+                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                            "bottom": 243
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/top_center_container",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 540,
+                                                                                                                                                                            "top": 279,
+                                                                                                                                                                            "right": 540,
+                                                                                                                                                                            "bottom": 279
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "id": "com.ubercab.driver:id/navigation_container",
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 0,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 136
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        }
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "class": "com.uber.rib.core.compose.root.UberComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 136,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    },
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_view",
+                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 136,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_control_top_right_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 1044,
+                                                                                                                                                                                    "top": 136,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 172
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_left_container",
+                                                                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 1820,
+                                                                                                                                                                                    "right": 179,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_safety_toolkit_container",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 18,
+                                                                                                                                                                                            "top": 1838,
+                                                                                                                                                                                            "right": 161,
+                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__safety_toolkit_container",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Safety Toolkit",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__safety_toolkit_button_container",
+                                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 36,
+                                                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                                                    "right": 143,
+                                                                                                                                                                                                                    "bottom": 1963
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__shield_animation_view",
+                                                                                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 36,
+                                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                                            "right": 143,
+                                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_bottom_center_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 357,
+                                                                                                                                                                                    "top": 1856,
+                                                                                                                                                                                    "right": 723,
+                                                                                                                                                                                    "bottom": 2355
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 375,
+                                                                                                                                                                                            "top": 1874,
+                                                                                                                                                                                            "right": 705,
+                                                                                                                                                                                            "bottom": 1981
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "text": "Trip Radar",
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__driver_job_offers_pill_title",
+                                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 411,
+                                                                                                                                                                                                    "top": 1900,
+                                                                                                                                                                                                    "right": 606,
+                                                                                                                                                                                                    "bottom": 1956
+                                                                                                                                                                                                }
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__driver_job_offers_pill_badge",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 624,
+                                                                                                                                                                                                    "top": 1905,
+                                                                                                                                                                                                    "right": 669,
+                                                                                                                                                                                                    "bottom": 1950
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "2",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 628,
+                                                                                                                                                                                                            "top": 1909,
+                                                                                                                                                                                                            "right": 665,
+                                                                                                                                                                                                            "bottom": 1946
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_container",
+                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 901,
+                                                                                                                                                                                    "top": 1534,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2373
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                            "top": 1552,
+                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                            "bottom": 1999
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_ugc_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1552,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1695
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__ugc_map_button",
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1552,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1695
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Report a map issue",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__ugc_map_button_icon",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1570,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1677
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_controls_earnings_trends_container",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1695,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1838
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1695,
+                                                                                                                                                                                                            "right": 1062,
+                                                                                                                                                                                                            "bottom": 1838
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "desc": "Earnings Trends",
+                                                                                                                                                                                                                "id": "com.ubercab.driver:id/map_control_earnings_trends",
+                                                                                                                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 937,
+                                                                                                                                                                                                                    "top": 1713,
+                                                                                                                                                                                                                    "right": 1044,
+                                                                                                                                                                                                                    "bottom": 1820
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            },
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "id": "com.ubercab.driver:id/ub__map_bottom_right_buttons",
+                                                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": 919,
+                                                                                                                                                                                                    "top": 1838,
+                                                                                                                                                                                                    "right": 1062,
+                                                                                                                                                                                                    "bottom": 1999
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_nav_button_layout",
+                                                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 919,
+                                                                                                                                                                                                            "top": 1838,
+                                                                                                                                                                                                            "right": 919,
+                                                                                                                                                                                                            "bottom": 1838
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "com.ubercab.driver:id/ub__map_controls_bottom_right_center_me",
+                                                                                                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 937,
+                                                                                                                                                                                                            "top": 1856,
+                                                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                                                            "bottom": 1963
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/bottom_sheet_container",
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 0,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 2400
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 0,
+                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                            "bottom": 2400
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.ubercab.driver:id/status_assistant",
+                                                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 0,
+                                                                                                                                                                                    "top": 2026,
+                                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                                    "bottom": 2168
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "id": "com.ubercab.driver:id/status_assistant_go_offline_animation_view",
+                                                                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": 0,
+                                                                                                                                                                                            "top": 2026,
+                                                                                                                                                                                            "right": 1080,
+                                                                                                                                                                                            "bottom": 2168
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.ubercab.driver:id/glide_background_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 0,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2400
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.ubercab.driver:id/rxmap",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 0,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2400
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/annotations",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.ubercab.driver:id/map",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 0,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2400
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 0,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2400
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.TextureView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 0,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2400
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 579,
+                                                                                                                                            "top": 507,
+                                                                                                                                            "right": 989,
+                                                                                                                                            "bottom": 602
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Camila's Mexican Restaurant",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 579,
+                                                                                                                                                    "top": 507,
+                                                                                                                                                    "right": 989,
+                                                                                                                                                    "bottom": 602
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1143,
+                                                                                                                                            "top": 2467,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1143,
+                                                                                                                                                    "top": 2467,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1156,
+                                                                                                                                                            "top": 2480,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2400
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1165,
+                                                                                                                                                    "top": 2517,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 391,
+                                                                                                                                            "top": 2337,
+                                                                                                                                            "right": 444,
+                                                                                                                                            "bottom": 2390
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 391,
+                                                                                                                                                    "top": 2337,
+                                                                                                                                                    "right": 444,
+                                                                                                                                                    "bottom": 2390
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 404,
+                                                                                                                                                            "top": 2350,
+                                                                                                                                                            "right": 431,
+                                                                                                                                                            "bottom": 2377
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 413,
+                                                                                                                                                    "top": 2387,
+                                                                                                                                                    "right": 422,
+                                                                                                                                                    "bottom": 2387
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 751,
+                                                                                                                                            "right": 31,
+                                                                                                                                            "bottom": 804
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 751,
+                                                                                                                                                    "right": 31,
+                                                                                                                                                    "bottom": 804
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 764,
+                                                                                                                                                            "right": 18,
+                                                                                                                                                            "bottom": 791
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 801,
+                                                                                                                                                    "right": 9,
+                                                                                                                                                    "bottom": 801
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 184,
+                                                                                                                                            "top": 1425,
+                                                                                                                                            "right": 237,
+                                                                                                                                            "bottom": 1478
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 184,
+                                                                                                                                                    "top": 1425,
+                                                                                                                                                    "right": 237,
+                                                                                                                                                    "bottom": 1478
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 197,
+                                                                                                                                                            "top": 1438,
+                                                                                                                                                            "right": 224,
+                                                                                                                                                            "bottom": 1465
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 206,
+                                                                                                                                                    "top": 1475,
+                                                                                                                                                    "right": 215,
+                                                                                                                                                    "bottom": 1475
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 614,
+                                                                                                                                            "top": 875,
+                                                                                                                                            "right": 667,
+                                                                                                                                            "bottom": 928
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 614,
+                                                                                                                                                    "top": 875,
+                                                                                                                                                    "right": 667,
+                                                                                                                                                    "bottom": 928
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 627,
+                                                                                                                                                            "top": 888,
+                                                                                                                                                            "right": 654,
+                                                                                                                                                            "bottom": 915
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 636,
+                                                                                                                                                    "top": 925,
+                                                                                                                                                    "right": 645,
+                                                                                                                                                    "bottom": 925
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 98,
+                                                                                                                                            "top": 1012,
+                                                                                                                                            "right": 151,
+                                                                                                                                            "bottom": 1065
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 98,
+                                                                                                                                                    "top": 1012,
+                                                                                                                                                    "right": 151,
+                                                                                                                                                    "bottom": 1065
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 111,
+                                                                                                                                                            "top": 1025,
+                                                                                                                                                            "right": 138,
+                                                                                                                                                            "bottom": 1052
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 120,
+                                                                                                                                                    "top": 1062,
+                                                                                                                                                    "right": 129,
+                                                                                                                                                    "bottom": 1062
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 705,
+                                                                                                                                            "top": 1576,
+                                                                                                                                            "right": 758,
+                                                                                                                                            "bottom": 1629
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 705,
+                                                                                                                                                    "top": 1576,
+                                                                                                                                                    "right": 758,
+                                                                                                                                                    "bottom": 1629
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 718,
+                                                                                                                                                            "top": 1589,
+                                                                                                                                                            "right": 745,
+                                                                                                                                                            "bottom": 1616
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 727,
+                                                                                                                                                    "top": 1626,
+                                                                                                                                                    "right": 736,
+                                                                                                                                                    "bottom": 1626
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 348,
+                                                                                                                                            "top": 1707,
+                                                                                                                                            "right": 401,
+                                                                                                                                            "bottom": 1760
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 348,
+                                                                                                                                                    "top": 1707,
+                                                                                                                                                    "right": 401,
+                                                                                                                                                    "bottom": 1760
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 361,
+                                                                                                                                                            "top": 1720,
+                                                                                                                                                            "right": 388,
+                                                                                                                                                            "bottom": 1747
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 370,
+                                                                                                                                                    "top": 1757,
+                                                                                                                                                    "right": 379,
+                                                                                                                                                    "bottom": 1757
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 946,
+                                                                                                                                            "top": 910,
+                                                                                                                                            "right": 999,
+                                                                                                                                            "bottom": 963
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 946,
+                                                                                                                                                    "top": 910,
+                                                                                                                                                    "right": 999,
+                                                                                                                                                    "bottom": 963
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 959,
+                                                                                                                                                            "top": 923,
+                                                                                                                                                            "right": 986,
+                                                                                                                                                            "bottom": 950
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 968,
+                                                                                                                                                    "top": 960,
+                                                                                                                                                    "right": 977,
+                                                                                                                                                    "bottom": 960
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 412,
+                                                                                                                                            "top": 1470,
+                                                                                                                                            "right": 465,
+                                                                                                                                            "bottom": 1523
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 412,
+                                                                                                                                                    "top": 1470,
+                                                                                                                                                    "right": 465,
+                                                                                                                                                    "bottom": 1523
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 425,
+                                                                                                                                                            "top": 1483,
+                                                                                                                                                            "right": 452,
+                                                                                                                                                            "bottom": 1510
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 434,
+                                                                                                                                                    "top": 1520,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 1520
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 758,
+                                                                                                                                            "top": 432,
+                                                                                                                                            "right": 811,
+                                                                                                                                            "bottom": 485
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 758,
+                                                                                                                                                    "top": 432,
+                                                                                                                                                    "right": 811,
+                                                                                                                                                    "bottom": 485
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 771,
+                                                                                                                                                            "top": 445,
+                                                                                                                                                            "right": 798,
+                                                                                                                                                            "bottom": 472
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 780,
+                                                                                                                                                    "top": 482,
+                                                                                                                                                    "right": 789,
+                                                                                                                                                    "bottom": 482
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 603,
+                                                                                                                                            "top": 266,
+                                                                                                                                            "right": 656,
+                                                                                                                                            "bottom": 319
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 603,
+                                                                                                                                                    "top": 266,
+                                                                                                                                                    "right": 656,
+                                                                                                                                                    "bottom": 319
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 616,
+                                                                                                                                                            "top": 279,
+                                                                                                                                                            "right": 643,
+                                                                                                                                                            "bottom": 306
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 625,
+                                                                                                                                                    "top": 316,
+                                                                                                                                                    "right": 634,
+                                                                                                                                                    "bottom": 316
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 311,
+                                                                                                                                            "top": 372,
+                                                                                                                                            "right": 364,
+                                                                                                                                            "bottom": 425
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 311,
+                                                                                                                                                    "top": 372,
+                                                                                                                                                    "right": 364,
+                                                                                                                                                    "bottom": 425
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 324,
+                                                                                                                                                            "top": 385,
+                                                                                                                                                            "right": 351,
+                                                                                                                                                            "bottom": 412
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 333,
+                                                                                                                                                    "top": 422,
+                                                                                                                                                    "right": 342,
+                                                                                                                                                    "bottom": 422
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 596,
+                                                                                                                                            "top": 1835,
+                                                                                                                                            "right": 649,
+                                                                                                                                            "bottom": 1888
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 596,
+                                                                                                                                                    "top": 1835,
+                                                                                                                                                    "right": 649,
+                                                                                                                                                    "bottom": 1888
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 609,
+                                                                                                                                                            "top": 1848,
+                                                                                                                                                            "right": 636,
+                                                                                                                                                            "bottom": 1875
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 618,
+                                                                                                                                                    "top": 1885,
+                                                                                                                                                    "right": 627,
+                                                                                                                                                    "bottom": 1885
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 575,
+                                                                                                                                            "top": 1072,
+                                                                                                                                            "right": 628,
+                                                                                                                                            "bottom": 1125
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 575,
+                                                                                                                                                    "top": 1072,
+                                                                                                                                                    "right": 628,
+                                                                                                                                                    "bottom": 1125
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 588,
+                                                                                                                                                            "top": 1085,
+                                                                                                                                                            "right": 615,
+                                                                                                                                                            "bottom": 1112
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 597,
+                                                                                                                                                    "top": 1122,
+                                                                                                                                                    "right": 606,
+                                                                                                                                                    "bottom": 1122
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 740,
+                                                                                                                                            "top": 1982,
+                                                                                                                                            "right": 793,
+                                                                                                                                            "bottom": 2035
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 740,
+                                                                                                                                                    "top": 1982,
+                                                                                                                                                    "right": 793,
+                                                                                                                                                    "bottom": 2035
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 753,
+                                                                                                                                                            "top": 1995,
+                                                                                                                                                            "right": 780,
+                                                                                                                                                            "bottom": 2022
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 762,
+                                                                                                                                                    "top": 2032,
+                                                                                                                                                    "right": 771,
+                                                                                                                                                    "bottom": 2032
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "id": "com.ubercab.driver:id/map_marker",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 471,
+                                                                                                                                            "top": 2266,
+                                                                                                                                            "right": 524,
+                                                                                                                                            "bottom": 2319
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_pin_head",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 471,
+                                                                                                                                                    "top": 2266,
+                                                                                                                                                    "right": 524,
+                                                                                                                                                    "bottom": 2319
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.ubercab.driver:id/leading_icon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 484,
+                                                                                                                                                            "top": 2279,
+                                                                                                                                                            "right": 511,
+                                                                                                                                                            "bottom": 2306
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_needle_view",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 493,
+                                                                                                                                                    "top": 2316,
+                                                                                                                                                    "right": 502,
+                                                                                                                                                    "bottom": 2316
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 446,
+                                                                                                                                            "top": 795,
+                                                                                                                                            "right": 835,
+                                                                                                                                            "bottom": 847
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "P. Terry’s Burger Stand",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 446,
+                                                                                                                                                    "top": 795,
+                                                                                                                                                    "right": 835,
+                                                                                                                                                    "bottom": 847
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 420,
+                                                                                                                                            "top": 1707,
+                                                                                                                                            "right": 806,
+                                                                                                                                            "bottom": 1759
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Saltgrass Steak House",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 420,
+                                                                                                                                                    "top": 1707,
+                                                                                                                                                    "right": 806,
+                                                                                                                                                    "bottom": 1759
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 32,
+                                                                                                                                            "top": 1345,
+                                                                                                                                            "right": 389,
+                                                                                                                                            "bottom": 1397
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Salata Salad Kitchen",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 32,
+                                                                                                                                                    "top": 1345,
+                                                                                                                                                    "right": 389,
+                                                                                                                                                    "bottom": 1397
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 612,
+                                                                                                                                            "top": 1902,
+                                                                                                                                            "right": 921,
+                                                                                                                                            "bottom": 1954
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Thai Chili Express",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 612,
+                                                                                                                                                    "top": 1902,
+                                                                                                                                                    "right": 921,
+                                                                                                                                                    "bottom": 1954
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 484,
+                                                                                                                                            "top": 1470,
+                                                                                                                                            "right": 786,
+                                                                                                                                            "bottom": 1522
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Teriyaki Madness",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 484,
+                                                                                                                                                    "top": 1470,
+                                                                                                                                                    "right": 786,
+                                                                                                                                                    "bottom": 1522
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 386,
+                                                                                                                                            "top": 1576,
+                                                                                                                                            "right": 685,
+                                                                                                                                            "bottom": 1628
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Delicious Garden",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 386,
+                                                                                                                                                    "top": 1576,
+                                                                                                                                                    "right": 685,
+                                                                                                                                                    "bottom": 1628
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 651,
+                                                                                                                                            "top": 910,
+                                                                                                                                            "right": 926,
+                                                                                                                                            "bottom": 962
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "46th St Pizzeria",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 651,
+                                                                                                                                                    "top": 910,
+                                                                                                                                                    "right": 926,
+                                                                                                                                                    "bottom": 962
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 170,
+                                                                                                                                            "top": 1012,
+                                                                                                                                            "right": 443,
+                                                                                                                                            "bottom": 1064
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Curry Boys BBQ",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 170,
+                                                                                                                                                    "top": 1012,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 1064
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 383,
+                                                                                                                                            "top": 372,
+                                                                                                                                            "right": 632,
+                                                                                                                                            "bottom": 424
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Sonic Drive-In",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 383,
+                                                                                                                                                    "top": 372,
+                                                                                                                                                    "right": 632,
+                                                                                                                                                    "bottom": 424
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 311,
+                                                                                                                                            "top": 1072,
+                                                                                                                                            "right": 555,
+                                                                                                                                            "bottom": 1124
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Little Caesars",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 311,
+                                                                                                                                                    "top": 1072,
+                                                                                                                                                    "right": 555,
+                                                                                                                                                    "bottom": 1124
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 50,
+                                                                                                                                            "top": 751,
+                                                                                                                                            "right": 285,
+                                                                                                                                            "bottom": 803
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Whataburger",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 50,
+                                                                                                                                                    "top": 751,
+                                                                                                                                                    "right": 285,
+                                                                                                                                                    "bottom": 803
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 463,
+                                                                                                                                            "top": 2337,
+                                                                                                                                            "right": 686,
+                                                                                                                                            "bottom": 2389
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "McDonald's®",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 463,
+                                                                                                                                                    "top": 2337,
+                                                                                                                                                    "right": 686,
+                                                                                                                                                    "bottom": 2389
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 514,
+                                                                                                                                            "top": 1755,
+                                                                                                                                            "right": 731,
+                                                                                                                                            "bottom": 1807
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Dairy Queen",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 514,
+                                                                                                                                                    "top": 1755,
+                                                                                                                                                    "right": 731,
+                                                                                                                                                    "bottom": 1807
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 544,
+                                                                                                                                            "top": 2266,
+                                                                                                                                            "right": 746,
+                                                                                                                                            "bottom": 2318
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Gogi Street",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 544,
+                                                                                                                                                    "top": 2266,
+                                                                                                                                                    "right": 746,
+                                                                                                                                                    "bottom": 2318
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 535,
+                                                                                                                                            "top": 186,
+                                                                                                                                            "right": 724,
+                                                                                                                                            "bottom": 238
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Walgreens",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 535,
+                                                                                                                                                    "top": 186,
+                                                                                                                                                    "right": 724,
+                                                                                                                                                    "bottom": 238
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 1216,
+                                                                                                                                            "top": 2467,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2400
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "The Shack",
+                                                                                                                                                "id": "com.ubercab.driver:id/map_marker_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1216,
+                                                                                                                                                    "top": 2467,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2400
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 325,
+                                                                                                                                            "top": 1485,
+                                                                                                                                            "right": 361,
+                                                                                                                                            "bottom": 1521
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1535,
+                                                                                                                                            "right": -8,
+                                                                                                                                            "bottom": 1571
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 307,
+                                                                                                                                            "top": 1816,
+                                                                                                                                            "right": 343,
+                                                                                                                                            "bottom": 1852
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 198,
+                                                                                                                                            "top": 2154,
+                                                                                                                                            "right": 234,
+                                                                                                                                            "bottom": 2190
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 466,
+                                                                                                                                            "top": 1546,
+                                                                                                                                            "right": 502,
+                                                                                                                                            "bottom": 1582
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Closes #941
Closes #929

Four related gaps from the 2026-07-30 ground-up adversarial review (§4.4 items 4–5), plus the #929 pruner footgun that lives in the same two files. All of it is desk test-infrastructure: no production code, no rule JSON, no goldens regenerated.

## 1. Negative corpus — `snapshots/UNKNOWN/negative/`

Over-match is the dangerous recognition failure direction. Under-match only drops a frame to UNKNOWN (the pipeline's own fail-safe); over-match **forges state** — #857/#874/#875 claimed `modeHint: offline` from ABSENCE on partially-rendered Uber home frames and permanently split live dashes into phantom `session_records`, and #858's expiry overlay minted an offer named "This request is no longer available". Yet the must-stay-UNKNOWN discipline was 10 frames hard-wired into three rule-specific evidence tests, and `UnknownScreenAnalysisTest` **green-passed on an empty set**.

- New committed corpus at `app/src/test/resources/snapshots/UNKNOWN/negative/`, seeded with the 10 existing must-stay-UNKNOWN fixtures (4 × `uber_idle_map_partial`, 4 × `uber_home_dashboard_partial`, 2 × `uber_offer_expiry_overlay`). **Copied, not moved** — `UberIdleMapOfflineEvidenceTest` / `UberHomeDashboardOfflineEvidenceTest` / `UberOfferExpiryOverlayTest` are unchanged and still assert something the general guard cannot: that each frame is still a specimen of *its specific bug* (it carries `home_screen_overlay_container` / `glide_bottom_nav_home` / `image_message_text`). No new field data was pulled — PII discipline.
- New `NegativeCorpusStaysUnknownTest` (an `AllMatchersSuite` member, pure verification) asserts per frame: still classifies UNKNOWN **inside its own platform partition** (matching how `ObservationClassifier` partitions by wire — the #900/#898-F5 scoping), carries a resolvable `__<platformWire>__` token, is scanner-clean, and is not also reachable from the flat staging listing.
- Emptiness fails: `MINIMUM_FRAMES = 10` is a **floor, not an equality pin** — the corpus may only grow. Verified by removing one frame ⇒ `holds 9 frames, below the 10-frame floor`.

**Why a subfolder.** The decision was "home = `snapshots/UNKNOWN/`". The parent is gitignored *staging* (raw unsorted device pulls, un-swept for PII — that ignore is a real privacy control worth keeping), so the committed corpus lives one level down behind an explicit `.gitignore` negation (`/UNKNOWN/*` + `!/UNKNOWN/negative/` — ignoring the folder's **contents** rather than the folder is what makes the negation reachable at all). The placement is also load-bearing, not cosmetic: `InboxProcessorTest` / `UnknownScreenAnalysisTest` enumerate `.json` files in a **flat** directory listing, so they can never see — and therefore never graduate, move or prune — a committed negative frame. Verified: `UNKNOWN/negative/*.json` is not ignored, `UNKNOWN/random.json` still is.

## 2. Intake failures fail loud

`TestResourceLoader.loadSnapshots` used to `println("⚠️ Skipping unparseable file")` and return null — so a corrupt committed fixture sat in git looking like coverage while **no test ever read it** (a silently lost regression guard).

It now throws for every directory except the two *staging* areas (`INBOX/`, `UNKNOWN/`), where a malformed raw pull is expected traffic and the triage tool's job is to survive the batch and report. `snapshots/UNKNOWN/negative/` is committed and therefore strict — the leaf directory name decides.

**Seam scoped deliberately:** the issue's other half ("an unrecognized INBOX capture → green test") is left alone. `InboxProcessorTest`'s X-Ray report on an unrecognized capture *is* the triage workflow's product; failing there would abort the sorting run mid-batch. Verified: a corrupt file under `negative/` ⇒ `IllegalStateException: Unparseable committed corpus file … (#941)`.

## 3. Corpus-mutating tests excluded from the sweep

`InboxProcessorTest` and `UnknownScreenAnalysisTest` redact / move / prune / delete files under `snapshots/` as their normal operation. Only `*Suite` was excluded from an unfiltered `testDebugUnitTest`, so they were no-ops on CI purely because `INBOX/` is gitignored and therefore empty there — luck, not a guarantee, and a developer's local sweep *does* hit a populated INBOX and silently rewrites the corpus mid-run.

Extended the existing `doFirst` filter mechanism in `app/build.gradle.kts` with an explicit, named list. They stay runnable by name (`--tests` sets `commandLineIncludePatterns`, which turns the whole block off). Verified: absent from a full-sweep result set; `--tests "*InboxProcessorTest"` still runs green (EMPTY_INBOX no-op) and mutated nothing.

## 4. Coverage ratchet keyed by platform + intent

Intent names are shared across platforms (`idle_map`, `offer`, `home_dashboard`…) and corpus folders are intent-named, so a DoorDash-populated folder marked the same-named **Uber** intent covered. The pin is now `platform:intent`, and coverage is *measured* rather than inferred from folder names: a pair is covered iff some corpus snapshot classifies to that intent inside that platform's rule partition.

**Finding: the gap's size is unchanged (14 → 14) — no fabrication needed, nothing added to the pin.** No cross-platform folder was masking a real gap today; the blindness was latent. What it *did* expose is that the old pin's attribution was wrong: `photo_capture`, `pickup_verification_info`, `pickup_verification_pin`, `shop_and_pay_checkout` and `shop_and_pay_list` sat under a "DoorDash — rules added from triage" comment header but are declared by the **Uber** ruleset (DoorDash's own same-named surfaces are covered). Corrected in-place with a note. The next Uber rule that borrows a DoorDash-covered intent name can no longer hide.

## 5. #929 — the pruner's sort-order eviction footgun

`SnapshotLibrarian.pruneFolder` sorted candidates by **raw filename**, and the corpus carries two capture naming conventions whose lexical order is *inverted* against their real chronology: legacy `20260128_155954_491_…` sorts ABOVE current `2026-07-17_18-08-53-720__…` (`'0'` > `'-'`), and bare-hash names (`c46728d0.json`) sort above both. On a saturated folder the prune therefore kept the OLDEST representatives and evicted the newest — PR #926's pass deleted 8 `dropoff_pre_arrival` + 1 `ratings` fixture before a human noticed the `git status`.

Two changes, both documented in KDoc:

- **Sort by the parsed capture timestamp.** `captureTimestampOf` handles both conventions (they encode the same `yyyy MM dd HH mm ss SSS` fields in the same order, so stripping separators yields a directly comparable number — no date parsing, no zone, no locale). Un-timestamped names sort as oldest (the honest reading: they predate both conventions), with the filename as a total tie-break so the order is reproducible.
- **An at-cap safe.** `pruneFolder(folder, addedFilename)` — when the folder held `RETENTION_LIMIT` distinct variants *before* the newcomer arrived, the newcomer and only the newcomer is dropped. Incumbents are never evicted to make room (PR #800's capped-additions-only discipline). Below cap the newest-per-fingerprint refresh still runs and may replace an incumbent with a fresher capture of *identical* content — that is the retention policy working, and it is pinned by a test so #929's fix can't quietly delete it. `addedFilename = null` (a bare cleanup pass) disables the safe.

New `SnapshotLibrarianPruneTest` covers all of it — the one piece of test infrastructure that deletes committed corpus had no test of its own.

## Verification

- `./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL**, 1148 tests, 0 failures, 0 errors, 0 skipped.
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — green.
- `--tests "*InboxProcessorTest"` run by name — green, empty-INBOX no-op, corpus unmutated (`git status` clean apart from the intended additions).
- Goldens untouched: `approved-parse-output.json` is **not** in the diff; no regen was run or needed.
- Both new fail-closed seams proved by deliberate probe (corrupt fixture ⇒ loud throw; removed frame ⇒ floor trip), each reverted.

## Field validation

None warranted — this is desk test-infrastructure with no on-device behaviour. No `docs/field-testing/` checklist item added.

### Design-goal review

- **3 — Clean code / single responsibility.** Each seam landed in the file that already owned it: loader tolerance in `TestResourceLoader`, retention policy in `SnapshotLibrarian`, sweep filtering in the existing `doFirst` block, coverage measurement in `ParseOutputGoldenTest`. One new guard test and one new pruner test, both small and single-purpose. No file grew a second responsibility.
- **4 — Kotlin/Android best practices.** `captureTimestampOf` does pure digit concatenation rather than date parsing, so it carries no zone/locale hazard at all. The at-cap safe is an explicit, defaulted parameter (`addedFilename: String? = null`) so the bare-cleanup call shape stays legal and honest. Fingerprints are computed once per prune and shared with the safe rather than re-parsed.
- **5 — SSOT.** The tolerant-staging directory set and the retention limit each have one definition. The negative corpus does **not** duplicate the three evidence tests' assertions — it adds the general "still UNKNOWN" bar and leaves the "still a specimen of bug X" bar with the test that owns bug X. The `.gitignore` negation is the single place the committed/staging split is declared.
- **6 — Security & privacy.** Net positive, no new exposure. Every seeded frame is a **copy of an already-committed, already-swept** fixture (each explicitly PII-asserted by its existing evidence test); no device pull dir was touched and no new field data enters the repo. The new guard re-asserts `SnapshotSecurityScanner` cleanliness on each frame, so committed negative corpus is held to the same bar as the golden corpus. The gitignore change *narrows* nothing: raw untracked drops into `UNKNOWN/` remain ignored, which is the control that keeps un-swept captures out of git. And the corpus itself defends a Pledge-adjacent property — over-match is exactly how a recognition change silently downgrades a fail-closed claim.
- **7 — Semantic logging.** No production log sites touched. Test-harness `println`s only; the new at-cap line names the file being dropped and the reason, which is the information a corpus pass needs.
- **8 — Platform-agnostic core.** Directly strengthened, and the reason item 4 exists. The ratchet no longer credits one platform's corpus to another; platform identity is resolved by wire prefix / the `Platform` registry (`Platform.fromWire`) with no literal `== Platform.DoorDash` anywhere, and the pin is data (`"uber:post_trip"`), not a Kotlin `when`. `NegativeCorpusStaysUnknownTest` derives its partition from the capture's own naming token and iterates whatever wires the rules declare — adding a platform needs no edit here. The one asymmetry left is honest and visible: the pin now *shows* Uber's thinness instead of hiding it behind DoorDash folders.
- Principles 1 (UDF) and 2 (MAD) are untouched — no state, reducers, effects, DI or UI in this diff. Reactive UI rules N/A.
