### PR TITLE
fix(state): #967 — ratings stamp survives Offline; all-null snapshot renders empty state

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsUiState.kt
@@ -57,9 +57,27 @@ data class RatingsUiState(
     companion object {
         val EMPTY = RatingsUiState()
 
-        /** Project a snapshot (may be null → empty) onto the UI state. */
+        /**
+         * Project a snapshot (may be null → empty) onto the UI state.
+         *
+         * #967: an ALL-NULL snapshot object counts as no data. A pre-#963 build stamped a
+         * value-less snapshot whenever a ratings frame classified but parsed nothing, and
+         * `snapshot != null` alone then rendered the populated layout with every gauge/tile
+         * blank — a bare platform header instead of the empty-state explainer that tells the
+         * dasher how to populate the screen. `hasData` now means "at least one VALUE".
+         */
         fun from(platform: Platform?, snapshot: RatingsSnapshot?): RatingsUiState {
             if (snapshot == null) return EMPTY.copy(platformName = platform?.displayName)
+            val hasAnyValue = with(snapshot) {
+                listOf(
+                    customerRating, onTimeRate, completionRate, acceptanceRate,
+                    deliveriesLast30Days, lifetimeDeliveries, originalItemsFoundRate,
+                    totalItemsFoundRate, substitutionIssuesRate, itemsWithQualityIssuesRate,
+                    itemsWrongOrMissingRate, lifetimeShoppingOrders, overallRatingPoints,
+                    tierLabel, qualityRate,
+                ).any { it != null }
+            }
+            if (!hasAnyValue) return EMPTY.copy(platformName = platform?.displayName)
             return RatingsUiState(
                 hasData = true,
                 platformName = platform?.displayName,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -237,8 +237,19 @@ class PlatformRegionStepper @Inject constructor() {
             }
         }
 
+        // #967: stamp the opportunistic ratings snapshot BEFORE the lifecycle gates.
+        // updateLifecycle early-returns on `mode == Offline` (idle-anchor/pending clear), and the
+        // ratings stamp used to sit AFTER that return — so a ratings observation while the platform
+        // was Offline (precisely when a dasher browses their ratings) was parsed and then discarded
+        // (fielded 2026-07-30, minutes after #963 shipped: a fully-parsed hub frame left the prior
+        // all-null snapshot in place; it had only ever stamped mid-dash). Ratings stamping is
+        // observation-driven and mode-independent (#962: opportunistic, display-only — the
+        // RatingsSnapshotIsDisplayOnlyTest allowlist covers this site), so it rides ahead of the
+        // lifecycle, not inside it.
+        val afterRatings = updateRatings(afterMode, flowObs)
+
         // Update session/job/task lifecycle based on flow changes
-        return updateLifecycle(afterMode, prevFlow, nextFlow, flowObs, policy)
+        return updateLifecycle(afterRatings, prevFlow, nextFlow, flowObs, policy)
     }
 
     // =========================================================================
@@ -471,8 +482,7 @@ class PlatformRegionStepper @Inject constructor() {
             }
         }
 
-        // Update ratings if we got a ratings observation
-        r = updateRatings(r, obs)
+        // (Ratings stamping moved to stepCore, ahead of this function's early returns — #967.)
 
         // Job lifecycle
         r = updateJobLifecycle(r, prev, next, obs, policy)

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/RatingsSnapshotFlowThroughTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/RatingsSnapshotFlowThroughTest.kt
@@ -98,4 +98,43 @@ class RatingsSnapshotFlowThroughTest {
         assertNull(snap.qualityRate)
         assertNull(snap.acceptanceRate)
     }
+
+    /**
+     * #967 — the FIELDED gap this file originally missed: both tests above step an ONLINE
+     * region, but the natural time a dasher browses their ratings is while OFFLINE, and
+     * `updateLifecycle`'s Offline early-return used to sit above the ratings stamp — a
+     * fully-parsed hub frame was discarded minutes after #963 shipped. Opportunistic
+     * capture is mode-independent by design (#962); this pins it for every mode.
+     */
+    @Test
+    fun `a ratings observation stamps while the platform is OFFLINE`() {
+        val offline = PlatformRegion(platform = Platform.DoorDash, mode = Mode.Offline)
+        val parsed = ParsedFields.RatingsFields(
+            acceptanceRate = 24.0,
+            overallRatingPoints = 74,
+            tierLabel = "Silver",
+        )
+        val next = stepper.step(offline, flow, flow, ratingsObs(parsed), policy)
+        val snap = next.ratings
+        assertNotNull("an OFFLINE ratings observation must still stamp (#967)", snap)
+        requireNotNull(snap)
+        assertEquals(24.0, snap.acceptanceRate!!, 1e-9)
+        assertEquals(74, snap.overallRatingPoints)
+        assertEquals("Silver", snap.tierLabel)
+    }
+
+    /** #967 — a stale snapshot must be OVERWRITTEN by a newer observation, offline or not. */
+    @Test
+    fun `a newer ratings observation replaces a stale all-null snapshot while OFFLINE`() {
+        val staleStamped = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Offline,
+            ratings = cloud.trotter.dashbuddy.domain.model.ratings.RatingsSnapshot(capturedAt = 1L),
+        )
+        val parsed = ParsedFields.RatingsFields(overallRatingPoints = 74, tierLabel = "Silver")
+        val next = stepper.step(staleStamped, flow, flow, ratingsObs(parsed), policy)
+        val snap = requireNotNull(next.ratings)
+        assertEquals("newer observation wins", 1_000L, snap.capturedAt)
+        assertEquals(74, snap.overallRatingPoints)
+    }
 }


### PR DESCRIPTION
## What / why

Fielded minutes after #963: the dev browsed DoorDash → Ratings on the new build and DashBuddy's Ratings page stayed a bare platform header. Desk trace (pull3) proved the full chain worked — frame classified, parse produced every field on the exact envelope (local replay), `PROCESSING` ran — and the state snapshot still carried the previous day's all-null stamp. Two defects, both fixed:

1. **`updateLifecycle`'s `mode == Offline` early-return sat above `updateRatings`** — opportunistic ratings capture only ever worked while ON a dash. The stamp now rides `stepCore` ahead of the lifecycle gates (observation-driven, mode-independent per the #962 design; the `RatingsSnapshotIsDisplayOnlyTest` scan still passes — same file, same single stamping seam).
2. **`hasData = (snapshot != null)`** made yesterday's all-null pre-#963 stamp render the populated layout with every tile blank, hiding the existing (and correct) empty-state explainer. `hasData` now requires at least one non-null value.

## Tests
- New: stamping while OFFLINE (the fielded shape), stale-snapshot overwrite while OFFLINE — both in `RatingsSnapshotFlowThroughTest`, whose existing cases all stepped an Online region (the gap that let this ship).
- `:core:state` + `:app` + `:domain` full suites green.

### Design-goal review
- **1 (UDF):** the stamp stays a pure reduction step, just sequenced ahead of gated lifecycle logic; no side effects moved.
- **5 (SSOT):** `hasData` derives from the one snapshot object; no second "is empty" flag introduced.
- **8:** no platform literals; mode/lifecycle logic untouched otherwise.

Closes #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)