### PR TITLE
feature(pipeline): #937 — recognition-health liveness (versionName stamping + UNKNOWN-rate alarm)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,33 @@ supported one. (Distinct from #428, which bounds the app's OWN copy/TTS to en/es
 assumption; the #938 notice copy itself IS translated into `values-es` since a Spanish dasher is
 exactly its audience.)
 
+**Recognition has a liveness signal (#937)** — the last unfilled quadrant of the #909 silent-death
+family (effect engine #914, bubble #916, odometer #917). Two pieces, both fail-OPEN and both inert
+to frame processing. (1) **Version stamping:** `PlatformAppVersions` resolves the OBSERVED app's
+`versionName` (`CachingPlatformAppVersions` — one `PackageManager` lookup per package per process,
+negative results cached too, `catch (Throwable)`; the `PackageManager` call is a lambda injected at
+the `PipelineModule` DI edge so the caching logic is a plain unit test). `ObservationClassifier`
+stamps it onto every observation's `ReplayMetadata.platformAppVersion` — classification is the one
+point that always runs AND knows the package, since the capture stage is skipped wholesale on a
+disabled bus (release `NoOpCaptureBus`) — from where it rides into the capture envelope for free.
+Additive + nullable, and `Json.encodeDefaults` is false, so an unstamped envelope is byte-identical
+to a pre-#937 one: the committed corpus and the parse golden carry no such key and no test may
+require it. The cache is deliberately NOT invalidated on a package update (a process restart follows
+one in practice; a stale diagnostic stamp is a nuisance, never a correctness problem). The resolved
+`package@version` pairs also ride the periodic `PipelineStats` INFO summary (`platformApps=…`) —
+platform-app facts, PII-free. (2) **UNKNOWN-rate alarm:** `RecognitionHealth` (pure, per-platform
+rolling window of the last `WINDOW_SIZE`=50 **admitted** screen frames — post-`FrameGate`, so a
+dasher parked on one unruled screen contributes a couple of samples, not a thousand) trips when the
+window is FULL and ≥`UNKNOWN_RATIO_THRESHOLD`=0.80 of it classified UNKNOWN. Field-derived: the
+07-28/29 pulls put a healthy dash near 16 % UNKNOWN on that same stream, so the threshold sits 5×
+clear of the noise while a real anchor break drives the ratio toward 1.0. `RecognitionHealthMonitor`
+owns the edges — package→platform via the registry (an `Unknown` package is ignored; no platform
+literal anywhere), one WARN + one `RecognitionHealthReporter` call per platform per **process**
+(per-*dash* would need `:core:state`, which depends on `:core:pipeline` and not the reverse;
+recovery deliberately does not re-arm). The `:domain` reporter contract is #938's inversion reused:
+the `:app` `RecognitionHealthNotifier` posts on the shared `app_notice_channel`, whose id + copy now
+live in one owner (`AppNoticeChannel`, ids 102 locale / 103 recognition).
+
 ### 2. JSON Rule Engine (`core/pipeline/.../rules/` + generated `assets/rules/`)
 
 Recognition is **data, not code**. The rule SOURCE is per-platform **JSON5** under `matchers/rules/`

--- a/app/src/main/java/cloud/trotter/dashbuddy/di/AppModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/AppModule.kt
@@ -9,7 +9,9 @@ import cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers
 import cloud.trotter.dashbuddy.core.state.EffectExecutor
 import cloud.trotter.dashbuddy.core.state.MetadataProvider
 import cloud.trotter.dashbuddy.domain.pipeline.LocaleBoundaryReporter
+import cloud.trotter.dashbuddy.domain.pipeline.RecognitionHealthReporter
 import cloud.trotter.dashbuddy.locale.LocaleBoundaryNotifier
+import cloud.trotter.dashbuddy.notice.RecognitionHealthNotifier
 import cloud.trotter.dashbuddy.state.effects.SideEffectEngine
 import dagger.Binds
 import dagger.Module
@@ -34,6 +36,15 @@ abstract class AppBindingsModule {
      */
     @Binds
     abstract fun bindLocaleBoundaryReporter(impl: LocaleBoundaryNotifier): LocaleBoundaryReporter
+
+    /**
+     * #937: the same inversion for the recognition-health alarm — `:core:pipeline` measures the
+     * UNKNOWN rate and decides, `:app` owns the notification it can't reach.
+     */
+    @Binds
+    abstract fun bindRecognitionHealthReporter(
+        impl: RecognitionHealthNotifier,
+    ): RecognitionHealthReporter
 }
 
 @Module

--- a/app/src/main/java/cloud/trotter/dashbuddy/locale/LocaleBoundaryNotifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/locale/LocaleBoundaryNotifier.kt
@@ -1,12 +1,12 @@
 package cloud.trotter.dashbuddy.locale
 
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.notice.AppNoticeChannel
 import cloud.trotter.dashbuddy.ui.main.MainActivity
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.domain.di.ApplicationScope
@@ -97,19 +97,9 @@ class LocaleBoundaryNotifier @Inject constructor(
     }
 
     private fun postNotice() {
-        // Created lazily: a channel the dasher never needs shouldn't clutter their notification
-        // settings. A dedicated channel rather than a reused one — a channel name IS the user's
-        // mute control, so filing this under "Offer Alerts" or "Odometer Active" would both
-        // mislabel it and let an unrelated mute silence a Pledge-honesty disclosure.
-        notificationManager.createNotificationChannel(
-            NotificationChannel(
-                CHANNEL_ID,
-                context.getString(R.string.locale_notice_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT,
-            ).apply {
-                description = context.getString(R.string.locale_notice_channel_description)
-            },
-        )
+        // The shared "App notices" channel (#937 moved the id + copy into AppNoticeChannel when
+        // the recognition-health notice joined this family — one owner, principle 5).
+        AppNoticeChannel.ensure(context, notificationManager)
 
         val contentIntent = PendingIntent.getActivity(
             context,
@@ -121,7 +111,7 @@ class LocaleBoundaryNotifier @Inject constructor(
         )
 
         val text = context.getString(R.string.locale_notice_text)
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+        val notification = NotificationCompat.Builder(context, AppNoticeChannel.ID)
             .setSmallIcon(R.drawable.bag_red_idle)
             .setContentTitle(context.getString(R.string.locale_notice_title))
             .setContentText(text)
@@ -136,15 +126,8 @@ class LocaleBoundaryNotifier @Inject constructor(
     companion object {
         private const val TAG = "LocaleBoundary"
 
-        /** Own channel — see [postNotice] for why this is not one of the existing three. */
-        const val CHANNEL_ID = "app_notice_channel"
-
-        /**
-         * Fixed id in the small-constant range the bubble (1), offer fallback (2) and odometer
-         * (101) already occupy; `BubbleManager.offerNotificationId` deliberately folds per-offer
-         * ids into the disjoint `[2^30, 2^31)` namespace, so a fixed small id cannot collide.
-         */
-        const val NOTIFICATION_ID = 102
+        /** This notice's id on the shared channel — see [AppNoticeChannel.Ids]. */
+        const val NOTIFICATION_ID = AppNoticeChannel.Ids.LOCALE_BOUNDARY
 
         private const val REQUEST_CODE = 938
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/notice/AppNoticeChannel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/notice/AppNoticeChannel.kt
@@ -1,0 +1,55 @@
+package cloud.trotter.dashbuddy.notice
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import cloud.trotter.dashbuddy.R
+
+/**
+ * The one "App notices" notification channel (#938, extended by #937) — one-off, honest
+ * disclosures about how DashBuddy itself is working on this device.
+ *
+ * A dedicated channel rather than a reused one: a channel name IS the user's mute control, so
+ * filing these under "Offer Alerts" or "Odometer Active" would both mislabel them and let an
+ * unrelated mute silence a disclosure. And ONE channel for the family rather than one per
+ * notice — a settings screen with a channel per diagnostic is noise, and every member has the
+ * same "you'd want to know this" character, so they share a mute.
+ *
+ * The id + copy live here (principle 5) because two notifiers now post on this channel and a
+ * second hand-maintained copy of the id would be a divergence bug waiting to fire.
+ */
+object AppNoticeChannel {
+
+    /** Stable channel id. Do not rename — the user's mute state is keyed on it. */
+    const val ID = "app_notice_channel"
+
+    /**
+     * Create (or refresh) the channel. Cheap and idempotent by platform contract, and called
+     * lazily at post time: a channel the dasher never needs shouldn't clutter their settings.
+     */
+    fun ensure(context: Context, notificationManager: NotificationManager) {
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                ID,
+                context.getString(R.string.app_notice_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description = context.getString(R.string.app_notice_channel_description)
+            },
+        )
+    }
+
+    /**
+     * Notification ids for this channel, in the small-constant range the bubble (1), offer
+     * fallback (2) and odometer (101) already occupy; `BubbleManager.offerNotificationId`
+     * deliberately folds per-offer ids into the disjoint `[2^30, 2^31)` namespace, so fixed
+     * small ids cannot collide.
+     */
+    object Ids {
+        /** #938 — the once-per-install non-English locale notice. */
+        const val LOCALE_BOUNDARY = 102
+
+        /** #937 — recognition has stopped understanding a platform's screens. */
+        const val RECOGNITION_HEALTH = 103
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/notice/RecognitionHealthNotifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/notice/RecognitionHealthNotifier.kt
@@ -1,0 +1,92 @@
+package cloud.trotter.dashbuddy.notice
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.domain.pipeline.RecognitionHealthReporter
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.ui.main.MainActivity
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The dasher-visible half of the #937 recognition-health alarm: when a platform's screens stop
+ * being recognized, say so out loud instead of quietly narrating nothing.
+ *
+ * This is the recognition entry in the #909 silent-death family. The effect engine (#914), the
+ * bubble (#916) and the odometer (#917) each got a liveness signal; recognition had none, so a
+ * platform app update that broke every anchor mid-dash was detectable only at the next desk
+ * pull — and once rules ship OTA (#640) to users who never do a desk pull, never at all.
+ *
+ * **Stateless by design.** The once-per-platform-per-process edge gate lives in
+ * `RecognitionHealthMonitor` (`:core:pipeline`), which owns the window that decides; duplicating
+ * a gate here would be a second source of truth for "have we already said this".
+ *
+ * **Fail-open.** Every path is wrapped: this is called from the sensing hot path, and a
+ * notification the OS refuses (POST_NOTIFICATIONS not granted) must degrade to the monitor's
+ * WARN alone, never to a thrown frame.
+ *
+ * **PII posture:** the only values that reach the notification are a platform's own display
+ * name (resolved from its wire through the `Platform` registry) and a percentage. No screen
+ * text, no customer data, no store names — principle 7's INFO+ contract holds trivially.
+ */
+@Singleton
+class RecognitionHealthNotifier @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val notificationManager: NotificationManager,
+) : RecognitionHealthReporter {
+
+    override fun onRecognitionDegraded(platformWire: String, unknownPercent: Int) {
+        try {
+            postNotice(platformWire, unknownPercent)
+        } catch (t: Throwable) {
+            // Deliberately broad and NOT rethrown (#909): the caller is a sensing frame.
+            Timber.tag(TAG).e(t, "Recognition health notice could not be posted (#937)")
+        }
+    }
+
+    private fun postNotice(platformWire: String, unknownPercent: Int) {
+        AppNoticeChannel.ensure(context, notificationManager)
+
+        // The registry is the only path from a wire to display copy (principle 8). An unknown
+        // wire — a ruleset naming a platform this build doesn't carry — still gets a notice,
+        // with the generic wording rather than a fabricated brand name.
+        val platformName = Platform.fromWire(platformWire)
+            ?.takeIf { it != Platform.Unknown }
+            ?.displayName
+            ?: context.getString(R.string.recognition_health_notice_platform_fallback)
+
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_CODE,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val text = context.getString(
+            R.string.recognition_health_notice_text, platformName, unknownPercent,
+        )
+        val notification = NotificationCompat.Builder(context, AppNoticeChannel.ID)
+            .setSmallIcon(R.drawable.bag_red_idle)
+            .setContentTitle(context.getString(R.string.recognition_health_notice_title, platformName))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setContentIntent(contentIntent)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(AppNoticeChannel.Ids.RECOGNITION_HEALTH, notification)
+    }
+
+    private companion object {
+        const val TAG = "RecognitionHealth"
+        const val REQUEST_CODE = 937
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,8 +99,12 @@
          even though values-es is otherwise incomplete: this notice exists FOR a dasher whose phone
          is not in English, so an untranslated copy would be the one string that fails its own
          audience. -->
-    <string name="locale_notice_channel_name">Avisos de la aplicación</string>
-    <string name="locale_notice_channel_description">Avisos puntuales sobre cómo funciona DashBuddy en este teléfono</string>
+    <string name="app_notice_channel_name">Avisos de la aplicación</string>
+    <string name="app_notice_channel_description">Avisos puntuales sobre cómo funciona DashBuddy en este teléfono</string>
     <string name="locale_notice_title">DashBuddy solo lee pantallas en inglés</string>
     <string name="locale_notice_text">Tu teléfono está configurado en un idioma distinto del inglés. DashBuddy reconoce las pantallas de reparto por su texto en inglés, así que se le escaparán casi todas las ofertas y entregas — y los filtros de privacidad que ocultan los datos del cliente funcionan con ese mismo texto en inglés, por lo que también cubren menos. Cambiar el teléfono a inglés restablece ambas cosas.</string>
+
+    <string name="recognition_health_notice_title">DashBuddy no puede leer %1$s ahora mismo</string>
+    <string name="recognition_health_notice_text">El %2$d%% de las últimas pantallas de %1$s no se reconocieron, lo que suele significar que la aplicación de %1$s se actualizó y cambió de aspecto. Puede que las ofertas, recogidas y entregas no se registren hasta que DashBuddy se actualice.</string>
+    <string name="recognition_health_notice_platform_fallback">esta plataforma</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,10 +493,15 @@
          Deliberately does NOT name a specific language: the string is device-independent, and the
          only device-derived value the feature ever handles is an ISO-639 code (kept out of the
          copy so nothing device-specific rides a user-visible surface). -->
-    <string name="locale_notice_channel_name">App notices</string>
-    <string name="locale_notice_channel_description">One-off notices about how DashBuddy is working on this device</string>
+    <string name="app_notice_channel_name">App notices</string>
+    <string name="app_notice_channel_description">One-off notices about how DashBuddy is working on this device</string>
     <string name="locale_notice_title">DashBuddy reads English screens only</string>
     <string name="locale_notice_text">Your phone is set to a language other than English. DashBuddy recognises delivery screens by their English wording, so it will miss most offers and deliveries — and the privacy filters that hide customer details work by the same English wording, so they cover less too. Switching the phone to English restores both.</string>
+
+    <!-- #937 recognition-health alarm (App notices channel) -->
+    <string name="recognition_health_notice_title">DashBuddy can\'t read %1$s right now</string>
+    <string name="recognition_health_notice_text">%2$d%% of the last few %1$s screens were unrecognised, which usually means the %1$s app updated and moved things around. Offers, pickups and deliveries may not be tracked until DashBuddy is updated to match.</string>
+    <string name="recognition_health_notice_platform_fallback">this platform</string>
 
     <!-- ui/bubble/BubbleManager.kt -->
     <string name="bubble_channel_stream_name">DashBuddy Stream</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -17,6 +17,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 
 class ClickClassifierTest {
 
@@ -25,6 +26,7 @@ class ClickClassifierTest {
             on { clickRuleset } doReturn TestRulesetFactory.clickRuleset
         },
         mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+        PlatformAppVersions.NONE,
     )
 
     // =========================================================================

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationClassifierTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 
 /**
  * Unit tests for notification classification via [ObservationClassifier].
@@ -29,6 +30,7 @@ class NotificationClassifierTest {
             on { notificationRuleset } doReturn TestRulesetFactory.notificationRuleset
         },
         mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+        PlatformAppVersions.NONE,
     )
 
     // =========================================================================

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipelineSensitiveOrderingTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipelineSensitiveOrderingTest.kt
@@ -36,6 +36,7 @@ import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 
 /**
  * #599 adversarial F2 — pins the PIPELINE ORDERING the sensitive block rests
@@ -61,6 +62,7 @@ class NotificationPipelineSensitiveOrderingTest {
             on { isLoaded } doReturn true
         },
         mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+        PlatformAppVersions.NONE,
     )
     private val source = NotificationSource()
     private val pipeline = NotificationPipeline(

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/OfferPipelineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/OfferPipelineTest.kt
@@ -27,6 +27,7 @@ import org.junit.runners.Parameterized
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.io.File
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 
 /**
  * Layer 2 (#105): JSON snapshot → recognition → [OfferEvaluator] → [OfferEvaluation].
@@ -62,6 +63,7 @@ class OfferPipelineTest(private val case: PipelineTestCase) {
             ObservationClassifier(
                 mock<JsonRuleInterpreter> { on { screenRuleset } doReturn TestRulesetFactory.screenRuleset },
                 mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+                PlatformAppVersions.NONE,
             )
         }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/notice/RecognitionHealthNotifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/notice/RecognitionHealthNotifierTest.kt
@@ -1,0 +1,101 @@
+package cloud.trotter.dashbuddy.notice
+
+import android.app.Notification
+import android.app.NotificationManager
+import androidx.core.app.NotificationCompat
+import cloud.trotter.dashbuddy.domain.state.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * The dasher-visible half of #937 — the mirror of `LocaleBoundaryNotifierTest`.
+ *
+ * Robolectric supplies a real `Context` (the notice needs `getString`); the
+ * `NotificationManager` is a mock so the post is directly observable.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RecognitionHealthNotifierTest {
+
+    private lateinit var notificationManager: NotificationManager
+
+    @Before
+    fun setUp() {
+        notificationManager = mock()
+    }
+
+    private fun notifier() = RecognitionHealthNotifier(
+        context = RuntimeEnvironment.getApplication(),
+        notificationManager = notificationManager,
+    )
+
+    private fun postedText(): String {
+        val cap = argumentCaptor<Notification>()
+        verify(notificationManager).notify(any<Int>(), cap.capture())
+        val n = cap.lastValue
+        val title = n.extras.getCharSequence(NotificationCompat.EXTRA_TITLE)?.toString().orEmpty()
+        val body = n.extras.getCharSequence(NotificationCompat.EXTRA_TEXT)?.toString().orEmpty()
+        return "$title\n$body"
+    }
+
+    @Test
+    fun `a degraded platform posts one notice on the shared app-notice channel`() {
+        notifier().onRecognitionDegraded("doordash", 96)
+
+        verify(notificationManager).createNotificationChannel(any())
+        verify(notificationManager).notify(eq(AppNoticeChannel.Ids.RECOGNITION_HEALTH), any<Notification>())
+    }
+
+    @Test
+    fun `the notice names the platform and the rate - and nothing else`() {
+        notifier().onRecognitionDegraded(Platform.DoorDash.wire, 96)
+
+        val text = postedText()
+        assertTrue("expected the platform's display name in $text", text.contains("DoorDash"))
+        assertTrue("expected the percentage in $text", text.contains("96"))
+        // Principle 7 / the Pledges: a liveness notice carries platform facts, never screen text.
+        assertFalse("a wire is not user-facing copy", text.contains("doordash"))
+    }
+
+    @Test
+    fun `an unrecognised wire still notifies, with generic wording`() {
+        notifier().onRecognitionDegraded("some_future_platform", 88)
+
+        val text = postedText()
+        assertTrue("expected the generic fallback in $text", text.contains("this platform"))
+        assertFalse("never fabricate a brand name: $text", text.contains("some_future_platform"))
+    }
+
+    @Test
+    fun `the two app notices do not collide`() {
+        assertEquals(
+            "the locale notice and the recognition notice must not overwrite each other",
+            2,
+            setOf(
+                AppNoticeChannel.Ids.LOCALE_BOUNDARY,
+                AppNoticeChannel.Ids.RECOGNITION_HEALTH,
+            ).size,
+        )
+    }
+
+    @Test
+    fun `a refused post is swallowed - the sensing frame never sees it`() {
+        doThrow(SecurityException("POST_NOTIFICATIONS not granted"))
+            .whenever(notificationManager).notify(any<Int>(), any<Notification>())
+
+        // Must not throw: this runs on the pipeline's own frame path.
+        notifier().onRecognitionDegraded("doordash", 100)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 
 /**
  * #590 fill-in — end-to-end `classify → gate → capture` on adversarial trees.
@@ -73,6 +74,7 @@ class ClassifyGateCaptureFuzzTest {
             on { screenRuleset } doReturn TestRulesetFactory.screenRuleset
         },
         mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+        PlatformAppVersions.NONE,
     )
 
     /** A capture bus that records whether it was offered a write this frame. */

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.json.longOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.io.File
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 
 /**
  * Session-replay harness — drives a *sequence* of real on-device captures through the
@@ -317,6 +318,7 @@ object SessionReplay {
     private fun screenClassifier(): ObservationClassifier = ObservationClassifier(
         mock<JsonRuleInterpreter> { on { screenRuleset } doReturn TestRulesetFactory.screenRuleset },
         mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+        PlatformAppVersions.NONE,
     )
 
     /**
@@ -329,5 +331,6 @@ object SessionReplay {
             on { clickRuleset } doReturn TestRulesetFactory.clickRuleset
         },
         mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+        PlatformAppVersions.NONE,
     )
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline
 
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
@@ -35,7 +36,34 @@ import cloud.trotter.dashbuddy.domain.pipeline.NO_ID_FALLBACK
 class ObservationClassifier @Inject constructor(
     private val interpreter: JsonRuleInterpreter,
     private val metadataProvider: ReplayMetadataProvider,
+    private val appVersions: PlatformAppVersions,
 ) {
+
+    /**
+     * Live replay metadata stamped with the OBSERVED app's `versionName` (#937).
+     *
+     * Classification is the one point that always runs and always knows the frame's package —
+     * the capture stage is skipped wholesale on a disabled bus (release `NoOpCaptureBus`), so
+     * stamping there would leave release builds' log line unstamped. Stamping the observation
+     * carries the value into the envelope for free, since `CaptureWriter` serializes
+     * `obs.metadata`.
+     *
+     * Fail-open: an unresolvable package leaves the base metadata untouched, and a resolver that
+     * breaks its own never-throws contract costs the stamp, not the frame. Classification runs
+     * inside the sensing flow, where an escaping throwable takes the whole upstream down until
+     * supervision resubscribes (#430) — a diagnostic must never be able to buy that (#909).
+     */
+    private fun metadataFor(packageName: String?): ReplayMetadata {
+        val base = metadataProvider.current()
+        val version = try {
+            packageName?.takeIf { it.isNotEmpty() }?.let { appVersions.versionName(it) }
+        } catch (t: Throwable) {
+            Timber.tag("Classifier").w(t, "Platform app version stamp failed — unstamped (#937)")
+            null
+        }
+        return if (version == null) base else base.copy(platformAppVersion = version)
+    }
+
     /**
      * Last classified screen target, keyed by platform wire (#438 item 2). A single
      * global `lastScreenTarget` let an Uber screen gate a DoorDash click rule's
@@ -114,14 +142,18 @@ class ObservationClassifier @Inject constructor(
         if (ruleset == null) {
             // Fail-closed invariant fired (rulesets not loaded) — a real WARN (#551 P7).
             Timber.tag("Classifier").w("no screen ruleset loaded")
-            return makeScreenObservation(now, UNKNOWN_TARGET, null, null, ParsedFields.None, null)
+            return makeScreenObservation(
+                now, metadataFor(event.packageName), UNKNOWN_TARGET, null, null, ParsedFields.None, null,
+            )
         }
 
         val result = ruleset.matchFirst(event.tree, platformWire)
         if (result == null) {
             // #551 P7: per-frame trace → VERBOSE (firehose only), never the shareable INFO stream.
             Timber.tag("Classifier").v("SCREEN: UNKNOWN")
-            return makeScreenObservation(now, UNKNOWN_TARGET, null, null, ParsedFields.None, null)
+            return makeScreenObservation(
+                now, metadataFor(event.packageName), UNKNOWN_TARGET, null, null, ParsedFields.None, null,
+            )
         }
 
         Timber.tag("Classifier").v("SCREEN: ${result.intent}")
@@ -132,6 +164,7 @@ class ObservationClassifier @Inject constructor(
         val parsed = ParsedFieldsFactory.create(result.shape, result.fields)
         val obs = makeScreenObservation(
             now = now,
+            metadata = metadataFor(event.packageName),
             screenName = result.intent,
             flow = result.flow,
             modeHint = result.modeHint,
@@ -156,6 +189,7 @@ class ObservationClassifier @Inject constructor(
 
     private fun makeScreenObservation(
         now: Long,
+        metadata: ReplayMetadata,
         screenName: String,
         flow: Flow?,
         modeHint: Mode?,
@@ -168,7 +202,7 @@ class ObservationClassifier @Inject constructor(
         timestamp = now,
         captureId = null,
         ruleId = ruleId,
-        metadata = metadataProvider.current(),
+        metadata = metadata,
         flow = flow,
         modeHint = modeHint,
         parsed = parsed,
@@ -197,7 +231,7 @@ class ObservationClassifier @Inject constructor(
                     timestamp = now,
                     captureId = null,
                     ruleId = result.ruleId,
-                    metadata = metadataProvider.current(),
+                    metadata = metadataFor(event.packageName),
                     flow = result.flow,
                     modeHint = result.modeHint,
                     parsed = parsed,
@@ -219,7 +253,7 @@ class ObservationClassifier @Inject constructor(
             timestamp = now,
             captureId = null,
             ruleId = null,
-            metadata = metadataProvider.current(),
+            metadata = metadataFor(event.packageName),
             flow = null,
             modeHint = null,
             parsed = ParsedFields.ClickFields(
@@ -247,7 +281,7 @@ class ObservationClassifier @Inject constructor(
                     timestamp = event.raw.postTime,
                     captureId = null,
                     ruleId = result.ruleId,
-                    metadata = metadataProvider.current(),
+                    metadata = metadataFor(event.raw.packageName),
                     flow = result.flow,
                     modeHint = result.modeHint,
                     parsed = parsed,
@@ -265,7 +299,7 @@ class ObservationClassifier @Inject constructor(
             timestamp = event.raw.postTime,
             captureId = null,
             ruleId = null,
-            metadata = metadataProvider.current(),
+            metadata = metadataFor(event.raw.packageName),
             flow = null,
             modeHint = null,
             parsed = ParsedFields.NotificationFields(

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.pipeline
 
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +40,14 @@ class PipelineStats @Inject constructor() {
     private val notifRedactBackstopScrubs = AtomicLong()
     private val notifListenerConnects = AtomicLong()
     private val notifListenerDisconnects = AtomicLong()
+
+    /**
+     * `packageName → versionName` for every observed third-party app whose version resolved
+     * this process (#937). A render-only record for [summary] — the resolution + its cache are
+     * owned by [CachingPlatformAppVersions], which is the SSOT; this map only remembers what
+     * that resolver already answered, so the two cannot disagree.
+     */
+    private val platformAppVersions = ConcurrentHashMap<String, String>()
 
     val droppedSensitiveCount: Long get() = droppedSensitive.get()
     val droppedNoiseCount: Long get() = droppedNoise.get()
@@ -116,6 +125,17 @@ class PipelineStats @Inject constructor() {
         notifRedactBackstopScrubs.incrementAndGet()
     }
 
+    /**
+     * An observed third-party app's `versionName` resolved for the first time this process
+     * (#937). Recorded so the periodic summary — the INFO line a user can export as a bug
+     * report — says WHICH build of the platform app produced the frames it is describing.
+     *
+     * Principle 7: a package name + a version string are platform-app facts, not user data.
+     */
+    fun onPlatformAppVersion(packageName: String, versionName: String) {
+        platformAppVersions[packageName] = versionName
+    }
+
     /** The supervised upstream crashed and is resubscribing. Returns the restart ordinal. */
     fun onPipelineRestart(): Long = restarts.incrementAndGet()
 
@@ -152,7 +172,16 @@ class PipelineStats @Inject constructor() {
             " notifRedactBackstopScrubs=${notifRedactBackstopScrubs.get()}" +
             " notifListenerConnects=${notifListenerConnects.get()}" +
             " notifListenerDisconnects=${notifListenerDisconnects.get()}" +
-            " restarts=${restarts.get()}"
+            " restarts=${restarts.get()}" +
+            platformAppVersionsSuffix()
+
+    /** `" platformApps=com.doordash.driverapp@15.2.3,com.ubercab.driver@4.5"`, or empty. */
+    private fun platformAppVersionsSuffix(): String =
+        platformAppVersions.entries
+            .sortedBy { it.key }
+            .joinToString(separator = ",", prefix = " platformApps=") { "${it.key}@${it.value}" }
+            .takeIf { platformAppVersions.isNotEmpty() }
+            ?: ""
 
     companion object {
         /** Forwarded-observation interval between periodic summary log lines. */

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PlatformAppVersions.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PlatformAppVersions.kt
@@ -1,0 +1,90 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Resolves the `versionName` of an OBSERVED third-party app (#937).
+ *
+ * Recognition anchors break when a platform ships an app update, and until #937 nothing on
+ * the device recorded which version produced a given frame — so a desk pull could see the
+ * breakage but never correlate it with the release that caused it. Every classified
+ * observation now carries the stamp in its `ReplayMetadata`.
+ */
+fun interface PlatformAppVersions {
+
+    /** The package's `versionName`, or null when it can't be resolved. Never throws. */
+    fun versionName(packageName: String): String?
+
+    companion object {
+        /** The no-op resolver — nothing is ever stamped. For tests that don't exercise #937. */
+        val NONE = PlatformAppVersions { null }
+    }
+}
+
+/**
+ * The production [PlatformAppVersions]: one lookup per package per process, cached.
+ *
+ * **Caching decision (#937):** the cache is never invalidated on a package update. An app
+ * update kills the updated app's process and the accessibility service is re-bound, and in
+ * practice DashBuddy's own process is restarted alongside it; the residual — one stale stamp
+ * on the frames between an in-place update and the next process start — is strictly smaller
+ * than the cost of listening for `PACKAGE_REPLACED` broadcasts on the sensing hot path. The
+ * stamp is a diagnostic, not an input to any decision, so a stale value is a nuisance, never
+ * a correctness problem.
+ *
+ * **Negative results are cached too.** A package that doesn't resolve (uninstalled, an OEM
+ * overlay, a `NameNotFoundException`) would otherwise pay a binder round-trip on EVERY frame.
+ *
+ * **Fail-open by construction** (#909's lesson): the lookup is wrapped in `catch (Throwable)`
+ * with only `CancellationException` rethrown — a diagnostic must never be able to kill a
+ * frame, and a `PackageManager` call crosses a process boundary.
+ *
+ * @param lookup the raw resolution (the `PackageManager` call at the DI edge). Injected as a
+ *   lambda so the caching/fail-open logic above is unit-testable without Robolectric.
+ * @param stats records each FIRST resolution for the periodic summary line. The cache here is
+ *   the SSOT of resolution; [PipelineStats] holds only a render-only copy for the log line.
+ */
+class CachingPlatformAppVersions(
+    private val lookup: (String) -> String?,
+    private val stats: PipelineStats,
+) : PlatformAppVersions {
+
+    /** `packageName → versionName`, with [ABSENT] standing in for "resolved to nothing". */
+    private val cache = ConcurrentHashMap<String, String>()
+
+    override fun versionName(packageName: String): String? {
+        if (packageName.isEmpty()) return null
+        cache[packageName]?.let { return it.takeIf { v -> v != ABSENT } }
+
+        val resolved = try {
+            lookup(packageName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Timber.tag(TAG).w(t, "versionName lookup failed for a package — leaving it unstamped (#937)")
+            null
+        }
+
+        // Bounded: the observed-package set is small (the enabled platforms plus whatever the
+        // dasher's screen shows), but this is fed from untrusted frame data, so cap it rather
+        // than trust that. Past the cap we still ANSWER, we just stop remembering — correctness
+        // is unchanged, only the binder traffic.
+        if (cache.size < MAX_CACHED_PACKAGES) {
+            cache[packageName] = resolved ?: ABSENT
+            if (resolved != null) stats.onPlatformAppVersion(packageName, resolved)
+        }
+        return resolved
+    }
+
+    companion object {
+        private const val TAG = "Pipeline"
+
+        /** Sentinel for a negative lookup — `ConcurrentHashMap` cannot hold a null value. */
+        private const val ABSENT = ""
+
+        /** Cache cap; see [versionName] for why exceeding it is not an error. */
+        const val MAX_CACHED_PACKAGES = 64
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealth.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealth.kt
@@ -1,0 +1,93 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+/**
+ * The pure half of the #937 recognition-health alarm: a rolling per-platform
+ * recognized-vs-UNKNOWN ratio over the frames the pipeline actually admitted.
+ *
+ * No Android, no logging, no notification — [record] just returns the trip edge, so the whole
+ * decision is unit-testable and the side effects live in [RecognitionHealthMonitor].
+ *
+ * **Why a window and not a lifetime ratio.** A lifetime counter dilutes: after two healthy
+ * hours a total recognition break barely moves the average, which is precisely the moment the
+ * dasher needs to hear about it. A rolling window forgets the healthy past.
+ *
+ * **Where the samples come from.** The caller feeds frames that survived `FrameGate`
+ * (post-dedup), not raw frames. Both classes are deduped there — recognized screens by
+ * identity, UNKNOWN frames by content hash — so a dasher parked on one unruled screen
+ * contributes a couple of samples rather than a thousand, and the measured baseline is the
+ * one the field logs report.
+ *
+ * **Tuning (all three consts are deliberate and field-derived).** The 2026-07-28/29 pulls put
+ * a HEALTHY dash at roughly 16 % UNKNOWN on the admitted stream (`forwarded=450
+ * unknownDropped=86` and `forwarded=500 unknownDropped=87` in consecutive `PipelineStats`
+ * lines). [UNKNOWN_RATIO_THRESHOLD] sits at 0.80 — five times that baseline — because a real
+ * anchor break drives the ratio toward 1.0, so the alarm can afford to be far from the noise
+ * rather than sensitive to it. [WINDOW_SIZE] of 50 admitted frames is a few minutes of dashing
+ * at those rates, and the window must be FULL before it is evaluated, so a handful of unruled
+ * launch screens can never trip it.
+ *
+ * Not thread-safe on its own; [RecognitionHealthMonitor] owns the lock.
+ */
+class RecognitionHealth(
+    private val windowSize: Int = WINDOW_SIZE,
+    private val threshold: Double = UNKNOWN_RATIO_THRESHOLD,
+) {
+
+    /** One trip, reported once. */
+    data class Alarm(val platformWire: String, val unknownPercent: Int)
+
+    private val windows = HashMap<String, Window>()
+
+    /** Platforms already alarmed — the once-per-process edge gate. */
+    private val alarmed = HashSet<String>()
+
+    /**
+     * Record one admitted frame for [platformWire].
+     *
+     * @return the [Alarm] on the frame that crosses the threshold, null otherwise (including
+     *   every frame after the first trip: a platform alarms at most once per process).
+     */
+    fun record(platformWire: String, unknown: Boolean): Alarm? {
+        if (platformWire in alarmed) return null
+
+        val window = windows.getOrPut(platformWire) { Window(windowSize) }
+        window.add(unknown)
+        if (!window.isFull) return null
+
+        val ratio = window.unknownRatio
+        if (ratio < threshold) return null
+
+        alarmed += platformWire
+        return Alarm(platformWire, (ratio * 100).toInt())
+    }
+
+    /** True once [platformWire] has alarmed — recovery deliberately does NOT re-arm it. */
+    fun hasAlarmed(platformWire: String): Boolean = platformWire in alarmed
+
+    /** A fixed-capacity ring of "was this frame UNKNOWN", with a running count. */
+    private class Window(private val capacity: Int) {
+        private val samples = BooleanArray(capacity)
+        private var next = 0
+        private var size = 0
+        private var unknowns = 0
+
+        val isFull: Boolean get() = size == capacity
+        val unknownRatio: Double get() = if (size == 0) 0.0 else unknowns.toDouble() / size
+
+        fun add(unknown: Boolean) {
+            if (isFull && samples[next]) unknowns--
+            samples[next] = unknown
+            if (unknown) unknowns++
+            next = (next + 1) % capacity
+            if (size < capacity) size++
+        }
+    }
+
+    companion object {
+        /** Admitted frames per platform in the rolling window; evaluated only when full. */
+        const val WINDOW_SIZE = 50
+
+        /** Share of the window that must classify UNKNOWN to trip. See the class KDoc. */
+        const val UNKNOWN_RATIO_THRESHOLD = 0.80
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealth.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealth.kt
@@ -15,7 +15,10 @@ package cloud.trotter.dashbuddy.core.pipeline
  * (post-dedup), not raw frames. Both classes are deduped there — recognized screens by
  * identity, UNKNOWN frames by content hash — so a dasher parked on one unruled screen
  * contributes a couple of samples rather than a thousand, and the measured baseline is the
- * one the field logs report.
+ * one the field logs report. The same dedup is also this alarm's known limit: it needs a
+ * window's worth of DISTINCT frames, so it detects a broken-but-LIVE app (the platform-update
+ * case it exists for — offers, timers and maps keep the content changing) rather than a wedged
+ * one, which is the bubble/odometer liveness signals' territory (#916/#917).
  *
  * **Tuning (all three consts are deliberate and field-derived).** The 2026-07-28/29 pulls put
  * a HEALTHY dash at roughly 16 % UNKNOWN on the admitted stream (`forwarded=450

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealthMonitor.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealthMonitor.kt
@@ -1,0 +1,75 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.pipeline.RecognitionHealthReporter
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The side-effecting half of the #937 recognition-health alarm: one WARN plus one
+ * dasher-visible notice the first time a platform's recognition collapses in this process.
+ *
+ * The decision is pure and lives in [RecognitionHealth]; this class owns only the edges — the
+ * package→platform resolution, the lock, the log line and the reporter call.
+ *
+ * **Fail-open, absolutely.** This is called from inside the sensing flow, one call per admitted
+ * frame. Every path is wrapped in `catch (Throwable)` (only `CancellationException` rethrown —
+ * the #909 rule), because a health diagnostic that can kill the pipeline would be the very
+ * failure it exists to detect.
+ *
+ * **Scope of "once".** The edge gate is per platform per PROCESS. Per-*dash* would be the
+ * ideal grain, but dash lifecycle lives in `:core:state`, which depends on `:core:pipeline` and
+ * not the reverse — reaching for it would invert the module graph for a diagnostic. A process
+ * restart re-arms the alarm, which is the right bias: recognition breakage is per-dash news,
+ * not a once-per-install disclosure like #938's locale notice.
+ *
+ * **Platform-agnostic (principle 8).** Frames are keyed by `Platform.wire` via the registry;
+ * there is no platform literal here and nothing is tuned to whichever platform we field-test
+ * most. A frame whose package resolves to `Unknown` is ignored — an unattributable frame has no
+ * recognition contract to be measured against.
+ */
+@Singleton
+class RecognitionHealthMonitor @Inject constructor(
+    private val reporter: RecognitionHealthReporter,
+) {
+
+    private val lock = Any()
+    private val health = RecognitionHealth()
+
+    /**
+     * Record one frame that survived `FrameGate` admission.
+     *
+     * @param packageName the window's real package (the frame's own attribution).
+     * @param unknown true when the frame classified UNKNOWN.
+     */
+    fun onScreenAdmitted(packageName: String?, unknown: Boolean) {
+        try {
+            val platform = Platform.fromPackage(packageName)
+            if (platform == Platform.Unknown) return
+
+            val alarm = synchronized(lock) { health.record(platform.wire, unknown) } ?: return
+
+            // WARN, not ERROR: a defended invariant fired and the app is degraded, but nothing
+            // is lost or crashed (principle 7). PII-free by construction — a platform wire and
+            // a percentage, no screen text.
+            Timber.tag(TAG).w(
+                "Recognition health: %d%% of the last %d %s frames classified UNKNOWN — " +
+                    "anchors may be broken by a platform app update (#937)",
+                alarm.unknownPercent,
+                RecognitionHealth.WINDOW_SIZE,
+                alarm.platformWire,
+            )
+            reporter.onRecognitionDegraded(alarm.platformWire, alarm.unknownPercent)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Timber.tag(TAG).e(t, "Recognition health check failed — sensing unaffected (#937)")
+        }
+    }
+
+    private companion object {
+        const val TAG = "RecognitionHealth"
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.core.pipeline.passesContentGates
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
 import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
 import cloud.trotter.dashbuddy.core.pipeline.PipelineStats
+import cloud.trotter.dashbuddy.core.pipeline.RecognitionHealthMonitor
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.content_changed.ContentChangedPipeline
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.state_changed.StateChangedPipeline
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.windows_changed.WindowsChangedPipeline
@@ -47,6 +48,7 @@ class AccessibilityPipeline @Inject constructor(
     private val captureWriter: CaptureWriter,
     private val platformPreferences: PlatformPreferences,
     private val stats: PipelineStats,
+    private val recognitionHealth: RecognitionHealthMonitor,
 ) {
     companion object {
         const val SCREEN_PIPELINE_ID = "accessibility.window"
@@ -149,6 +151,15 @@ class AccessibilityPipeline @Inject constructor(
                 stats.onDuplicateSuppressed()
                 Timber.v("Dedup: suppressed %s", obs.target)
                 return@mapNotNull null
+            }
+            // #937 recognition-health sample, taken HERE — post-admission, pre-capture — so the
+            // ratio is measured on the same deduped stream the field logs report (a dasher
+            // parked on one unruled screen contributes a couple of samples, not a thousand).
+            // Screens only: a click/notification carries no recognition-coverage signal about
+            // the screen surface, and mixing them would dilute the denominator. Fail-open: the
+            // monitor swallows everything, so a broken alarm can never cost a frame.
+            if (event is PipelineEvent.Screen) {
+                recognitionHealth.onScreenAdmitted(event.packageName, obs.target == UNKNOWN_TARGET)
             }
             // Capture via the shared writer; smart-casts replace the old
             // unchecked downcasts (#361).

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/di/PipelineModule.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/di/PipelineModule.kt
@@ -1,12 +1,18 @@
 package cloud.trotter.dashbuddy.core.pipeline.di
 
+import android.content.Context
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
+import cloud.trotter.dashbuddy.core.pipeline.CachingPlatformAppVersions
+import cloud.trotter.dashbuddy.core.pipeline.PipelineStats
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 import cloud.trotter.dashbuddy.core.pipeline.ReplayMetadataProviderImpl
 import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -24,4 +30,27 @@ abstract class PipelineModule {
     // that owns the loaded rulesets.
     @Binds @Singleton
     abstract fun bindScreenRedactionSource(impl: JsonRuleInterpreter): ScreenRedactionSource
+
+    companion object {
+
+        /**
+         * #937: the observed platform app's `versionName`.
+         *
+         * The `PackageManager` call is supplied as a lambda so the caching + fail-open logic in
+         * [CachingPlatformAppVersions] stays a plain unit test — Android lives only at this DI
+         * edge. `getPackageInfo` throws `NameNotFoundException` for an unknown package, which
+         * the resolver treats as "unresolvable" and caches negatively.
+         */
+        @Provides @Singleton
+        fun providePlatformAppVersions(
+            @ApplicationContext context: Context,
+            stats: PipelineStats,
+        ): PlatformAppVersions = CachingPlatformAppVersions(
+            lookup = { pkg ->
+                @Suppress("DEPRECATION") // getPackageInfo(String, Int) — the flags overload is API 33+
+                context.packageManager.getPackageInfo(pkg, 0).versionName
+            },
+            stats = stats,
+        )
+    }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PlatformAppVersionStampTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PlatformAppVersionStampTest.kt
@@ -1,0 +1,132 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
+import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * #937 — the observed platform app's `versionName` reaches the capture envelope.
+ *
+ * Two halves: the classifier stamps every observation it produces (the one point that always
+ * runs, even when the release `NoOpCaptureBus` skips capture entirely), and the envelope
+ * serializes it — while an unstamped envelope stays byte-identical to a pre-#937 one, which is
+ * what keeps the committed corpus and the parse golden untouched.
+ */
+class PlatformAppVersionStampTest {
+
+    private val doordash = "com.doordash.driverapp"
+
+    private val metadataProvider = mock<ReplayMetadataProvider> {
+        on { current() } doReturn ReplayMetadata(engineVersion = 7)
+    }
+
+    private fun classifier(versions: PlatformAppVersions) =
+        ObservationClassifier(mock<JsonRuleInterpreter>(), metadataProvider, versions)
+
+    private fun screenEvent(pkg: String? = doordash) = PipelineEvent.Screen(
+        timestamp = 1_000L,
+        tree = UiNode(text = "anything"),
+        snapshot = TreeSnapshot(tree = UiNode(text = "anything"), packageName = pkg),
+        packageName = pkg,
+    )
+
+    // ── The classifier stamps ───────────────────────────────────────────
+
+    @Test
+    fun `a classified screen carries the observed app version`() {
+        val obs = classifier(PlatformAppVersions { "15.2.3" }).classify(screenEvent())
+
+        assertEquals("15.2.3", obs.metadata.platformAppVersion)
+        assertEquals("the base metadata is untouched", 7, obs.metadata.engineVersion)
+    }
+
+    @Test
+    fun `an unresolvable package leaves the observation unstamped`() {
+        val obs = classifier(PlatformAppVersions { null }).classify(screenEvent())
+
+        assertNull(obs.metadata.platformAppVersion)
+    }
+
+    @Test
+    fun `a frame with no package is never stamped`() {
+        val obs = classifier(PlatformAppVersions { "15.2.3" }).classify(screenEvent(pkg = null))
+
+        assertNull(obs.metadata.platformAppVersion)
+    }
+
+    @Test
+    fun `a resolver that breaks its never-throws contract costs the stamp, not the frame`() {
+        val obs = classifier(
+            PlatformAppVersions { throw IllegalStateException("PackageManager is unhappy") },
+        ).classify(screenEvent())
+
+        // The frame still classified — an escaping throwable here would take the whole
+        // sensing upstream down until supervision resubscribed (#430/#909).
+        assertNull(obs.metadata.platformAppVersion)
+    }
+
+    // ── The envelope serializes it ──────────────────────────────────────
+
+    private val captureBus: CaptureBus = mock { on { isEnabled } doReturn true }
+
+    private val noRedaction = object : ScreenRedactionSource {
+        override fun redactFor(ruleId: String): CompiledRedact? = null
+    }
+
+    private fun capture(metadata: ReplayMetadata): String {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val bus = captureBus
+        CaptureWriter(bus, PipelineStats(), noRedaction).captureScreen(
+            Observation.Screen(
+                timestamp = 1_000L,
+                captureId = null,
+                ruleId = "doordash.screen.offer",
+                metadata = metadata,
+                flow = null,
+                modeHint = null,
+                parsed = ParsedFields.None,
+                target = "offer",
+            ),
+            screenEvent(),
+        )
+        val cap = argumentCaptor<String>()
+        org.mockito.kotlin.verify(bus).offer(any(), any(), anyOrNull(), any(), cap.capture(), anyOrNull())
+        return cap.lastValue
+    }
+
+    @Test
+    fun `the envelope carries the version when the observation was stamped`() {
+        val json = capture(ReplayMetadata(engineVersion = 7, platformAppVersion = "15.2.3"))
+
+        assertTrue("expected the stamp in $json", json.contains("\"platformAppVersion\": \"15.2.3\""))
+    }
+
+    @Test
+    fun `an unstamped envelope omits the key entirely - the corpus stays pre-937 shaped`() {
+        val json = capture(ReplayMetadata(engineVersion = 7))
+
+        assertFalse(
+            "a null stamp must not even emit the key — committed fixtures carry none",
+            json.contains("platformAppVersion"),
+        )
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PlatformAppVersionsTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PlatformAppVersionsTest.kt
@@ -1,0 +1,91 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #937 — the caching/fail-open half of the observed-app version stamp. The `PackageManager`
+ * call itself is injected as a lambda, so everything that could actually misbehave in the
+ * field (a binder failure, a package that isn't there, per-frame lookup cost) is testable here
+ * with no Android at all.
+ */
+class PlatformAppVersionsTest {
+
+    private val doordash = "com.doordash.driverapp"
+
+    @Test
+    fun `a resolved version is returned and looked up only once`() {
+        var lookups = 0
+        val stats = PipelineStats()
+        val versions = CachingPlatformAppVersions({ lookups++; "15.2.3" }, stats)
+
+        repeat(100) { assertEquals("15.2.3", versions.versionName(doordash)) }
+
+        assertEquals("one binder round-trip per package per process", 1, lookups)
+    }
+
+    @Test
+    fun `an unresolvable package is cached negatively - no per-frame lookup storm`() {
+        var lookups = 0
+        val versions = CachingPlatformAppVersions({ lookups++; null }, PipelineStats())
+
+        repeat(100) { assertNull(versions.versionName("com.not.installed")) }
+
+        assertEquals(1, lookups)
+    }
+
+    @Test
+    fun `a throwing lookup fails open and is not retried per frame`() {
+        var lookups = 0
+        val versions = CachingPlatformAppVersions(
+            { lookups++; throw IllegalStateException("DeadObjectException") },
+            PipelineStats(),
+        )
+
+        repeat(50) { assertNull(versions.versionName(doordash)) }
+
+        assertEquals(1, lookups)
+    }
+
+    @Test
+    fun `a resolved version is recorded for the periodic summary line`() {
+        val stats = PipelineStats()
+        val versions = CachingPlatformAppVersions({ "15.2.3" }, stats)
+
+        versions.versionName(doordash)
+
+        val summary = stats.summary()
+        assertTrue("expected the version in $summary", summary.contains("platformApps=$doordash@15.2.3"))
+    }
+
+    @Test
+    fun `an unstamped process leaves the summary line unchanged`() {
+        assertTrue(
+            "no observed versions must add nothing to the summary",
+            !PipelineStats().summary().contains("platformApps"),
+        )
+    }
+
+    @Test
+    fun `the cache is bounded but still answers past the cap`() {
+        var lookups = 0
+        val versions = CachingPlatformAppVersions({ pkg -> lookups++; "v-$pkg" }, PipelineStats())
+
+        repeat(CachingPlatformAppVersions.MAX_CACHED_PACKAGES + 5) {
+            assertEquals("v-pkg$it", versions.versionName("pkg$it"))
+        }
+        // Past the cap the answer is still correct; only the memoisation stops.
+        assertEquals("v-pkg0", versions.versionName("pkg0"))
+
+        assertEquals(CachingPlatformAppVersions.MAX_CACHED_PACKAGES + 5, lookups)
+    }
+
+    @Test
+    fun `an empty package is never looked up`() {
+        val versions = CachingPlatformAppVersions({ error("must not be called") }, PipelineStats())
+
+        assertNull(versions.versionName(""))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealthMonitorTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealthMonitorTest.kt
@@ -1,0 +1,86 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.pipeline.RecognitionHealthReporter
+import cloud.trotter.dashbuddy.domain.state.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #937 — the side-effecting edge of the recognition-health alarm.
+ *
+ * The pure decision has its own test ([RecognitionHealthTest]); this one covers what the
+ * monitor adds: package→platform resolution through the registry, one report per platform per
+ * process, and — the property that actually matters on a dash — fail-open. This runs once per
+ * admitted frame, so a broken reporter must cost a log line, never a frame.
+ */
+class RecognitionHealthMonitorTest {
+
+    private class Recorder : RecognitionHealthReporter {
+        val calls = mutableListOf<Pair<String, Int>>()
+        override fun onRecognitionDegraded(platformWire: String, unknownPercent: Int) {
+            calls += platformWire to unknownPercent
+        }
+    }
+
+    private val doordash = requireNotNull(Platform.DoorDash.packageName)
+    private val uber = requireNotNull(Platform.Uber.packageName)
+
+    private fun RecognitionHealthMonitor.feed(pkg: String?, unknown: Boolean, times: Int) {
+        repeat(times) { onScreenAdmitted(pkg, unknown) }
+    }
+
+    @Test
+    fun `a collapsed platform is reported once, by wire, with its percentage`() {
+        val reporter = Recorder()
+        val monitor = RecognitionHealthMonitor(reporter)
+
+        monitor.feed(doordash, unknown = true, times = RecognitionHealth.WINDOW_SIZE * 3)
+
+        assertEquals(listOf("doordash" to 100), reporter.calls)
+    }
+
+    @Test
+    fun `a healthy platform is never reported`() {
+        val reporter = Recorder()
+        val monitor = RecognitionHealthMonitor(reporter)
+
+        repeat(RecognitionHealth.WINDOW_SIZE * 4) { i ->
+            monitor.onScreenAdmitted(doordash, unknown = i % 6 == 0)
+        }
+
+        assertTrue(reporter.calls.isEmpty())
+    }
+
+    @Test
+    fun `an unattributable frame is ignored - no platform, no recognition contract`() {
+        val reporter = Recorder()
+        val monitor = RecognitionHealthMonitor(reporter)
+
+        monitor.feed("com.android.settings", unknown = true, times = RecognitionHealth.WINDOW_SIZE * 2)
+        monitor.feed(null, unknown = true, times = RecognitionHealth.WINDOW_SIZE * 2)
+
+        assertTrue("an unknown package must never alarm", reporter.calls.isEmpty())
+    }
+
+    @Test
+    fun `each platform reports for itself`() {
+        val reporter = Recorder()
+        val monitor = RecognitionHealthMonitor(reporter)
+
+        monitor.feed(doordash, unknown = true, times = RecognitionHealth.WINDOW_SIZE)
+        monitor.feed(uber, unknown = true, times = RecognitionHealth.WINDOW_SIZE)
+
+        assertEquals(listOf("doordash" to 100, "uber" to 100), reporter.calls)
+    }
+
+    @Test
+    fun `a throwing reporter never reaches the sensing frame`() {
+        val monitor = RecognitionHealthMonitor { _, _ ->
+            throw SecurityException("POST_NOTIFICATIONS not granted")
+        }
+
+        // Must not throw — this is called from inside the pipeline flow.
+        monitor.feed(doordash, unknown = true, times = RecognitionHealth.WINDOW_SIZE * 2)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealthTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/RecognitionHealthTest.kt
@@ -1,0 +1,110 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #937 — the pure windowed recognition-health decision.
+ *
+ * The properties that matter in the field: a partial window never fires, a healthy dash never
+ * fires (the 2026-07-28/29 pulls sit near 16 % UNKNOWN on the admitted stream), a collapse
+ * fires exactly once, platforms are independent, and the window forgets — a platform that was
+ * healthy an hour ago must still be able to alarm now.
+ */
+class RecognitionHealthTest {
+
+    private val size = RecognitionHealth.WINDOW_SIZE
+
+    private fun RecognitionHealth.feed(wire: String, unknown: Boolean, times: Int): RecognitionHealth.Alarm? {
+        var alarm: RecognitionHealth.Alarm? = null
+        repeat(times) { alarm = record(wire, unknown) ?: alarm }
+        return alarm
+    }
+
+    @Test
+    fun `a partial window never alarms, however bad it looks`() {
+        val health = RecognitionHealth()
+
+        assertNull(health.feed("doordash", unknown = true, times = size - 1))
+        assertFalse(health.hasAlarmed("doordash"))
+    }
+
+    @Test
+    fun `a full window of UNKNOWN alarms on the frame that fills it`() {
+        val health = RecognitionHealth()
+
+        health.feed("doordash", unknown = true, times = size - 1)
+        val alarm = health.record("doordash", unknown = true)
+
+        assertNotNull("the window-filling frame must trip", alarm)
+        assertEquals("doordash", alarm!!.platformWire)
+        assertEquals(100, alarm.unknownPercent)
+    }
+
+    @Test
+    fun `a healthy dash never alarms`() {
+        val health = RecognitionHealth()
+
+        // ~16 % UNKNOWN — the measured field baseline — over four full windows.
+        repeat(size * 4) { i ->
+            assertNull(health.record("doordash", unknown = i % 6 == 0))
+        }
+    }
+
+    @Test
+    fun `a ratio just under the threshold does not alarm`() {
+        val health = RecognitionHealth(windowSize = 10, threshold = 0.80)
+
+        repeat(7) { assertNull(health.record("doordash", unknown = true)) }
+        repeat(3) { assertNull(health.record("doordash", unknown = false)) }
+    }
+
+    @Test
+    fun `a ratio at the threshold alarms`() {
+        val health = RecognitionHealth(windowSize = 10, threshold = 0.80)
+
+        repeat(8) { health.record("doordash", unknown = true) }
+        val alarm = health.record("doordash", unknown = false) ?: health.record("doordash", unknown = false)
+
+        assertEquals(80, alarm!!.unknownPercent)
+    }
+
+    @Test
+    fun `a platform alarms at most once - recovery deliberately does not re-arm`() {
+        val health = RecognitionHealth()
+
+        assertNotNull(health.feed("doordash", unknown = true, times = size))
+        // Recover completely, then break again.
+        assertNull(health.feed("doordash", unknown = false, times = size))
+        assertNull(health.feed("doordash", unknown = true, times = size * 2))
+    }
+
+    @Test
+    fun `platforms are independent - one breaking never implicates the other`() {
+        val health = RecognitionHealth()
+
+        // Interleaved, as two concurrent platforms would actually arrive.
+        repeat(size) {
+            health.record("doordash", unknown = true)
+            health.record("uber", unknown = false)
+        }
+
+        assertTrue(health.hasAlarmed("doordash"))
+        assertFalse("a healthy uber must not inherit doordash's alarm", health.hasAlarmed("uber"))
+    }
+
+    @Test
+    fun `the window forgets - a long healthy stretch does not immunise a later collapse`() {
+        val health = RecognitionHealth()
+
+        repeat(size * 10) { health.record("doordash", unknown = false) }
+        assertFalse(health.hasAlarmed("doordash"))
+
+        // A lifetime ratio would still read ~9 % here; the rolling window reads 100 %.
+        assertNotNull(health.feed("doordash", unknown = true, times = size))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/UnknownClickTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/UnknownClickTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.doReturn
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.kotlin.mock
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 
 /**
  * Regression tests for [ObservationClassifier] -> [Observation.Click] with intent "unknown".
@@ -25,6 +26,7 @@ class UnknownClickTest {
     private val classifier = ObservationClassifier(
         mock<JsonRuleInterpreter>(),
         mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+        PlatformAppVersions.NONE,
     )
 
     private fun node(viewId: String? = null, text: String? = null) =

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/UnknownNotificationClassifierTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/UnknownNotificationClassifierTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import cloud.trotter.dashbuddy.core.pipeline.PlatformAppVersions
 
 /**
  * Regression tests for [ObservationClassifier] producing `unknown` notification intent.
@@ -26,6 +27,7 @@ class UnknownNotificationClassifierTest {
     private val classifier = ObservationClassifier(
         mock<JsonRuleInterpreter>(),
         mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+        PlatformAppVersions.NONE,
     )
 
     private fun raw(title: String? = null, text: String? = null, bigText: String? = null) =

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/EnvelopeBuilder.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/EnvelopeBuilder.kt
@@ -52,6 +52,7 @@ object EnvelopeBuilder {
             stateMachineApiVersion = meta?.stateMachineApiVersion,
             appVersion = meta?.appVersion,
             deviceFingerprint = meta?.deviceFingerprint,
+            platformAppVersion = meta?.platformAppVersion,
         )
 
         val envelope = CaptureEnvelopeDto(
@@ -105,6 +106,13 @@ internal data class ReplayMetadataDto(
     val stateMachineApiVersion: String? = null,
     val appVersion: String? = null,
     val deviceFingerprint: String? = null,
+    /**
+     * #937 — the observed third-party app's `versionName`. Additive and nullable:
+     * `Json` here has `encodeDefaults = false`, so an envelope built without one omits
+     * the key entirely and stays byte-identical to a pre-#937 envelope (the committed
+     * snapshot corpus never carries it, and no test may require it).
+     */
+    val platformAppVersion: String? = null,
 )
 
 @Serializable

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/ReplayMetadata.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/ReplayMetadata.kt
@@ -19,6 +19,21 @@ data class ReplayMetadata(
     val stateMachineApiVersion: String? = null,
     val appVersion: String? = null,
     val deviceFingerprint: String? = null,
+    /**
+     * The `versionName` of the OBSERVED third-party app — the package this frame came
+     * from — at the moment it was classified (#937). Recognition anchors break when the
+     * platform ships an update, and without this stamp a desk pull can see the breakage
+     * but not correlate it with the release that caused it.
+     *
+     * Null whenever the package could not be resolved (no package on the frame, an
+     * uninstalled/unknown package, a PackageManager failure): the stamp is a diagnostic
+     * and fails OPEN. `Json.encodeDefaults` is false, so a null keeps the serialized
+     * envelope byte-identical to a pre-#937 one — committed corpus fixtures and the
+     * parse goldens carry no such key and must never be required to.
+     *
+     * PII posture: a package's version string is a platform-app fact, not user data.
+     */
+    val platformAppVersion: String? = null,
 ) {
     companion object {
         val EMPTY = ReplayMetadata(engineVersion = 0)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RecognitionHealthReporter.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RecognitionHealthReporter.kt
@@ -1,0 +1,31 @@
+package cloud.trotter.dashbuddy.domain.pipeline
+
+/**
+ * Surfaces a sustained recognition failure to the dasher (#937).
+ *
+ * The contract lives in `:domain` so `:core:pipeline` can call it while keeping its
+ * `:domain`-only dependency (the [LocaleBoundaryReporter] / `PlatformPreferences` inversion,
+ * #938/#355); the implementation lives in `:app`, which owns the notification surface.
+ *
+ * Recognition dying mid-dash is the unfilled quadrant of the #909 silent-death lesson: the
+ * pipeline keeps running, every frame classifies UNKNOWN, and the dasher sees an app that
+ * simply stops narrating. Without this the only detection is a desk pull days later.
+ */
+fun interface RecognitionHealthReporter {
+
+    /**
+     * A platform's recognition has degraded past the alarm threshold.
+     *
+     * Called at most **once per platform per process** — the sensing layer owns that edge gate,
+     * so the implementation is free to post unconditionally and needs no state of its own.
+     *
+     * **Fail-open:** the implementation must neither throw nor block. This is called from the
+     * sensing hot path; a diagnostic must never be able to disturb frame processing.
+     *
+     * @param platformWire the `Platform.wire` of the degraded platform (`"doordash"`, `"uber"`).
+     *   A wire, never a package or a display string — the caller keys by the registry, and the
+     *   implementation resolves display copy from it.
+     * @param unknownPercent the share of the sampled window that classified UNKNOWN, 0..100.
+     */
+    fun onRecognitionDegraded(platformWire: String, unknownPercent: Int)
+}


### PR DESCRIPTION
Closes #937.

Recognition was the last unfilled quadrant of the #909 silent-death family — the effect engine (#914), the bubble (#916) and the odometer (#917) each got a liveness signal, but a DoorDash update that broke every anchor mid-dash was detectable only at the next desk pull, and even then the desk could not correlate the breakage with the release that caused it. This ships the issue's items 1–2. **Item 3 (the unifying staleness heartbeat — each critical subsystem exports staleness, one surface renders it) is deliberately OUT of scope** and left as future work: it is a cross-subsystem design that should supersede or absorb #916/#917/#937's separate surfaces rather than be retrofitted under one of them.

Both pieces are **fail-open and inert to frame processing**. They run on the sensing hot path, so a diagnostic that could kill the pipeline would be the very failure it exists to detect.

## 1. Version stamping

`PlatformAppVersions` (`:core:pipeline`) resolves the **observed** package's `versionName`.

- `CachingPlatformAppVersions` — one lookup per package per process, **negative results cached too** (an unresolvable package would otherwise pay a binder round-trip per frame), bounded at 64 entries (fed from untrusted frame data; past the cap it still *answers*, it just stops memoising), `catch (Throwable)` with `CancellationException` rethrown (#909's rule).
- The `PackageManager` call is injected as a **lambda at the `PipelineModule` DI edge**, so all the logic that can actually misbehave in the field is a plain unit test with no Robolectric.
- **Cache invalidation on package update is deliberately not done** — an app update is followed by a process restart in practice, and a stale *diagnostic* stamp is a nuisance, never a correctness problem (nothing branches on it). Documented at the class.
- **Stamped at classification**, not at capture: classification is the one point that always runs *and* knows the frame's package, since the capture stage is skipped wholesale on a disabled bus (release `NoOpCaptureBus`) — stamping there would leave release builds' log line unstamped. Stamping the observation carries it into the envelope for free (`CaptureWriter` serializes `obs.metadata`).
- `ReplayMetadata.platformAppVersion` / `ReplayMetadataDto` are **additive + nullable**, and this `Json` has `encodeDefaults = false`, so an unstamped envelope is **byte-identical to a pre-#937 one**. The committed corpus and the parse golden carry no such key and no test requires it — **no golden regen** (verified: `AllMatchersSuite` green, working tree clean of snapshot/golden changes).
- The resolved `package@version` pairs also ride the periodic `PipelineStats` INFO summary as `platformApps=com.doordash.driverapp@15.2.3`.

## 2. UNKNOWN-rate alarm

`RecognitionHealth` (pure, no Android, no logging) keeps a per-platform rolling window and returns only the trip edge; `RecognitionHealthMonitor` owns the side effects.

**Tunables, all documented consts, all field-derived:**

| Const | Value | Why |
|---|---|---|
| `WINDOW_SIZE` | 50 | Rolling, per platform. A lifetime ratio dilutes — after two healthy hours a total break barely moves the average, which is exactly when the dasher needs to hear it. Evaluated **only when full**, which is also the "minimum frame count": a handful of unruled launch screens can never trip it. |
| `UNKNOWN_RATIO_THRESHOLD` | 0.80 | The 2026-07-28/29 pulls put a **healthy** dash near **16 %** UNKNOWN on the admitted stream (`forwarded=450 unknownDropped=86`, `forwarded=500 unknownDropped=87` in consecutive `PipelineStats` lines). 0.80 is 5× clear of that noise, and a real anchor break drives the ratio toward 1.0. |
| sample point | post-`FrameGate` | Samples are frames that survived **admission**, screens only. Both classes are deduped there (recognized by identity, UNKNOWN by content hash), so a dasher parked on one unruled screen contributes a couple of samples rather than a thousand — and it is the same stream the field-log baseline above was measured on. |

**Known limit (documented at the class):** sampling the deduped stream means the alarm needs a window's worth of *distinct* frames, so it detects a broken-but-**live** app — the platform-update case it exists for, where offers/timers/maps keep the content changing — rather than a wedged one, which is #916/#917's territory.

**Edge gate:** one WARN + one notice **per platform per process**. Per-*dash* would be the ideal grain, but dash lifecycle lives in `:core:state`, which depends on `:core:pipeline` and not the reverse — inverting the module graph for a diagnostic is not worth it. A process restart re-arms, which is the right bias (recognition breakage is per-dash news, not a once-per-install disclosure like #938's locale notice). Recovery deliberately does **not** re-arm within a process.

**The dasher-visible half reuses #938's inversion**: a `:domain` `RecognitionHealthReporter` contract called from `:core:pipeline`, implemented by the `:app` `RecognitionHealthNotifier` which posts on the shared `app_notice_channel`. The channel id + copy now have **one owner** (`AppNoticeChannel`, ids 102 locale / 103 recognition) instead of a second hand-maintained copy of the id — the `locale_notice_channel_*` strings were renamed to `app_notice_channel_*` (en + es) accordingly.

## Privacy / security posture

Nothing new is read, stored, or sent. **Trusted:** nothing — the observed package name comes from frame data and is treated as such (bounded cache, fail-open lookup). **Gated:** unchanged; neither piece touches the sensitive/content/UNKNOWN gates, the capture path's redaction, or any effect. **Scrubbed:** N/A — the two new data items are a *platform app's* `versionName` and a percentage. Both are platform-app facts, not user data: no screen text, no store/customer/address strings, no device identifiers reach the new INFO/WARN lines or the notification (the notice resolves its display name from the `Platform` registry, never from frame text). The envelope gains one nullable string that is null on every historical capture. Release builds are unchanged in capture behaviour (`NoOpCaptureBus`).

## Tests

- `RecognitionHealthTest` (pure) — partial window never fires; a healthy 16 %-UNKNOWN dash never fires over four windows; just-under vs at-threshold; fires exactly once (recovery does not re-arm); platforms independent under interleaving; the window **forgets** (a 10-window healthy stretch does not immunise a later collapse — the property a lifetime counter would fail).
- `RecognitionHealthMonitorTest` — registry keying, unattributable package/null package ignored, per-platform reports, **a throwing reporter never reaches the sensing frame**.
- `PlatformAppVersionsTest` — one lookup per package, negative caching, **fail-open on a throwing lookup (and not retried per frame)**, the summary-line record, the bound, empty package short-circuit.
- `PlatformAppVersionStampTest` — the classifier stamps a resolved version onto the observation (base metadata untouched); unresolvable / no-package leave it unstamped; a resolver that breaks its never-throws contract costs the stamp, not the frame; **the envelope carries the key when stamped and omits it entirely when not** (the corpus-compatibility guarantee).
- `RecognitionHealthNotifierTest` (Robolectric, mirrors `LocaleBoundaryNotifierTest`) — posts once on the shared channel/id, names the platform + rate and nothing else, an unknown wire gets generic wording rather than a fabricated brand, the two notice ids do not collide, a refused post is swallowed.

Verification: `./gradlew testDebugUnitTest :domain:test` green (re-run after merging master @ `ffd56ae4`, incl. a forced `:app:testDebugUnitTest --rerun-tasks` over #941's new negative corpus); `AllMatchersSuite` green; `:app:assembleDebug` (Hilt graph) and `:app:lintVitalRelease` (the #907 CI gate) green; **no golden regen, no corpus change**.

## Field-test checklist item (ready to transplant into `docs/field-testing/README.md`)

```markdown
- **Recognition-health liveness — version stamp + UNKNOWN-rate alarm (#937, PR #NNN).**
  What to watch: (a) after the dash, the desk pull's `PipelineStats[...]` INFO lines should
  carry a `platformApps=com.doordash.driverapp@<version>` suffix, and new capture envelopes
  should carry `"platformAppVersion"` in their `metadata` block — that is the stamp working;
  (b) you should see NO "recognition health" notification and no `RecognitionHealth` WARN on a
  normal dash where the bubble is narrating offers/pickups/deliveries as usual. A notification
  reading "DashBuddy can't read DoorDash right now" while the app is visibly tracking fine is a
  FALSE POSITIVE — note what was on screen for the previous minute or two (a long stretch on an
  unruled surface is the suspected shape) and the threshold needs raising. If recognition really
  does go quiet mid-dash (no offer cards, no phase changes), the notification SHOULD appear
  within ~50 admitted frames — that one is the feature working.
  - Confirmed: 0/2
```

### Design-goal review

- **1 (UDF).** No reducer or state touched. The alarm is a read-only observer of the classified stream and the notice is a side effect at the edge (`:app`), reached through a contract — nothing flows back into the pipeline or the state machine.
- **3 (single responsibility).** The decision (`RecognitionHealth`, pure) is split from its edges (`RecognitionHealthMonitor`), and the version resolver's caching logic is split from its `PackageManager` call (a DI-edge lambda). `PipelineStats` gains one counter-shaped recorder and one render helper, not the alarm itself.
- **5 (SSOT).** `AppNoticeChannel` now owns the `app_notice_channel` id + copy + the id namespace for both notifiers, replacing what would have been a second hand-maintained copy of the channel id. The resolver's cache is the single source of resolution; `PipelineStats`' map is an explicitly documented render-only record of what that resolver already answered, so the two cannot disagree.
- **6 (security & privacy).** Frame-derived package names are untrusted input: bounded cache, fail-open lookup, no interpolation into anything but a log line. No new persisted data beyond one nullable platform-app version string in the envelope; no network; no change to any sensitive/PII gate. See the posture section above.
- **7 (semantic, PII-safe logging).** The alarm is **WARN** — a defended invariant fired, degraded but nothing lost or crashed — and is edge-gated to once per platform per process, so it cannot drown the level. The version stamp rides the existing **INFO** summary. Both carry only platform-app facts (wire, package, version, percentage). Every new log site is tagged (`RecognitionHealth`, `Pipeline`, `Classifier`), never bare `Timber` — `TimberTagGuardTest` allowlist untouched.
- **8 (platform-agnostic core).** No platform literal anywhere in the new logic: the monitor keys by `Platform.fromPackage(...).wire` and the notifier resolves display copy by `Platform.fromWire(...)` — both registry lookups, with an unresolved wire falling back to generic copy rather than a fabricated name. The window is per-platform state keyed by wire, never a global tuned to the platform we field-test most (a test asserts a healthy Uber does not inherit DoorDash's alarm under interleaving). No new rule vocabulary, no ruleset change.
- **CLAUDE.md** updated in-PR (§1 Sensor Pipelines) with the seams, the tunables and their field derivation, and the deliberate non-decisions (no cache invalidation, per-process not per-dash, recovery does not re-arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
