### PR TITLE
feature(analytics): #970 — period-first analytics: arbitrary-window aggregates, pager + range picker, recap hero (redesign stage 1/7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,7 +601,29 @@ while an incremental fold split across a page boundary mints then deletes it —
 immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`; all-pay gross =
 reported-total authoritative + the unattributed review flag; per-store; Monday-week boundaries via
 `PeriodBounds`, midnight-reactive) as Room-invalidation Flows to the home glance + the future Analytics hub
-(#315). **The "(No session)" bucket (#660 piece 1):** `delivery_records` rows whose source event carried
+(#315). **Arbitrary review windows (#970, redesign epic #969 stage 1):** every period aggregate now has a
+second overload taking an `AnalyticsWindow` (`:domain` — a granularity + a half-open span of local
+**dates**: `DAY`/`WEEK`/`MONTH`/`LIFETIME`/`CUSTOM`), so the hub's `‹ ›` pager and range picker can read any
+span while the rolling four-value `AnalyticsPeriod` stays exactly as it was for the home glance. **One rule
+set, two callers:** `PeriodBounds.of(window, zone)` is the primitive and `PeriodBounds.of(period, now, zone)`
+delegates to it via `AnalyticsPeriod.toWindow(today)`, so the enum and window paths can never disagree about
+where Monday starts; inside the repository each pair (`periodEconomics`/`perStoreEconomics`/
+`decisionEconomics`/`timeEconomics`/`dailyEarnings`/`noSessionDeliveries`/`orphanOfferGroups`) shares ONE
+private `…In(boundsFlow)` core — the enum overload feeds it the midnight-re-anchoring `periodBoundariesFlow`,
+the window overload a fixed `flowOf(bounds)` (a paged window is an explicit span and must NOT silently become
+a different one while it is on screen; the hub re-resolves *which* window is current from
+`currentLocalDateFlow` one level up). `AnalyticsWindows` (pure `:domain`) owns the calendar math — Monday
+weeks, calendar-month stepping, the **previous-equivalent window** the recap hero's delta compares against
+(null for Lifetime — no predecessor, so the UI states that rather than inventing a comparison), and the
+`canStepForward` fence that keeps the pager out of the future. The selection persists in **app prefs** as an
+`AnalyticsWindowSelection` — `Relative(granularity, offset)` for the pageable granularities so reopening the
+hub next week still means *this* week, `Custom(start, endInclusive)` only for a driver-drawn range — decoded
+fail-closed to the current pay week. **Net per day (§7.3):** `DailyEarnings` gained `net` alongside `gross`
+(`sessionGrossRows`/`noSessionDailyRows` compute it from the same frozen columns + cash + the session's
+unattributed remainder), so Σ per-day net equals the window's `PeriodEconomics.netProfit` by construction and
+the hero's sparkline plots kept money, not gross. `dailyEarnings` returns an EMPTY axis for a single-day,
+unbounded, or over-`MAX_DAY_AXIS` (400-day) window. Read-side only — no schema change, no
+`PROJECTOR_VERSION` bump, no economy dependency. **The "(No session)" bucket (#660 piece 1):** `delivery_records` rows whose source event carried
 NO `sessionId` at all were already counted in net (`deliveryTotals`'s own-`completedAt` fallback, #655)
 but invisible to gross (`grossAndUnattributed`/`sessionGrossRows` iterate `session_records` only, so a
 null-session row joined to nothing) — a seam that could let displayed net exceed gross. Fixed by folding

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -168,10 +168,16 @@ fun AnalyticsScreen(
     }
 
     if (showRangePicker) {
+        val pickerMonth by viewModel.pickerMonth.collectAsStateWithLifecycle()
+        val pickerMonthDays by viewModel.pickerMonthDays.collectAsStateWithLifecycle()
         RangePickerSheet(
             window = uiState.window,
             today = uiState.today,
-            viewModel = viewModel,
+            month = pickerMonth,
+            monthDays = pickerMonthDays,
+            onMonthChange = viewModel::setPickerMonth,
+            onPickPreset = viewModel::setRelativeWindow,
+            onCommitRange = viewModel::setCustomRange,
             onDismiss = { showRangePicker = false },
         )
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -1,6 +1,5 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -30,13 +29,14 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
-import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 
 /**
- * The Analytics hub (#315). Money / Decisions / Time / Patterns (H5) all render real content. A
- * **review** surface: UDF state in, `setTab`/`setPeriod` intents out
- * (Principle 1); reactive-fresh via the read-model Flows, no `rememberNow()` tick (a historical
- * period's figures are fixed).
+ * The Analytics hub (#315), **period-first** since #970. A `‹ ›` window pager + a recap hero own the
+ * top of the screen; Money / Decisions / Time / Patterns (H5) render below as detail views of that
+ * one window. A **review** surface: UDF state in, `setTab`/`stepWindow`/`setGranularity`/
+ * `setCustomRange` intents out (Principle 1); reactive-fresh via the read-model Flows and a
+ * once-a-day local-date anchor, with no `rememberNow()` tick (a historical window's figures are
+ * fixed).
  *
  * The header's CSV action routes to the existing Data & Privacy export (#319) — the hub-header entry
  * point deferred from #671 (#315 H6); no new export logic, navigation only.
@@ -53,6 +53,8 @@ fun AnalyticsScreen(
     // "(No session)" categorize flow (#660 piece 2) — opened from the Money-tab callout.
     var showAssignSheet by remember { mutableStateOf(false) }
     var showOrphanOfferSheet by remember { mutableStateOf(false) }
+    // The #970 range picker (brief §3.2) — opened from the pager label or the `Custom…` chip.
+    var showRangePicker by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -84,6 +86,28 @@ fun AnalyticsScreen(
                 .padding(16.dp)
                 .fillMaxSize(),
         ) {
+            // Period-first (#970): the window control and the recap hero own the top of the screen;
+            // the tabs below are detail views OF that window, not the primary navigation.
+            PeriodPager(
+                window = uiState.window,
+                today = uiState.today,
+                canStepBack = uiState.canStepBack,
+                canStepForward = uiState.canStepForward,
+                onStep = viewModel::stepWindow,
+                onOpenPicker = { showRangePicker = true },
+                onSelectGranularity = viewModel::setGranularity,
+            )
+            Spacer(Modifier.height(16.dp))
+            RecapHero(
+                window = uiState.window,
+                today = uiState.today,
+                economics = uiState.economics,
+                previousEconomics = uiState.previousEconomics,
+                decisions = uiState.decisions,
+                dailyEarnings = uiState.dailyEarnings,
+            )
+            Spacer(Modifier.height(16.dp))
+
             val tabOptions = tabOptions()
             val selectedTabLabel = tabOptions.first { it.tab == uiState.selectedTab }.label
             AppSegmented(
@@ -99,42 +123,23 @@ fun AnalyticsScreen(
             )
             Spacer(Modifier.height(16.dp))
 
+            // Each tab is a detail view of the window selected above — the per-tab period selector is
+            // gone (#970); the pager at the top owns the window for all of them.
             when (uiState.selectedTab) {
-                AnalyticsTab.Money -> {
-                    PeriodSelector(
-                        selectedPeriod = uiState.selectedPeriod,
-                        onSelectPeriod = viewModel::setPeriod,
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    MoneyTab(
-                        economics = uiState.economics,
-                        topStores = uiState.topStores,
-                        recentSessions = uiState.recentSessions,
-                        dailyEarnings = uiState.dailyEarnings,
-                        orphanOfferGroups = uiState.orphanOfferGroups,
-                        onOpenSession = onOpenSession,
-                        onOpenNoSession = { showAssignSheet = true },
-                        onOpenOrphanOffers = { showOrphanOfferSheet = true },
-                    )
-                }
+                AnalyticsTab.Money -> MoneyTab(
+                    economics = uiState.economics,
+                    topStores = uiState.topStores,
+                    recentSessions = uiState.recentSessions,
+                    dailyEarnings = uiState.dailyEarnings,
+                    orphanOfferGroups = uiState.orphanOfferGroups,
+                    onOpenSession = onOpenSession,
+                    onOpenNoSession = { showAssignSheet = true },
+                    onOpenOrphanOffers = { showOrphanOfferSheet = true },
+                )
 
-                AnalyticsTab.Decisions -> {
-                    PeriodSelector(
-                        selectedPeriod = uiState.selectedPeriod,
-                        onSelectPeriod = viewModel::setPeriod,
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    DecisionsTab(decisions = uiState.decisions)
-                }
+                AnalyticsTab.Decisions -> DecisionsTab(decisions = uiState.decisions)
 
-                AnalyticsTab.Time -> {
-                    PeriodSelector(
-                        selectedPeriod = uiState.selectedPeriod,
-                        onSelectPeriod = viewModel::setPeriod,
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    TimeTab(time = uiState.time, period = uiState.selectedPeriod)
-                }
+                AnalyticsTab.Time -> TimeTab(time = uiState.time, window = uiState.window)
 
                 // Patterns (H5) is LIFETIME-scoped (rate/pattern-based) — deliberately NO period selector.
                 AnalyticsTab.Patterns -> PatternsTab(
@@ -161,6 +166,15 @@ fun AnalyticsScreen(
             onDismiss = { showOrphanOfferSheet = false },
         )
     }
+
+    if (showRangePicker) {
+        RangePickerSheet(
+            window = uiState.window,
+            today = uiState.today,
+            viewModel = viewModel,
+            onDismiss = { showRangePicker = false },
+        )
+    }
 }
 
 /** The hub tabs paired with their resolved label (#428 Half A) — identity stays the enum. */
@@ -169,31 +183,3 @@ private data class TabOption(val tab: AnalyticsTab, val label: String)
 @Composable
 private fun tabOptions(): List<TabOption> =
     AnalyticsTab.entries.map { TabOption(it, stringResource(it.labelRes)) }
-
-/** The review windows offered by the Money period selector, in display order. */
-private data class PeriodOption(val period: AnalyticsPeriod, val label: String)
-
-@Composable
-private fun periodOptions(): List<PeriodOption> = listOf(
-    PeriodOption(AnalyticsPeriod.TODAY, stringResource(R.string.common_period_today)),
-    PeriodOption(AnalyticsPeriod.THIS_WEEK, stringResource(R.string.common_period_week)),
-    PeriodOption(AnalyticsPeriod.THIS_MONTH, stringResource(R.string.common_period_month)),
-    PeriodOption(AnalyticsPeriod.LIFETIME, stringResource(R.string.common_period_lifetime)),
-)
-
-@Composable
-private fun PeriodSelector(
-    selectedPeriod: AnalyticsPeriod,
-    onSelectPeriod: (AnalyticsPeriod) -> Unit,
-) {
-    val periodOptions = periodOptions()
-    val selectedLabel = periodOptions.first { it.period == selectedPeriod }.label
-    AppSegmented(
-        options = periodOptions.map { it.label },
-        selected = selectedLabel,
-        onSelect = { label ->
-            periodOptions.firstOrNull { it.label == label }?.let { onSelectPeriod(it.period) }
-        },
-        modifier = Modifier.fillMaxWidth(),
-    )
-}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -2,7 +2,8 @@ package cloud.trotter.dashbuddy.ui.main.analytics
 
 import androidx.annotation.StringRes
 import cloud.trotter.dashbuddy.R
-import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindowSelection
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
@@ -13,6 +14,7 @@ import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
+import java.time.LocalDate
 
 /**
  * Below this a money figure is effectively zero — no callout, no cash-tip line (it avoids flagging
@@ -40,44 +42,63 @@ enum class AnalyticsTab(@param:StringRes val labelRes: Int) {
 /**
  * Immutable state for the Analytics hub (Principle 1 — UDF). A **review** surface opened
  * between shifts, so — like the reframed dashboard (#657) — the economics are the durable
- * read-model for the selected [selectedPeriod], reactive to projector commits (Room
- * invalidation) and midnight/week/month rollover, but **not** a per-second tick surface: a
+ * read-model for the selected [window], reactive to projector commits (Room
+ * invalidation) and to local-midnight re-anchoring of the *current* window, but **not** a per-second tick surface: a
  * historical period's $/hr is a fixed value, so no `rememberNow()` clock is needed.
  *
- * Defaults differ from the dashboard on purpose: a review hub opens on the week
- * ([AnalyticsPeriod.THIS_WEEK]) rather than the day, on the [AnalyticsTab.Money] tab.
+ * Defaults differ from the dashboard on purpose: a review hub opens on the current pay week
+ * ([AnalyticsWindowSelection.DEFAULT]) rather than the day, on the [AnalyticsTab.Money] tab.
  * All economics are frozen-net (an economy edit never rewrites a past period) and all
  * fields are read-model-only — nothing here re-enters the pure state machine.
  */
 data class AnalyticsUiState(
     val selectedTab: AnalyticsTab = AnalyticsTab.Money,
-    val selectedPeriod: AnalyticsPeriod = AnalyticsPeriod.THIS_WEEK,
-    /** Frozen-net economics for [selectedPeriod]; fresh-on-open, not live-ticking. */
+    /**
+     * The selected review window (#970) — an arbitrary `[start, end)` span of local days the `‹ ›`
+     * pager walks and the range picker commits. Replaces the old four-value `AnalyticsPeriod`
+     * selection; the rolling enum lives on for the home glance, which genuinely wants "the current
+     * week" rather than a pageable window.
+     */
+    val window: AnalyticsWindow = AnalyticsWindowSelection.DEFAULT.resolve(LocalDate.now()),
+    /** The device's current local date — the anchor "this week"/"today" labels and the `›` arrow read. */
+    val today: LocalDate = LocalDate.now(),
+    /** `‹` is live for every window except Lifetime. */
+    val canStepBack: Boolean = true,
+    /** `›` is live only once the window has moved off the current one (brief §3.1). */
+    val canStepForward: Boolean = false,
+    /** Frozen-net economics for [window]; fresh-on-open, not live-ticking. */
     val economics: PeriodEconomics = PeriodEconomics.EMPTY,
-    /** Top-earning stores for [selectedPeriod] (already capped to the display count). */
+    /**
+     * The **previous equivalent window**'s economics (#970 / brief §7.2) — the recap hero's delta
+     * chip compares against this. Null for Lifetime (all time has no predecessor), in which case the
+     * hero states that instead of inventing a comparison (§9).
+     */
+    val previousEconomics: PeriodEconomics? = null,
+    /** Top-earning stores for [window] (already capped to the display count). */
     val topStores: List<StoreEconomics> = emptyList(),
     /**
-     * Per-day earnings for [selectedPeriod] — the Money-tab earnings-by-day chart (#315 H6). Empty for
-     * Today/Lifetime (one bar / unbounded), so the Money tab hides the chart card on an empty list.
+     * Per-day earnings for [window] — the Money-tab earnings-by-day chart (#315 H6) and the recap
+     * hero's net sparkline (#970 §7.3). Empty for a single-day, unbounded, or over-long window, so
+     * both surfaces hide their chart on an empty list.
      */
     val dailyEarnings: List<DailyEarnings> = emptyList(),
     /** Most recent dash sessions, newest first — each row taps through to the per-dash drill-down (#650). */
     val recentSessions: List<SessionRecord> = emptyList(),
     /**
-     * The period's orphan "(No session)" deliveries (#660 piece 2) — the categorize flow's list, opened
+     * The window's orphan "(No session)" deliveries (#660 piece 2) — the categorize flow's list, opened
      * from the Money-tab callout. Reactive: shrinks as the projector folds a `DELIVERY_SESSION_ASSIGN`.
      */
     val noSessionDeliveries: List<DeliveryRecord> = emptyList(),
     /**
-     * The period's still-open orphan-offer mismatches (#810 B2 Tier 2) — accepted offers whose job
+     * The window's still-open orphan-offer mismatches (#810 B2 Tier 2) — accepted offers whose job
      * produced no matching delivery and whose same-store shape the projector's Tier-1 join could not
      * resolve. The Money-tab callout opens the attestation dialog; reactive — shrinks as the driver
      * attests (or Tier-1 resolves) an orphan.
      */
     val orphanOfferGroups: List<OrphanOfferGroup> = emptyList(),
-    /** Offer-decision economics for [selectedPeriod] — the Decisions tab (#315 H3, frozen est.). */
+    /** Offer-decision economics for [window] — the Decisions tab (#315 H3, frozen est.). */
     val decisions: DecisionEconomics = DecisionEconomics.EMPTY,
-    /** Time / mileage economics for [selectedPeriod] — the Time tab (#315 H4, measured). */
+    /** Time / mileage economics for [window] — the Time tab (#315 H4, measured). */
     val time: TimeEconomics = TimeEconomics.EMPTY,
     /**
      * Per-store report cards — the Patterns tab (#315 H5, #159), newest-visited first. **Lifetime-scoped**,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -4,7 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository
-import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.core.data.analytics.currentLocalDateFlow
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindowSelection
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
@@ -13,6 +17,7 @@ import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
+import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,26 +25,37 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.time.LocalDate
+import java.time.YearMonth
 import javax.inject.Inject
 
 /**
- * State holder for the Analytics hub (#315 H1) — a **review** surface assembled reactively
- * from the durable analytics read-model ([AnalyticsRepository]), exposing one immutable
- * [AnalyticsUiState] (Principle 1 — UDF). Over the read-model repository surface:
+ * State holder for the Analytics hub (#315 H1, made **period-first** by #970) — a **review** surface
+ * assembled reactively from the durable analytics read-model ([AnalyticsRepository]), exposing one
+ * immutable [AnalyticsUiState] (Principle 1 — UDF). Over the read-model repository surface:
  * `periodEconomics` (frozen-net totals), `perStoreEconomics` (top stores), `recentSessions`
  * (recent dashes), `decisionEconomics` (H3 funnel/verdicts), and `timeEconomics` (H4 time/mileage) —
- * every *period* source session-anchored (#655) via the DAO join, which owns the bucketing. The
+ * every *window* source session-anchored (#655) via the DAO join, which owns the bucketing. The
  * Patterns tab's `storeReportCards` (#159) + `earningsHeatmap` (H5) are LIFETIME-scoped and sit
- * outside the period `flatMapLatest`, so a period switch never re-queries them.
+ * outside the window `flatMapLatest`, so a window switch never re-queries them.
+ *
+ * **The window (#970).** The selection is persisted in app preferences and is the single source of
+ * truth: intents write to the DataStore and the resolved window comes back through
+ * [AppPreferencesRepository.analyticsWindow] — no optimistic local copy that could drift
+ * (Principle 5). A *relative* selection ("this week", "two weeks back") is resolved against
+ * [currentLocalDateFlow], so the hub re-anchors at local midnight without a restart and without a
+ * per-second ticker (Reactive UI rule 4: the anchor changes once a day, so its flow ticks once a
+ * day). The previous-equivalent window's economics ride the same fan-out for the recap hero's delta.
  *
  * Reactive by construction: every source is a Room-invalidation `Flow`, so the tiles re-emit
- * as the projector folds each delivery and at midnight/week/month rollover (the boundary
- * flow) — fresh-on-open, no `rememberNow()` clock (a historical period's $/hr is a fixed
- * value; same principle as the dashboard reframe #657).
+ * as the projector folds each delivery — fresh-on-open, no `rememberNow()` clock (a historical
+ * window's $/hr is a fixed value; same principle as the dashboard reframe #657).
  *
  * Privacy: economics/counts/store names only — customer PII is already sha256'd upstream and
  * never surfaces here (Principle 6); store names are merchants, fine to render (Principle 7
@@ -51,68 +67,180 @@ import javax.inject.Inject
 class AnalyticsViewModel @Inject constructor(
     private val analyticsRepository: AnalyticsRepository,
     private val correctionRepository: CorrectionRepository,
+    private val appPreferencesRepository: AppPreferencesRepository,
 ) : ViewModel() {
 
-    /** UDF intent targets — the selected review window and tab. */
-    private val selectedPeriod = MutableStateFlow(AnalyticsPeriod.THIS_WEEK)
+    /** UDF intent target — the visible tab (transient; only the window is persisted). */
     private val selectedTab = MutableStateFlow(AnalyticsTab.Money)
+
+    /** The persisted window selection — DataStore is the SSOT; intents write, this reads back. */
+    private val selection: StateFlow<AnalyticsWindowSelection> =
+        appPreferencesRepository.analyticsWindow
+            .stateIn(viewModelScope, SharingStarted.Eagerly, AnalyticsWindowSelection.DEFAULT)
+
+    /** The device's local date, re-emitting at midnight — the anchor a relative selection resolves against. */
+    private val today: StateFlow<LocalDate> = currentLocalDateFlow()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, LocalDate.now())
+
+    /** The resolved window the whole hub reads. */
+    private val window: StateFlow<AnalyticsWindow> =
+        combine(selection, today) { sel, day -> sel.resolve(day) }
+            .distinctUntilChanged()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, AnalyticsWindowSelection.DEFAULT.resolve(LocalDate.now()))
 
     val uiState: StateFlow<AnalyticsUiState> = combine(
         selectedTab,
-        // Re-anchor economics + top stores + decisions together on each period switch so a tile
-        // never renders one window's number under another's label. Decisions is collected
-        // unconditionally (not gated on the selected tab): the source is a cheap Room-invalidation
-        // aggregate and folding it in here keeps one immutable UiState re-anchored atomically with
-        // the period — the simpler correct shape (Principle 1).
-        selectedPeriod.flatMapLatest { period ->
+        // Re-anchor economics + top stores + decisions together on each window switch so a tile never
+        // renders one window's number under another's label. Decisions is collected unconditionally
+        // (not gated on the selected tab): the source is a cheap Room-invalidation aggregate and
+        // folding it in here keeps one immutable UiState re-anchored atomically with the window.
+        combine(window, today) { w, day -> w to day }.flatMapLatest { (w, day) ->
             combine(
-                analyticsRepository.periodEconomics(period),
-                analyticsRepository.perStoreEconomics(period),
-                analyticsRepository.decisionEconomics(period),
-                analyticsRepository.timeEconomics(period),
+                analyticsRepository.periodEconomics(w),
+                analyticsRepository.perStoreEconomics(w),
+                analyticsRepository.decisionEconomics(w),
+                analyticsRepository.timeEconomics(w),
                 // The typed `combine` tops out at 5 flows, so the per-day chart + the "(No session)"
-                // orphan list (#660 piece 2) + the orphan-OFFER groups (#810 B2 Tier 2) ride ONE nested
-                // sub-combine into the 5th slot. All period-anchored, so they re-anchor atomically with
-                // everything else on a period switch.
+                // orphan list (#660 piece 2) + the orphan-OFFER groups (#810 B2 Tier 2) + the
+                // previous-window economics (#970 §7.2) ride ONE nested sub-combine into the 5th slot.
+                // All window-anchored, so they re-anchor atomically with everything else.
                 combine(
-                    analyticsRepository.dailyEarnings(period),
-                    analyticsRepository.noSessionDeliveries(period),
-                    analyticsRepository.orphanOfferGroups(period),
-                ) { daily, orphans, offerGroups -> Triple(daily, orphans, offerGroups) },
-            ) { economics, stores, decisions, time, (daily, orphans, offerGroups) ->
-                PeriodData(period, economics, stores, decisions, time, daily, orphans, offerGroups)
+                    analyticsRepository.dailyEarnings(w),
+                    analyticsRepository.noSessionDeliveries(w),
+                    analyticsRepository.orphanOfferGroups(w),
+                    previousEconomics(w),
+                ) { daily, orphans, offerGroups, previous ->
+                    WindowExtras(daily, orphans, offerGroups, previous)
+                },
+            ) { economics, stores, decisions, time, extras ->
+                WindowData(w, day, economics, stores, decisions, time, extras)
             }
         },
         analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
         // The Patterns tab (H5, #159) is LIFETIME-scoped by design — its sources sit OUTSIDE the
-        // period flatMapLatest so switching the Money/Decisions/Time period never re-queries them.
+        // window flatMapLatest so switching the Money/Decisions/Time window never re-queries them.
         analyticsRepository.storeReportCards(),
         analyticsRepository.earningsHeatmap(),
     ) { tab, data, sessions, storeCards, heatmap ->
         AnalyticsUiState(
             selectedTab = tab,
-            selectedPeriod = data.period,
+            window = data.window,
+            today = data.today,
+            canStepBack = AnalyticsWindows.canStepBack(data.window),
+            canStepForward = AnalyticsWindows.canStepForward(data.window, data.today),
             economics = data.economics,
+            previousEconomics = data.extras.previousEconomics,
             topStores = data.stores.take(TOP_STORES),
             recentSessions = sessions,
             decisions = data.decisions,
             time = data.time,
-            dailyEarnings = data.dailyEarnings,
-            noSessionDeliveries = data.orphanDeliveries,
-            orphanOfferGroups = data.orphanOfferGroups,
+            dailyEarnings = data.extras.dailyEarnings,
+            noSessionDeliveries = data.extras.orphanDeliveries,
+            orphanOfferGroups = data.extras.orphanOfferGroups,
             storeReportCards = storeCards,
             earningsHeatmap = heatmap,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AnalyticsUiState())
 
-    /** UDF intent — switch the review window; economics + top stores re-anchor reactively. */
-    fun setPeriod(period: AnalyticsPeriod) {
-        selectedPeriod.value = period
+    /**
+     * The previous-equivalent window's economics, or a `null` emission for a window that has no
+     * predecessor (Lifetime). Kept as a flow (not a nullable read) so the sub-combine always has five
+     * live sources and the hero's delta re-emits with everything else.
+     */
+    private fun previousEconomics(window: AnalyticsWindow) =
+        AnalyticsWindows.previous(window)
+            ?.let { analyticsRepository.periodEconomics(it) }
+            ?: flowOf<PeriodEconomics?>(null)
+
+    // ── The range picker's calendar (brief §3.2) ─────────────────────────
+
+    /** Which month the picker's calendar is showing — picker-local, not part of the hub's UiState. */
+    private val calendarMonth = MutableStateFlow(YearMonth.now())
+
+    /** The visible calendar month, for the picker's header + month pager. */
+    val pickerMonth: StateFlow<YearMonth> = calendarMonth
+
+    /**
+     * Per-day earnings for the picker's visible month — the calendar's **earning dots**. Reuses the
+     * same arbitrary-window per-day read (#970 §7.1) the Money chart uses rather than a bespoke
+     * query (Principle 5); a month is 28–31 days, well inside the read's bounded day axis.
+     */
+    val pickerMonthDays: StateFlow<List<DailyEarnings>> = calendarMonth
+        .flatMapLatest { month ->
+            analyticsRepository.dailyEarnings(
+                AnalyticsWindows.custom(month.atDay(1), month.atEndOfMonth()),
+            )
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** UDF intent — page the picker's calendar to [month]. */
+    fun setPickerMonth(month: YearMonth) {
+        calendarMonth.value = month
     }
+
+    // ── Window intents ──────────────────────────────────────────────────
 
     /** UDF intent — switch the visible tab. */
     fun setTab(tab: AnalyticsTab) {
         selectedTab.value = tab
+    }
+
+    /**
+     * UDF intent — the `‹`/`›` pager. [steps] is negative to page back. A forward step past the
+     * current window is **ignored** rather than clamped silently into a future range (the arrow is
+     * already disabled there; this is the fail-closed backstop for the intent itself).
+     */
+    fun stepWindow(steps: Int) {
+        if (steps == 0) return
+        val current = window.value
+        if (steps > 0 && !AnalyticsWindows.canStepForward(current, today.value)) return
+        if (steps < 0 && !AnalyticsWindows.canStepBack(current)) return
+        val next = when (val sel = selection.value) {
+            is AnalyticsWindowSelection.Relative ->
+                sel.copy(offset = (sel.offset + steps).coerceAtMost(0))
+            is AnalyticsWindowSelection.Custom -> {
+                val stepped = AnalyticsWindows.step(current, steps)
+                val start = stepped.startDate
+                val end = stepped.endDateInclusive
+                if (start == null || end == null) sel else AnalyticsWindowSelection.Custom(start, end)
+            }
+        }
+        persist(next)
+    }
+
+    /**
+     * UDF intent — the granularity chips. Always lands on the CURRENT window of that granularity
+     * (offset 0), which is what "Day / Week / Month / Lifetime" reads as. `CUSTOM` is not a
+     * granularity you can select this way — that chip opens the picker, which calls [setCustomRange].
+     */
+    fun setGranularity(granularity: WindowGranularity) {
+        if (granularity == WindowGranularity.CUSTOM) return
+        persist(AnalyticsWindowSelection.Relative(granularity, 0))
+    }
+
+    /** UDF intent — a preset row in the range picker (e.g. "Last week" = week, one step back). */
+    fun setRelativeWindow(granularity: WindowGranularity, offset: Int) {
+        if (granularity == WindowGranularity.CUSTOM) return
+        persist(AnalyticsWindowSelection.Relative(granularity, offset.coerceAtMost(0)))
+    }
+
+    /** UDF intent — the picker's committed calendar range (both ends inclusive). */
+    fun setCustomRange(startDate: LocalDate, endDateInclusive: LocalDate) {
+        if (endDateInclusive.isBefore(startDate)) return
+        persist(AnalyticsWindowSelection.Custom(startDate, endDateInclusive))
+    }
+
+    private fun persist(selection: AnalyticsWindowSelection) {
+        viewModelScope.launch {
+            try {
+                appPreferencesRepository.setAnalyticsWindow(selection)
+            } catch (e: CancellationException) {
+                throw e // cooperative cancellation — never swallow it
+            } catch (e: Exception) {
+                // P7: no PII — a granularity name and an integer offset only.
+                Timber.tag(TAG).w(e, "window selection not persisted")
+            }
+        }
     }
 
     /**
@@ -169,16 +297,23 @@ class AnalyticsViewModel @Inject constructor(
         }
     }
 
-    /** One period switch's worth of read-model, re-anchored atomically under [flatMapLatest]. */
-    private data class PeriodData(
-        val period: AnalyticsPeriod,
+    /** The 5th-slot sub-combine's payload — window-anchored reads that don't fit the typed 5-arity. */
+    private data class WindowExtras(
+        val dailyEarnings: List<DailyEarnings>,
+        val orphanDeliveries: List<DeliveryRecord>,
+        val orphanOfferGroups: List<OrphanOfferGroup>,
+        val previousEconomics: PeriodEconomics?,
+    )
+
+    /** One window switch's worth of read-model, re-anchored atomically under [flatMapLatest]. */
+    private data class WindowData(
+        val window: AnalyticsWindow,
+        val today: LocalDate,
         val economics: PeriodEconomics,
         val stores: List<StoreEconomics>,
         val decisions: DecisionEconomics,
         val time: TimeEconomics,
-        val dailyEarnings: List<DailyEarnings>,
-        val orphanDeliveries: List<DeliveryRecord>,
-        val orphanOfferGroups: List<OrphanOfferGroup>,
+        val extras: WindowExtras,
     )
 
     private companion object {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PeriodPager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PeriodPager.kt
@@ -1,0 +1,227 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
+import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
+import cloud.trotter.dashbuddy.domain.format.formatMonthDay
+import cloud.trotter.dashbuddy.domain.format.formatMonthDayYear
+import cloud.trotter.dashbuddy.domain.format.formatMonthName
+import cloud.trotter.dashbuddy.domain.format.formatMonthYear
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.Locale
+
+/**
+ * How the selected window sits relative to "now" (#970) — the word in front of the range
+ * ("This week · Jul 13–19"). Pure, so the label logic is unit-testable away from Compose.
+ */
+enum class WindowRelation {
+    /** The window containing today. */
+    CURRENT,
+
+    /** Exactly one step back from the current window. */
+    PREVIOUS,
+
+    /** Further back, or a custom span — the range itself is the whole label. */
+    OLDER,
+}
+
+/**
+ * Pure label logic for the period pager (#970 / brief §3.1) — the relation word and the range text.
+ *
+ * Compose-free on purpose (the [WaterfallModel]/[MileageTaxModel] precedent): the interesting part is
+ * the *calendar* reasoning ("is this the current week?", "does this span two years?"), and it should
+ * be provable without rendering. Every rendered string routes through the `:domain` date-format SSOT.
+ */
+object WindowLabel {
+
+    /** En dash with hair spaces — a range separator, not a hyphen. */
+    private const val RANGE_SEPARATOR = " – "
+
+    /**
+     * Where [window] sits relative to [today]. A CUSTOM span is always [WindowRelation.OLDER]: it has
+     * no natural "this"/"last" reading even when it happens to contain today, and claiming one would
+     * put a word in front of a range the driver drew themselves.
+     */
+    fun relation(window: AnalyticsWindow, today: LocalDate): WindowRelation {
+        if (window.isLifetime) return WindowRelation.CURRENT
+        if (window.granularity == WindowGranularity.CUSTOM) return WindowRelation.OLDER
+        val current = AnalyticsWindows.current(window.granularity, today)
+        return when (window.startDate) {
+            current.startDate -> WindowRelation.CURRENT
+            AnalyticsWindows.step(current, -1).startDate -> WindowRelation.PREVIOUS
+            else -> WindowRelation.OLDER
+        }
+    }
+
+    /**
+     * The window's date range as display copy, or `null` for Lifetime (which has no range — its
+     * title carries the whole meaning).
+     *
+     * The year is stated only when the window leaves [today]'s year, so the common case stays short
+     * ("Jul 13 – 19") while a paged-back window is never ambiguous about which year it means.
+     */
+    fun range(window: AnalyticsWindow, today: LocalDate, locale: Locale = Locale.getDefault()): String? {
+        val start = window.startDate ?: return null
+        val end = window.endDateInclusive ?: return null
+        val sameYearAsToday = start.year == today.year && end.year == today.year
+        return when {
+            window.granularity == WindowGranularity.MONTH -> {
+                val month = YearMonth.from(start)
+                if (sameYearAsToday) formatMonthName(month, locale) else formatMonthYear(month, locale)
+            }
+            start == end ->
+                if (sameYearAsToday) formatMonthDay(start, locale) else formatMonthDayYear(start, locale)
+            start.year != end.year ->
+                formatMonthDayYear(start, locale) + RANGE_SEPARATOR + formatMonthDayYear(end, locale)
+            !sameYearAsToday ->
+                formatMonthDay(start, locale) + RANGE_SEPARATOR + formatMonthDayYear(end, locale)
+            start.month == end.month ->
+                formatMonthDay(start, locale) + RANGE_SEPARATOR + end.dayOfMonth.toString()
+            else ->
+                formatMonthDay(start, locale) + RANGE_SEPARATOR + formatMonthDay(end, locale)
+        }
+    }
+}
+
+/** The relation word for [window] — "This week", "Last month", or the range itself for older spans. */
+@Composable
+fun windowTitle(window: AnalyticsWindow, today: LocalDate): String {
+    if (window.isLifetime) return stringResource(R.string.analytics_window_lifetime)
+    val relation = WindowLabel.relation(window, today)
+    val titleRes = when (window.granularity) {
+        WindowGranularity.DAY -> when (relation) {
+            WindowRelation.CURRENT -> R.string.analytics_window_today
+            WindowRelation.PREVIOUS -> R.string.analytics_window_yesterday
+            WindowRelation.OLDER -> null
+        }
+        WindowGranularity.WEEK -> when (relation) {
+            WindowRelation.CURRENT -> R.string.analytics_window_this_week
+            WindowRelation.PREVIOUS -> R.string.analytics_window_last_week
+            WindowRelation.OLDER -> null
+        }
+        WindowGranularity.MONTH -> when (relation) {
+            WindowRelation.CURRENT -> R.string.analytics_window_this_month
+            WindowRelation.PREVIOUS -> R.string.analytics_window_last_month
+            WindowRelation.OLDER -> null
+        }
+        WindowGranularity.CUSTOM -> R.string.analytics_window_custom
+        WindowGranularity.LIFETIME -> R.string.analytics_window_lifetime
+    }
+    return titleRes?.let { stringResource(it) }
+        ?: WindowLabel.range(window, today).orEmpty()
+}
+
+/** The granularity chips, paired with their resolved label (#428 Half A — identity stays the enum). */
+private data class GranularityOption(val granularity: WindowGranularity, val label: String)
+
+@Composable
+private fun granularityOptions(): List<GranularityOption> = listOf(
+    GranularityOption(WindowGranularity.DAY, stringResource(R.string.analytics_granularity_day)),
+    GranularityOption(WindowGranularity.WEEK, stringResource(R.string.analytics_granularity_week)),
+    GranularityOption(WindowGranularity.MONTH, stringResource(R.string.analytics_granularity_month)),
+    GranularityOption(WindowGranularity.LIFETIME, stringResource(R.string.analytics_granularity_lifetime)),
+    GranularityOption(WindowGranularity.CUSTOM, stringResource(R.string.analytics_granularity_custom)),
+)
+
+/**
+ * The period control (#970 / brief §3.1) — a `‹ label ›` pager over a granularity chip row, replacing
+ * the old four-value segmented period selector.
+ *
+ * `›` is disabled at the current window (there is no data in the future to page into), `‹` for
+ * Lifetime (all time has nowhere to go). Tapping the centre label opens the range picker, as does the
+ * `Custom…` chip. Stateless and data-in/lambdas-out — every decision was made in the ViewModel.
+ */
+@Composable
+fun PeriodPager(
+    window: AnalyticsWindow,
+    today: LocalDate,
+    canStepBack: Boolean,
+    canStepForward: Boolean,
+    onStep: (Int) -> Unit,
+    onOpenPicker: () -> Unit,
+    onSelectGranularity: (WindowGranularity) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val c = AppTheme.colors
+    val title = windowTitle(window, today)
+    val range = WindowLabel.range(window, today)
+    val openPickerLabel = stringResource(R.string.analytics_window_open_picker)
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { onStep(-1) }, enabled = canStepBack) {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                    contentDescription = stringResource(R.string.analytics_window_previous),
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(onClickLabel = openPickerLabel, role = Role.Button) { onOpenPicker() },
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = c.text,
+                    textAlign = TextAlign.Center,
+                )
+                // Lifetime has no range, and an OLDER window already shows its range as the title —
+                // never print the same string twice.
+                if (range != null && range != title) {
+                    Text(
+                        text = range,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = c.text3,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+            IconButton(onClick = { onStep(1) }, enabled = canStepForward) {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = stringResource(R.string.analytics_window_next),
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        val options = granularityOptions()
+        val selectedLabel = options.first { it.granularity == window.granularity }.label
+        AppSegmented(
+            options = options.map { it.label },
+            selected = selectedLabel,
+            onSelect = { label ->
+                // Selection stays keyed off the enum (#428 Half A) — never a raw string comparison.
+                val picked = options.firstOrNull { it.label == label }?.granularity ?: return@AppSegmented
+                if (picked == WindowGranularity.CUSTOM) onOpenPicker() else onSelectGranularity(picked)
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/RangePickerSheet.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/RangePickerSheet.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
@@ -66,18 +65,23 @@ import java.util.Locale
  *
  * The earning dots reuse the same arbitrary-window per-day read the Money chart uses — no bespoke
  * query — so a dot and a bar can never disagree (Principle 5).
+ *
+ * Data-in / lambdas-out: the visible month and its per-day earnings are hoisted (the ViewModel owns
+ * them, since the dots are a repository read), and only the in-progress range selection is
+ * sheet-local — it must not touch the hub's window until the driver commits.
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun RangePickerSheet(
     window: AnalyticsWindow,
     today: LocalDate,
-    viewModel: AnalyticsViewModel,
+    month: YearMonth,
+    monthDays: List<DailyEarnings>,
+    onMonthChange: (YearMonth) -> Unit,
+    onPickPreset: (WindowGranularity, Int) -> Unit,
+    onCommitRange: (LocalDate, LocalDate) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val month by viewModel.pickerMonth.collectAsStateWithLifecycle()
-    val monthDays by viewModel.pickerMonthDays.collectAsStateWithLifecycle()
-
     // Selection is sheet-local until committed — opening the sheet never changes the hub's window.
     var pendingStart by remember { mutableStateOf(window.startDate) }
     var pendingEnd by remember { mutableStateOf(window.endDateInclusive) }
@@ -99,7 +103,7 @@ fun RangePickerSheet(
             Spacer(Modifier.height(8.dp))
             PresetRow(
                 onPick = { granularity, offset ->
-                    viewModel.setRelativeWindow(granularity, offset)
+                    onPickPreset(granularity, offset)
                     onDismiss()
                 },
             )
@@ -107,8 +111,8 @@ fun RangePickerSheet(
             Spacer(Modifier.height(20.dp))
             MonthHeader(
                 month = month,
-                onPrevious = { viewModel.setPickerMonth(month.minusMonths(1)) },
-                onNext = { viewModel.setPickerMonth(month.plusMonths(1)) },
+                onPrevious = { onMonthChange(month.minusMonths(1)) },
+                onNext = { onMonthChange(month.plusMonths(1)) },
                 canGoNext = month < YearMonth.from(today),
             )
             Spacer(Modifier.height(8.dp))
@@ -158,7 +162,7 @@ fun RangePickerSheet(
             Button(
                 onClick = {
                     if (start != null && end != null) {
-                        viewModel.setCustomRange(start, end)
+                        onCommitRange(start, end)
                         onDismiss()
                     }
                 },

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/RangePickerSheet.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/RangePickerSheet.kt
@@ -1,0 +1,362 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
+import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
+import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
+import cloud.trotter.dashbuddy.domain.format.formatMonthYear
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
+
+/**
+ * The range-picker bottom sheet (#970 / brief §3.2) — presets on top, a month-paged calendar below,
+ * and a commit button that **states the range it will show** (`Show Jul 13 – 19`).
+ *
+ * Calendar rules: weeks start Monday (the same pay-week anchor every aggregate uses), **future days
+ * are disabled** (there is nothing there to review), today carries an outline, a day the driver
+ * earned on carries a dot whose opacity tracks how much (brief §3.2), and tapping picks the range's
+ * start then its end (a second tap before the start re-anchors the start instead of drawing a
+ * backwards range).
+ *
+ * The earning dots reuse the same arbitrary-window per-day read the Money chart uses — no bespoke
+ * query — so a dot and a bar can never disagree (Principle 5).
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun RangePickerSheet(
+    window: AnalyticsWindow,
+    today: LocalDate,
+    viewModel: AnalyticsViewModel,
+    onDismiss: () -> Unit,
+) {
+    val month by viewModel.pickerMonth.collectAsStateWithLifecycle()
+    val monthDays by viewModel.pickerMonthDays.collectAsStateWithLifecycle()
+
+    // Selection is sheet-local until committed — opening the sheet never changes the hub's window.
+    var pendingStart by remember { mutableStateOf(window.startDate) }
+    var pendingEnd by remember { mutableStateOf(window.endDateInclusive) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = rememberModalBottomSheetState()) {
+        Column(Modifier.padding(horizontal = 16.dp).padding(bottom = 24.dp)) {
+            Text(
+                text = stringResource(R.string.analytics_picker_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = AppTheme.colors.text,
+            )
+            Spacer(Modifier.height(12.dp))
+
+            Text(
+                text = stringResource(R.string.analytics_picker_presets),
+                style = MaterialTheme.typography.labelMedium,
+                color = AppTheme.colors.text3,
+            )
+            Spacer(Modifier.height(8.dp))
+            PresetRow(
+                onPick = { granularity, offset ->
+                    viewModel.setRelativeWindow(granularity, offset)
+                    onDismiss()
+                },
+            )
+
+            Spacer(Modifier.height(20.dp))
+            MonthHeader(
+                month = month,
+                onPrevious = { viewModel.setPickerMonth(month.minusMonths(1)) },
+                onNext = { viewModel.setPickerMonth(month.plusMonths(1)) },
+                canGoNext = month < YearMonth.from(today),
+            )
+            Spacer(Modifier.height(8.dp))
+            WeekdayHeader()
+            MonthGrid(
+                month = month,
+                today = today,
+                days = monthDays,
+                selectionStart = pendingStart,
+                selectionEnd = pendingEnd,
+                onPick = { picked ->
+                    val start = pendingStart
+                    val end = pendingEnd
+                    when {
+                        // A completed range, or no range yet, starts a new one.
+                        start == null || end != null -> {
+                            pendingStart = picked
+                            pendingEnd = null
+                        }
+                        // A second tap before the anchor re-anchors rather than drawing backwards.
+                        picked.isBefore(start) -> pendingStart = picked
+                        else -> pendingEnd = picked
+                    }
+                },
+            )
+
+            Spacer(Modifier.height(10.dp))
+            Text(
+                text = stringResource(R.string.analytics_picker_dot_legend),
+                style = MaterialTheme.typography.bodySmall,
+                color = AppTheme.colors.text3,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = if (pendingStart == null || pendingEnd != null) {
+                    stringResource(R.string.analytics_picker_pick_start)
+                } else {
+                    stringResource(R.string.analytics_picker_pick_end)
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = AppTheme.colors.text3,
+            )
+
+            Spacer(Modifier.height(16.dp))
+            val start = pendingStart
+            val end = pendingEnd ?: pendingStart
+            Button(
+                onClick = {
+                    if (start != null && end != null) {
+                        viewModel.setCustomRange(start, end)
+                        onDismiss()
+                    }
+                },
+                enabled = start != null && end != null,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                val label = if (start != null && end != null) {
+                    WindowLabel.range(AnalyticsWindows.custom(start, end), today).orEmpty()
+                } else {
+                    ""
+                }
+                Text(stringResource(R.string.analytics_picker_show_format, label))
+            }
+        }
+    }
+}
+
+/** The §3.2 preset row — each chip is a relative selection, which is exactly what the pager persists. */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PresetRow(onPick: (WindowGranularity, Int) -> Unit) {
+    val presets = listOf(
+        Triple(stringResource(R.string.analytics_window_today), WindowGranularity.DAY, 0),
+        Triple(stringResource(R.string.analytics_window_yesterday), WindowGranularity.DAY, -1),
+        Triple(stringResource(R.string.analytics_window_this_week), WindowGranularity.WEEK, 0),
+        Triple(stringResource(R.string.analytics_window_last_week), WindowGranularity.WEEK, -1),
+        Triple(stringResource(R.string.analytics_window_this_month), WindowGranularity.MONTH, 0),
+        Triple(stringResource(R.string.analytics_window_last_month), WindowGranularity.MONTH, -1),
+        Triple(stringResource(R.string.analytics_window_lifetime), WindowGranularity.LIFETIME, 0),
+    )
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        presets.forEach { (label, granularity, offset) ->
+            AppChip(
+                text = label,
+                uppercase = false,
+                color = AppTheme.colors.accent,
+                container = AppTheme.colors.accentDim,
+                modifier = Modifier.clickable(role = Role.Button) { onPick(granularity, offset) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MonthHeader(
+    month: YearMonth,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    canGoNext: Boolean,
+) {
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = onPrevious) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = stringResource(R.string.analytics_picker_previous_month),
+            )
+        }
+        Text(
+            text = formatMonthYear(month),
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.titleSmall,
+            color = AppTheme.colors.text,
+            textAlign = TextAlign.Center,
+        )
+        IconButton(onClick = onNext, enabled = canGoNext) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = stringResource(R.string.analytics_picker_next_month),
+            )
+        }
+    }
+}
+
+/** Monday-first weekday initials — the same week anchor every aggregate uses. */
+@Composable
+private fun WeekdayHeader() {
+    Row(Modifier.fillMaxWidth()) {
+        MONDAY_FIRST_WEEK.forEach { day ->
+            Text(
+                text = day.getDisplayName(TextStyle.NARROW, Locale.getDefault()),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.labelSmall,
+                color = AppTheme.colors.text3,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+private val MONDAY_FIRST_WEEK = listOf(
+    DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+    DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY,
+)
+
+@Composable
+private fun MonthGrid(
+    month: YearMonth,
+    today: LocalDate,
+    days: List<DailyEarnings>,
+    selectionStart: LocalDate?,
+    selectionEnd: LocalDate?,
+    onPick: (LocalDate) -> Unit,
+) {
+    val grossByDay = remember(days) { days.associate { it.date to it.gross } }
+    val maxGross = remember(days) { days.maxOfOrNull { it.gross }?.takeIf { it > 0.0 } }
+    // Leading blanks so the 1st lands under its weekday (Monday-first).
+    val leading = month.atDay(1).dayOfWeek.value - DayOfWeek.MONDAY.value
+    val cells = leading + month.lengthOfMonth()
+    val rows = (cells + 6) / 7
+
+    Column(Modifier.fillMaxWidth()) {
+        repeat(rows) { row ->
+            Row(Modifier.fillMaxWidth()) {
+                repeat(7) { column ->
+                    val index = row * 7 + column
+                    val dayOfMonth = index - leading + 1
+                    if (dayOfMonth < 1 || dayOfMonth > month.lengthOfMonth()) {
+                        Box(Modifier.weight(1f).aspectRatio(1f))
+                    } else {
+                        val date = month.atDay(dayOfMonth)
+                        DayCell(
+                            date = date,
+                            isFuture = date.isAfter(today),
+                            isToday = date == today,
+                            inSelection = inSelection(date, selectionStart, selectionEnd),
+                            isSelectionEdge = date == selectionStart || date == selectionEnd,
+                            earningWeight = maxGross?.let { max ->
+                                (grossByDay[date] ?: 0.0).takeIf { it > 0.0 }?.let { (it / max) }
+                            },
+                            onPick = onPick,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun inSelection(date: LocalDate, start: LocalDate?, end: LocalDate?): Boolean {
+    if (start == null) return false
+    val last = end ?: start
+    return !date.isBefore(start) && !date.isAfter(last)
+}
+
+@Composable
+private fun DayCell(
+    date: LocalDate,
+    isFuture: Boolean,
+    isToday: Boolean,
+    inSelection: Boolean,
+    isSelectionEdge: Boolean,
+    earningWeight: Double?,
+    onPick: (LocalDate) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val c = AppTheme.colors
+    val container = when {
+        isSelectionEdge -> c.accent
+        inSelection -> c.accentDim
+        else -> null
+    }
+    Box(
+        modifier = modifier
+            .aspectRatio(1f)
+            .padding(2.dp)
+            .clip(CircleShape)
+            .let { if (container != null) it.background(container) else it }
+            .let { if (isFuture) it else it.clickable(role = Role.Button) { onPick(date) } },
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = date.dayOfMonth.toString(),
+                style = MaterialTheme.typography.bodySmall,
+                color = when {
+                    isFuture -> c.text3
+                    isSelectionEdge -> c.accentText
+                    isToday -> c.accent
+                    else -> c.text
+                },
+                modifier = if (isFuture) Modifier.alpha(0.4f) else Modifier,
+            )
+            // The earning dot: present only on a day with recorded gross, brighter the more was
+            // earned (floored so a small day is still visible rather than invisibly faint).
+            if (earningWeight != null) {
+                Spacer(Modifier.height(2.dp))
+                Box(
+                    Modifier
+                        .size(4.dp)
+                        .clip(CircleShape)
+                        .alpha((0.35f + 0.65f * earningWeight.toFloat()).coerceIn(0f, 1f))
+                        .background(if (isSelectionEdge) c.accentText else c.good),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/RecapHero.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/RecapHero.kt
@@ -1,0 +1,219 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSparkline
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
+import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
+import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatDuration
+import java.time.LocalDate
+
+/**
+ * Pure copy logic for the recap hero (#970 / brief §3.3) — Compose-free so the comparison rules are
+ * unit-testable away from rendering (the [WaterfallModel] precedent).
+ *
+ * The rules exist to keep §9's honesty bar: a delta is only stated when there is something real to
+ * compare against. No previous window (Lifetime) says so; a previous window that earned nothing gets
+ * a worded statement rather than a divide-by-zero percentage; a sub-half-percent move reads as
+ * "the same" rather than as a spurious `▲ 0%`.
+ */
+object RecapModel {
+
+    /** Below this a money figure is effectively zero — the same threshold the hub's callouts use. */
+    private const val MONEY_EPSILON = UNATTRIBUTED_EPSILON
+
+    /** Below this magnitude a relative move is noise, not a trend. */
+    private const val FLAT_FRACTION = 0.005
+
+    enum class Direction {
+        /** There is no previous equivalent window (Lifetime) — state that, compare nothing. */
+        NONE,
+
+        /** The previous window earned (effectively) nothing, so a percentage would divide by zero. */
+        FROM_ZERO,
+
+        /** Materially unchanged. */
+        FLAT,
+        UP,
+        DOWN,
+    }
+
+    /** [fraction] is the signed relative change, present only for [Direction.UP]/[Direction.DOWN]. */
+    data class Delta(val direction: Direction, val fraction: Double?)
+
+    /**
+     * The delta of [currentNet] against [previousNet] (the previous equivalent window's frozen net).
+     * A null [previousNet] means "no such window".
+     */
+    fun delta(currentNet: Double, previousNet: Double?): Delta {
+        if (previousNet == null) return Delta(Direction.NONE, null)
+        if (kotlin.math.abs(previousNet) < MONEY_EPSILON) {
+            return if (kotlin.math.abs(currentNet) < MONEY_EPSILON) {
+                Delta(Direction.FLAT, null)
+            } else {
+                Delta(Direction.FROM_ZERO, null)
+            }
+        }
+        val fraction = (currentNet - previousNet) / kotlin.math.abs(previousNet)
+        return when {
+            fraction > FLAT_FRACTION -> Delta(Direction.UP, fraction)
+            fraction < -FLAT_FRACTION -> Delta(Direction.DOWN, fraction)
+            else -> Delta(Direction.FLAT, null)
+        }
+    }
+
+    /** True when the window recorded nothing at all — the hero says so instead of printing zeros. */
+    fun isEmpty(economics: PeriodEconomics): Boolean =
+        economics.totals.deliveries == 0 &&
+            economics.totals.onlineDuration == 0L &&
+            kotlin.math.abs(economics.grossEarnings) < MONEY_EPSILON
+}
+
+/**
+ * The recap hero (#970 / brief §3.3) — the window's **kept** money, its delta against the previous
+ * equivalent window, a per-day net sparkline, and one factual summary line. Sits above the tabs, so
+ * every tab is read as a detail view of this one window.
+ *
+ * Copy discipline (§9): the headline is net and is labelled as **frozen** at decision-time costs; the
+ * summary line states measured facts (gross, deliveries, online time, acceptance) and makes no
+ * projection; a delta is stated only when a real previous window exists.
+ *
+ * Stateless and data-in — no clock: every figure here is a settled historical value (Reactive UI
+ * rule 1's "would the dasher believe a stale value?" is answered by the fact that none of these tick).
+ */
+@Composable
+fun RecapHero(
+    window: AnalyticsWindow,
+    today: LocalDate,
+    economics: PeriodEconomics,
+    previousEconomics: PeriodEconomics?,
+    decisions: DecisionEconomics,
+    dailyEarnings: List<DailyEarnings>,
+    modifier: Modifier = Modifier,
+) {
+    val c = AppTheme.colors
+    val netColor = if (economics.netProfit >= 0.0) c.good else c.bad
+
+    AppCard(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.analytics_hero_kept_label),
+            style = MaterialTheme.typography.labelMedium,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(text = Formats.money(economics.netProfit), style = AppTheme.num.heroNum, color = netColor)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = deltaText(window, today, economics, previousEconomics),
+            style = MaterialTheme.typography.bodySmall,
+            color = deltaColor(economics, previousEconomics),
+        )
+
+        // Sparkline of KEPT money per day (§7.3) — hidden when the window has no meaningful day axis
+        // (a single day, Lifetime, or an over-long custom span all return an empty list).
+        if (dailyEarnings.size >= 2) {
+            Spacer(Modifier.height(10.dp))
+            AppSparkline(values = dailyEarnings.map { it.net }, color = c.accent)
+        }
+
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = summaryLine(economics, decisions),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text2,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.analytics_hero_frozen_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+    }
+}
+
+@Composable
+private fun deltaColor(economics: PeriodEconomics, previous: PeriodEconomics?) =
+    when (RecapModel.delta(economics.netProfit, previous?.netProfit).direction) {
+        RecapModel.Direction.UP, RecapModel.Direction.FROM_ZERO -> AppTheme.colors.good
+        RecapModel.Direction.DOWN -> AppTheme.colors.bad
+        RecapModel.Direction.FLAT, RecapModel.Direction.NONE -> AppTheme.colors.text3
+    }
+
+/** "▲ 12% vs Jul 6 – 12" and friends — the previous window is named by its RANGE, never by a guess. */
+@Composable
+private fun deltaText(
+    window: AnalyticsWindow,
+    today: LocalDate,
+    economics: PeriodEconomics,
+    previous: PeriodEconomics?,
+): String {
+    val delta = RecapModel.delta(economics.netProfit, previous?.netProfit)
+    val previousLabel = AnalyticsWindows.previous(window)
+        ?.let { WindowLabel.range(it, today) }
+        ?: return stringResource(R.string.analytics_hero_delta_none)
+    return when (delta.direction) {
+        RecapModel.Direction.NONE -> stringResource(R.string.analytics_hero_delta_none)
+        RecapModel.Direction.FROM_ZERO ->
+            stringResource(R.string.analytics_hero_delta_from_nothing_format, previousLabel)
+        RecapModel.Direction.FLAT ->
+            stringResource(R.string.analytics_hero_delta_flat_format, previousLabel)
+        RecapModel.Direction.UP -> stringResource(
+            R.string.analytics_hero_delta_up_format,
+            Formats.percent(delta.fraction ?: 0.0),
+            previousLabel,
+        )
+        RecapModel.Direction.DOWN -> stringResource(
+            R.string.analytics_hero_delta_down_format,
+            Formats.percent(kotlin.math.abs(delta.fraction ?: 0.0)),
+            previousLabel,
+        )
+    }
+}
+
+/** "$412.83 gross · 47 deliveries · 15h 49m online · 37% acceptance" — measured facts only. */
+@Composable
+private fun summaryLine(economics: PeriodEconomics, decisions: DecisionEconomics): String {
+    if (RecapModel.isEmpty(economics)) return stringResource(R.string.analytics_hero_no_data)
+    val deliveryWord = if (economics.totals.deliveries == 1) {
+        stringResource(R.string.time_tab_delivery_singular)
+    } else {
+        stringResource(R.string.time_tab_delivery_plural)
+    }
+    val parts = buildList {
+        add(stringResource(R.string.analytics_hero_summary_gross_format, Formats.money(economics.grossEarnings)))
+        add(
+            stringResource(
+                R.string.analytics_hero_summary_deliveries_format,
+                Formats.commaInt(economics.totals.deliveries),
+                deliveryWord,
+            ),
+        )
+        if (economics.totals.onlineDuration > 0L) {
+            add(
+                stringResource(
+                    R.string.analytics_hero_summary_online_format,
+                    formatDuration(economics.totals.onlineDuration),
+                ),
+            )
+        }
+        decisions.acceptanceRate?.let {
+            add(stringResource(R.string.analytics_hero_summary_acceptance_format, Formats.percent(it)))
+        }
+    }
+    return parts.joinToString(stringResource(R.string.analytics_hero_summary_separator))
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -22,8 +22,7 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppStackBar
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
-import cloud.trotter.dashbuddy.core.data.analytics.PeriodBounds
-import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.export.IrsMileage
 import cloud.trotter.dashbuddy.domain.format.Formats
@@ -49,14 +48,14 @@ import kotlin.math.roundToLong
 @Composable
 fun TimeTab(
     time: TimeEconomics,
-    period: AnalyticsPeriod,
+    window: AnalyticsWindow,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         TimeSplitCard(time)
         DeadheadCard(time)
         OnTimeCard(time)
-        MileageTaxCard(time, period)
+        MileageTaxCard(time, window)
     }
 }
 
@@ -201,7 +200,7 @@ private fun OnTimeCard(time: TimeEconomics) {
 
 /** Mileage & tax: the period's session odometer miles + the estimated IRS standard-mileage deduction. */
 @Composable
-private fun MileageTaxCard(time: TimeEconomics, period: AnalyticsPeriod) {
+private fun MileageTaxCard(time: TimeEconomics, window: AnalyticsWindow) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(text = stringResource(R.string.time_tab_mileage_tax_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
@@ -216,7 +215,7 @@ private fun MileageTaxCard(time: TimeEconomics, period: AnalyticsPeriod) {
             miles = time.miles,
             nowMillis = System.currentTimeMillis(),
             zone = ZoneId.systemDefault(),
-            period = period,
+            window = window,
         )
 
         Text(text = "${Formats.decimal(time.miles, 1)} mi", style = AppTheme.num.heroNum, color = c.text)
@@ -241,36 +240,48 @@ private fun MileageTaxCard(time: TimeEconomics, period: AnalyticsPeriod) {
 
 /**
  * Pure copy logic for the MILEAGE & TAX card (#689) — Compose-free so it's unit-testable in
- * isolation from rendering (the [WaterfallModel] precedent). Today and This-Month are single-year
- * by construction, but the Monday-anchored week straddles Jan 1 whenever New Year's Day falls
- * Tue–Sun, and Lifetime can span any boundary — so the spans-years check derives from the period's
- * actual [PeriodBounds] window (the bounds SSOT), not from the enum.
+ * isolation from rendering (the [WaterfallModel] precedent). A single day or a calendar month is
+ * single-year by construction, but the Monday-anchored week straddles Jan 1 whenever New Year's Day
+ * falls Tue–Sun, a driver-drawn custom range can straddle anything, and Lifetime can span any
+ * boundary — so the spans-years check derives from the selected [AnalyticsWindow]'s own endpoints
+ * (the window SSOT), never from a granularity guess.
  *
- * Locked policy: label the deduction with the **current** year's rate via the [IrsMileage] lookup
- * (never a literal year/rate); the fallback policy and disclaimer copy are [IrsMileage.effectiveRate]
- * / [IrsMileage.fallbackNote] (one owner — the CSV renders the identical note). A period that spans
- * tax years gets a note pointing at the CSV export (which owns the per-year precision) — cheap
- * honesty over re-costing every row here.
+ * **Rate year (#970):** the deduction is labelled with the year the *window* falls in, not the
+ * device's current year. Before the pager existed every window was the current one, so reading the
+ * clock was the same answer; once a driver can page back to last December, quoting this year's rate
+ * over last year's miles would be a wrong number with a confident label. An unbounded (Lifetime) or
+ * year-straddling window falls back to the current year AND carries the spans-years note, which
+ * points at the CSV export (which owns the per-year precision) — cheap honesty over re-costing every
+ * row here.
+ *
+ * Locked policy: the rate itself always comes from the [IrsMileage] lookup (never a literal
+ * year/rate); the fallback policy and disclaimer copy are [IrsMileage.effectiveRate] /
+ * [IrsMileage.fallbackNote] (one owner — the CSV renders the identical note).
  */
 object MileageTaxModel {
 
     data class Labels(
         /** "$X.XX est. IRS <year> standard-mileage deduction ($0.725/mi)". */
         val deductionLine: String,
-        /** Non-null only when the current year has no rate in the table — [IrsMileage.fallbackNote]. */
+        /** Non-null only when the labelled year has no rate in the table — [IrsMileage.fallbackNote]. */
         val disclaimer: String?,
-        /** Non-null when the period's window spans (Lifetime: may span) a tax-year boundary. */
+        /** Non-null when the window spans (Lifetime: may span) a tax-year boundary. */
         val spansYearsNote: String?,
     )
 
-    fun from(miles: Double, nowMillis: Long, zone: ZoneId, period: AnalyticsPeriod): Labels {
-        val year = Instant.ofEpochMilli(nowMillis).atZone(zone).year
+    fun from(miles: Double, nowMillis: Long, zone: ZoneId, window: AnalyticsWindow): Labels {
+        val currentYear = Instant.ofEpochMilli(nowMillis).atZone(zone).year
+        val startYear = window.startDate?.year
+        val endYear = window.endDateInclusive?.year
+        val spansYears = startYear == null || endYear == null || startYear != endYear
+        // A window wholly inside one year is labelled with THAT year's rate; anything ambiguous falls
+        // back to the current year and says so.
+        val year = if (spansYears) currentYear else startYear
         val deductionLine = "${Formats.money(IrsMileage.deduction(miles, year))} " +
             "est. IRS $year standard-mileage deduction (${Formats.money3(IrsMileage.effectiveRate(year))}/mi)"
         val spansYearsNote = when {
-            period == AnalyticsPeriod.LIFETIME -> "may span tax years — see the CSV export for per-year figures"
-            Instant.ofEpochMilli(PeriodBounds.of(period, nowMillis, zone).start).atZone(zone).year != year ->
-                "spans tax years — see the CSV export for per-year figures"
+            window.isLifetime -> "may span tax years — see the CSV export for per-year figures"
+            spansYears -> "spans tax years — see the CSV export for per-year figures"
             else -> null
         }
         return Labels(deductionLine, IrsMileage.fallbackNote(year), spansYearsNote)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -549,4 +549,47 @@
     <string name="analytics_tab_patterns">Patterns</string>
     <string name="analytics_tab_decisions">Decisions</string>
     <string name="analytics_tab_time">Time</string>
+
+    <!-- ui/main/analytics/PeriodPager.kt — the #970 period-first pager + range picker -->
+    <string name="analytics_window_today">Today</string>
+    <string name="analytics_window_yesterday">Yesterday</string>
+    <string name="analytics_window_this_week">This week</string>
+    <string name="analytics_window_last_week">Last week</string>
+    <string name="analytics_window_this_month">This month</string>
+    <string name="analytics_window_last_month">Last month</string>
+    <string name="analytics_window_lifetime">Lifetime</string>
+    <string name="analytics_window_custom">Custom range</string>
+    <string name="analytics_granularity_day">Day</string>
+    <string name="analytics_granularity_week">Week</string>
+    <string name="analytics_granularity_month">Month</string>
+    <string name="analytics_granularity_lifetime">Lifetime</string>
+    <string name="analytics_granularity_custom">Custom…</string>
+    <string name="analytics_window_previous">Previous window</string>
+    <string name="analytics_window_next">Next window</string>
+    <string name="analytics_window_open_picker">Choose a date range</string>
+    <string name="analytics_picker_title">Pick a range</string>
+    <string name="analytics_picker_presets">Quick picks</string>
+    <string name="analytics_picker_show_format">Show %1$s</string>
+    <string name="analytics_picker_show_lifetime">Show everything</string>
+    <string name="analytics_picker_pick_start">Tap a day to start the range</string>
+    <string name="analytics_picker_pick_end">Tap another day to end the range</string>
+    <string name="analytics_picker_previous_month">Previous month</string>
+    <string name="analytics_picker_next_month">Next month</string>
+    <string name="analytics_picker_dot_legend">A dot marks a day you earned</string>
+
+    <!-- ui/main/analytics/RecapHero.kt — the #970 recap hero above the tabs -->
+    <string name="analytics_hero_kept_label">You kept</string>
+    <string name="analytics_hero_frozen_note">Net is frozen at the costs in effect when you accepted each offer</string>
+    <string name="analytics_hero_delta_up_format">▲ %1$s vs %2$s</string>
+    <string name="analytics_hero_delta_down_format">▼ %1$s vs %2$s</string>
+    <string name="analytics_hero_delta_flat_format">Same as %1$s</string>
+    <string name="analytics_hero_delta_none">No earlier window to compare</string>
+    <string name="analytics_hero_delta_from_nothing_format">Up from nothing in %1$s</string>
+    <string name="analytics_hero_previous_window">the window before</string>
+    <string name="analytics_hero_summary_gross_format">%1$s gross</string>
+    <string name="analytics_hero_summary_deliveries_format">%1$s %2$s</string>
+    <string name="analytics_hero_summary_online_format">%1$s online</string>
+    <string name="analytics_hero_summary_acceptance_format">%1$s acceptance</string>
+    <string name="analytics_hero_summary_separator"> · </string>
+    <string name="analytics_hero_no_data">Nothing recorded in this window</string>
 </resources>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -1,7 +1,10 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
-import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindowSelection
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
@@ -11,71 +14,110 @@ import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
+import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.time.ZoneId
 
 /**
- * #315 H1 — the Analytics hub ViewModel exposes the read-model economics for the selected
- * period (default [AnalyticsPeriod.THIS_WEEK], switchable via [AnalyticsViewModel.setPeriod])
- * on the selected tab (default [AnalyticsTab.Money], switchable via [AnalyticsViewModel.setTab]),
- * strictly over the existing repository surface. Same stub-flow pattern as DashboardViewModelTest.
+ * #315 H1 / #970 — the Analytics hub ViewModel exposes the read-model economics for the selected
+ * **window** (default: the current pay week, paged by `stepWindow` and re-shaped by
+ * `setGranularity`/`setCustomRange`) on the selected tab (default [AnalyticsTab.Money], switchable
+ * via [AnalyticsViewModel.setTab]), strictly over the existing repository surface.
+ *
+ * The window selection round-trips through [AppPreferencesRepository] — the mock's setter writes
+ * into the same flow its getter exposes, which is exactly the DataStore-is-SSOT contract the
+ * ViewModel relies on (it holds no local copy). Same stub-flow pattern as DashboardViewModelTest.
+ *
+ * **Settle with `runCurrent()`, never `advanceUntilIdle()`.** The ViewModel resolves its window
+ * against the local-date flow, which — like `periodBoundariesFlow` — emits and then sleeps until the
+ * next local midnight, forever. Under a `StandardTestDispatcher` that delay is *virtual*, so
+ * `advanceUntilIdle()` advances the clock past midnight, gets another emission, and never runs out
+ * of work (it hangs the suite; a 15-minute CI timeout was the receipt). `runCurrent()` drains
+ * everything scheduled at the current instant — which is every real emission — and leaves the
+ * midnight re-anchor pending where it belongs.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class AnalyticsViewModelTest {
 
     private val analyticsRepository: AnalyticsRepository = mock()
     private val correctionRepository: cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository = mock()
+    private val appPreferencesRepository: AppPreferencesRepository = mock()
 
-    /**
-     * The Patterns-tab sources (#315 H5) are LIFETIME-scoped and collected unconditionally in the
-     * combine, so every test must supply them or the combine folds a null Flow. They're period-
-     * independent, so a single default stub covers all tests (the Patterns behavior has its own
-     * repository/domain tests).
-     */
+    /** The persisted selection, round-tripped by the mocked prefs repository. */
+    private val selectionFlow = MutableStateFlow(AnalyticsWindowSelection.DEFAULT)
+
+    /** Per-window economics the stubbed repository serves; anything unlisted reads EMPTY. */
+    private val economicsByWindow = mutableMapOf<AnalyticsWindow, PeriodEconomics>()
+
+    /** Per-window top stores; anything unlisted reads empty. */
+    private val storesByWindow = mutableMapOf<AnalyticsWindow, List<StoreEconomics>>()
+
+    private var decisions: DecisionEconomics = DecisionEconomics.EMPTY
+    private var dailyEarnings: List<DailyEarnings> = emptyList()
+
+    private val today: LocalDate get() = LocalDate.now()
+
+    /** Every repository read the VM collects is window-shaped now, so one stub block covers them all. */
     @Before
-    fun stubPatternsSources() {
+    fun stubRepositories() {
+        whenever(appPreferencesRepository.analyticsWindow).thenReturn(selectionFlow)
+        // The setter writes into the SAME flow the getter exposes — the DataStore-is-SSOT contract
+        // the ViewModel depends on (it keeps no local copy of the selection).
+        whenever(runBlocking { appPreferencesRepository.setAnalyticsWindow(any()) }).thenAnswer { invocation ->
+            selectionFlow.value = invocation.getArgument(0)
+            Unit
+        }
+
+        whenever(analyticsRepository.periodEconomics(any<AnalyticsWindow>(), anyOrNull(), any<ZoneId>()))
+            .thenAnswer { invocation ->
+                flowOf(economicsByWindow[invocation.getArgument<AnalyticsWindow>(0)] ?: PeriodEconomics.EMPTY)
+            }
+        whenever(analyticsRepository.perStoreEconomics(any<AnalyticsWindow>(), any<ZoneId>()))
+            .thenAnswer { invocation ->
+                flowOf(storesByWindow[invocation.getArgument<AnalyticsWindow>(0)] ?: emptyList<StoreEconomics>())
+            }
+        whenever(analyticsRepository.decisionEconomics(any<AnalyticsWindow>(), any<ZoneId>()))
+            .thenAnswer { flowOf(decisions) }
+        whenever(analyticsRepository.timeEconomics(any<AnalyticsWindow>(), any<ZoneId>()))
+            .thenReturn(flowOf(TimeEconomics.EMPTY))
+        whenever(analyticsRepository.dailyEarnings(any<AnalyticsWindow>(), any<ZoneId>()))
+            .thenAnswer { flowOf(dailyEarnings) }
+        whenever(analyticsRepository.noSessionDeliveries(any<AnalyticsWindow>(), any<ZoneId>()))
+            .thenReturn(flowOf(emptyList()))
+        whenever(analyticsRepository.orphanOfferGroups(any<AnalyticsWindow>(), any<ZoneId>()))
+            .thenReturn(flowOf(emptyList()))
+        whenever(analyticsRepository.recentSessions(any())).thenReturn(flowOf(emptyList()))
+        // The Patterns-tab sources (#315 H5) are LIFETIME-scoped and collected unconditionally in
+        // the combine, so they must always be stubbed or the combine folds a null Flow.
         whenever(analyticsRepository.storeReportCards()).thenReturn(flowOf(emptyList<StoreReportCard>()))
         whenever(analyticsRepository.earningsHeatmap(anyOrNull())).thenReturn(flowOf(EarningsHeatmap.EMPTY))
     }
 
-    private fun stubPeriod(
-        period: AnalyticsPeriod,
-        economics: PeriodEconomics,
-        stores: List<StoreEconomics> = emptyList(),
-        decisions: DecisionEconomics = DecisionEconomics.EMPTY,
-        time: TimeEconomics = TimeEconomics.EMPTY,
-        dailyEarnings: List<DailyEarnings> = emptyList(),
-    ) {
-        whenever(analyticsRepository.periodEconomics(eq(period), anyOrNull())).thenReturn(flowOf(economics))
-        whenever(analyticsRepository.perStoreEconomics(eq(period))).thenReturn(flowOf(stores))
-        // The VM collects decisions + time + dailyEarnings unconditionally (see AnalyticsViewModel), so
-        // every period stub must supply all three flows or the combine would fold a null.
-        whenever(analyticsRepository.decisionEconomics(eq(period))).thenReturn(flowOf(decisions))
-        whenever(analyticsRepository.timeEconomics(eq(period))).thenReturn(flowOf(time))
-        whenever(analyticsRepository.dailyEarnings(eq(period), anyOrNull())).thenReturn(flowOf(dailyEarnings))
-        // The VM also collects the "(No session)" orphan list per period (#660 piece 2) in the same
-        // combine, so it must be stubbed or the combine folds a null Flow.
-        whenever(analyticsRepository.noSessionDeliveries(eq(period))).thenReturn(flowOf(emptyList()))
-        // The orphan-OFFER groups (#810 B2 Tier 2) ride the same 5th-slot sub-combine — stub too.
-        whenever(analyticsRepository.orphanOfferGroups(eq(period))).thenReturn(flowOf(emptyList()))
-    }
+    private fun currentWeek() = AnalyticsWindows.current(WindowGranularity.WEEK, today)
+    private fun lastWeek() = AnalyticsWindows.step(currentWeek(), -1)
+    private fun currentMonth() = AnalyticsWindows.current(WindowGranularity.MONTH, today)
 
     private fun decisions(accepted: Int, declined: Int, timedOut: Int, acceptanceRate: Double?) =
         DecisionEconomics(
@@ -134,27 +176,26 @@ class AnalyticsViewModelTest {
         offersDeclined = 2, offersTimeout = 0,
     )
 
-    private fun buildViewModel() = AnalyticsViewModel(analyticsRepository, correctionRepository)
+    private fun buildViewModel() =
+        AnalyticsViewModel(analyticsRepository, correctionRepository, appPreferencesRepository)
 
     @After
     fun tearDown() = Dispatchers.resetMain()
 
     @Test
-    fun `defaults to THIS_WEEK on the Money tab and maps the read-model into state`() = runTest {
+    fun `defaults to the current pay week on the Money tab and maps the read-model into state`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        stubPeriod(
-            AnalyticsPeriod.THIS_WEEK,
-            economics(net = 312.0, netPerHour = 24.0),
-            stores = listOf(store("H-E-B", 120.0, 5), store("Chili's", 40.0, 2)),
-        )
+        economicsByWindow[currentWeek()] = economics(net = 312.0, netPerHour = 24.0)
+        storesByWindow[currentWeek()] = listOf(store("H-E-B", 120.0, 5), store("Chili's", 40.0, 2))
         stubSessions(listOf(session("s1", 90.0), session("s2", null)))
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
-        testScheduler.advanceUntilIdle()
+        testScheduler.runCurrent()
 
         val ui = viewModel.uiState.value
-        assertEquals(AnalyticsPeriod.THIS_WEEK, ui.selectedPeriod)
+        assertEquals(currentWeek(), ui.window)
+        assertEquals(WindowGranularity.WEEK, ui.window.granularity)
         assertEquals(AnalyticsTab.Money, ui.selectedTab)
         assertEquals(312.0, ui.economics.netProfit, 1e-9)
         assertEquals(2, ui.topStores.size)
@@ -162,51 +203,185 @@ class AnalyticsViewModelTest {
         job.cancel()
     }
 
+    /** The `›` arrow must be dead at the current window and live once the pager has moved back. */
     @Test
-    fun `setPeriod re-anchors economics and top stores to the selected window`() = runTest {
+    fun `forward paging is disabled at the current window and enabled after stepping back`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        stubPeriod(AnalyticsPeriod.THIS_WEEK, economics(net = 312.0, netPerHour = 24.0), stores = listOf(store("H-E-B", 120.0, 5)))
-        stubPeriod(AnalyticsPeriod.THIS_MONTH, economics(net = 1280.0, netPerHour = 22.0), stores = listOf(store("Target", 400.0, 12)))
-        stubSessions(emptyList())
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.runCurrent()
+
+        assertTrue(viewModel.uiState.value.canStepBack)
+        assertFalse(viewModel.uiState.value.canStepForward)
+
+        viewModel.stepWindow(-1)
+        testScheduler.runCurrent()
+
+        assertEquals(lastWeek(), viewModel.uiState.value.window)
+        assertTrue(viewModel.uiState.value.canStepForward)
+        job.cancel()
+    }
+
+    /** A forward step at the current window is a fail-closed no-op — never a future range. */
+    @Test
+    fun `stepping forward at the current window is ignored`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.runCurrent()
+
+        viewModel.stepWindow(1)
+        testScheduler.runCurrent()
+
+        assertEquals(currentWeek(), viewModel.uiState.value.window)
+        assertEquals(AnalyticsWindowSelection.Relative(WindowGranularity.WEEK, 0), selectionFlow.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `stepWindow re-anchors economics and top stores to the paged window`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        economicsByWindow[currentWeek()] = economics(net = 312.0, netPerHour = 24.0)
+        storesByWindow[currentWeek()] = listOf(store("H-E-B", 120.0, 5))
+        economicsByWindow[lastWeek()] = economics(net = 1280.0, netPerHour = 22.0)
+        storesByWindow[lastWeek()] = listOf(store("Target", 400.0, 12))
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
-        testScheduler.advanceUntilIdle()
+        testScheduler.runCurrent()
         assertEquals(312.0, viewModel.uiState.value.economics.netProfit, 1e-9)
 
-        viewModel.setPeriod(AnalyticsPeriod.THIS_MONTH)
-        testScheduler.advanceUntilIdle()
+        viewModel.stepWindow(-1)
+        testScheduler.runCurrent()
 
         val ui = viewModel.uiState.value
-        assertEquals(AnalyticsPeriod.THIS_MONTH, ui.selectedPeriod)
+        assertEquals(lastWeek(), ui.window)
         assertEquals(1280.0, ui.economics.netProfit, 1e-9)
         assertEquals("Target", ui.topStores.single().storeName)
         job.cancel()
     }
 
     @Test
-    fun `setTab switches to Decisions and the decision read-model is present in state`() = runTest {
+    fun `setGranularity switches to the current window of that granularity`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        stubPeriod(
-            AnalyticsPeriod.THIS_WEEK,
-            economics(net = 100.0, netPerHour = 20.0),
-            decisions = decisions(accepted = 3, declined = 5, timedOut = 2, acceptanceRate = 0.3),
-        )
-        stubSessions(emptyList())
+        economicsByWindow[currentMonth()] = economics(net = 2100.0, netPerHour = 21.0)
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
-        testScheduler.advanceUntilIdle()
+        testScheduler.runCurrent()
+
+        viewModel.setGranularity(WindowGranularity.MONTH)
+        testScheduler.runCurrent()
+
+        val ui = viewModel.uiState.value
+        assertEquals(currentMonth(), ui.window)
+        assertEquals(2100.0, ui.economics.netProfit, 1e-9)
+        // Landing on a granularity always lands on ITS current window, so forward stays disabled.
+        assertFalse(ui.canStepForward)
+        job.cancel()
+    }
+
+    /** A committed calendar range persists as an absolute CUSTOM selection. */
+    @Test
+    fun `setCustomRange commits an absolute window and persists it`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val start = today.minusDays(10)
+        val end = today.minusDays(4)
+        economicsByWindow[AnalyticsWindows.custom(start, end)] = economics(net = 77.0, netPerHour = 11.0)
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.runCurrent()
+
+        viewModel.setCustomRange(start, end)
+        testScheduler.runCurrent()
+
+        val ui = viewModel.uiState.value
+        assertEquals(WindowGranularity.CUSTOM, ui.window.granularity)
+        assertEquals(start, ui.window.startDate)
+        assertEquals(end, ui.window.endDateInclusive)
+        assertEquals(77.0, ui.economics.netProfit, 1e-9)
+        assertEquals(AnalyticsWindowSelection.Custom(start, end), selectionFlow.value)
+        job.cancel()
+    }
+
+    /** A persisted selection is restored on construction — the across-restart half of the contract. */
+    @Test
+    fun `a persisted selection is restored instead of the default`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        selectionFlow.value = AnalyticsWindowSelection.Relative(WindowGranularity.WEEK, -2)
+        val twoWeeksBack = AnalyticsWindows.step(currentWeek(), -2)
+        economicsByWindow[twoWeeksBack] = economics(net = 42.0, netPerHour = 9.0)
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.runCurrent()
+
+        val ui = viewModel.uiState.value
+        assertEquals(twoWeeksBack, ui.window)
+        assertEquals(42.0, ui.economics.netProfit, 1e-9)
+        job.cancel()
+    }
+
+    /** The recap hero's delta source: the previous equivalent window's economics ride the same fan-out. */
+    @Test
+    fun `previous-window economics are exposed for the delta chip`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        economicsByWindow[currentWeek()] = economics(net = 300.0, netPerHour = 20.0)
+        economicsByWindow[lastWeek()] = economics(net = 200.0, netPerHour = 15.0)
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.runCurrent()
+
+        val ui = viewModel.uiState.value
+        assertEquals(300.0, ui.economics.netProfit, 1e-9)
+        assertEquals(200.0, ui.previousEconomics!!.netProfit, 1e-9)
+        job.cancel()
+    }
+
+    /** Lifetime has no predecessor, so the hero must get a null rather than a fabricated comparison. */
+    @Test
+    fun `lifetime exposes no previous-window economics`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        economicsByWindow[AnalyticsWindows.LIFETIME] = economics(net = 9000.0, netPerHour = 19.0)
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.runCurrent()
+
+        viewModel.setGranularity(WindowGranularity.LIFETIME)
+        testScheduler.runCurrent()
+
+        val ui = viewModel.uiState.value
+        assertTrue(ui.window.isLifetime)
+        assertEquals(9000.0, ui.economics.netProfit, 1e-9)
+        assertNull(ui.previousEconomics)
+        // Lifetime pages nowhere in either direction.
+        assertFalse(ui.canStepBack)
+        assertFalse(ui.canStepForward)
+        job.cancel()
+    }
+
+    @Test
+    fun `setTab switches to Decisions and the decision read-model is present in state`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        economicsByWindow[currentWeek()] = economics(net = 100.0, netPerHour = 20.0)
+        decisions = decisions(accepted = 3, declined = 5, timedOut = 2, acceptanceRate = 0.3)
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.runCurrent()
 
         // Decisions are collected unconditionally, so they're in state even before the tab switch.
         assertEquals(3, viewModel.uiState.value.decisions.accepted)
 
         viewModel.setTab(AnalyticsTab.Decisions)
-        testScheduler.advanceUntilIdle()
+        testScheduler.runCurrent()
 
         val ui = viewModel.uiState.value
         assertEquals(AnalyticsTab.Decisions, ui.selectedTab)
-        assertEquals(AnalyticsPeriod.THIS_WEEK, ui.selectedPeriod)
+        assertEquals(currentWeek(), ui.window)
         assertEquals(10, ui.decisions.received)
         assertEquals(5, ui.decisions.declined)
         assertEquals(0.3, ui.decisions.acceptanceRate!!, 1e-9)
@@ -217,8 +392,6 @@ class AnalyticsViewModelTest {
     @Test
     fun `patterns-tab sources (store cards + heatmap) are wired into state`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        stubPeriod(AnalyticsPeriod.THIS_WEEK, economics(net = 100.0, netPerHour = 20.0))
-        stubSessions(emptyList())
         // Override the @Before defaults with NON-DEFAULT values so the assertion is falsifiable — an
         // empty stub would equal the UiState defaults and prove nothing about the wiring.
         val heatmap = EarningsHeatmap.EMPTY.copy(minCoverageHours = 0.75)
@@ -228,7 +401,7 @@ class AnalyticsViewModelTest {
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
-        testScheduler.advanceUntilIdle()
+        testScheduler.runCurrent()
 
         val ui = viewModel.uiState.value
         assertEquals("Wendys", ui.storeReportCards.single().chainDisplay)
@@ -239,12 +412,10 @@ class AnalyticsViewModelTest {
     @Test
     fun `empty read-model maps to a safe zero-state`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        stubPeriod(AnalyticsPeriod.THIS_WEEK, PeriodEconomics.EMPTY, stores = emptyList())
-        stubSessions(emptyList())
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
-        testScheduler.advanceUntilIdle()
+        testScheduler.runCurrent()
 
         val ui = viewModel.uiState.value
         assertEquals(0.0, ui.economics.netProfit, 1e-9)

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
+import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
@@ -17,12 +18,14 @@ import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -50,13 +53,16 @@ import java.time.ZoneId
  * into the same flow its getter exposes, which is exactly the DataStore-is-SSOT contract the
  * ViewModel relies on (it holds no local copy). Same stub-flow pattern as DashboardViewModelTest.
  *
- * **Settle with `runCurrent()`, never `advanceUntilIdle()`.** The ViewModel resolves its window
- * against the local-date flow, which — like `periodBoundariesFlow` — emits and then sleeps until the
- * next local midnight, forever. Under a `StandardTestDispatcher` that delay is *virtual*, so
- * `advanceUntilIdle()` advances the clock past midnight, gets another emission, and never runs out
- * of work (it hangs the suite; a 15-minute CI timeout was the receipt). `runCurrent()` drains
- * everything scheduled at the current instant — which is every real emission — and leaves the
- * midnight re-anchor pending where it belongs.
+ * **Harness note — the midnight re-anchor is an unbounded virtual-time loop.** The ViewModel
+ * resolves its window against the local-date flow, which (like `periodBoundariesFlow`) emits and
+ * then sleeps until the next local midnight, forever. Under a `StandardTestDispatcher` that delay is
+ * *virtual*, so anything that tries to drain the scheduler spins through midnight after midnight and
+ * never runs out of work. Two consequences, both load-bearing — a 12-minute CI hang was the receipt:
+ *  1. settle with **`runCurrent()`**, never `advanceUntilIdle()` — it drains everything scheduled at
+ *     the current instant (which is every real emission) and leaves the re-anchor pending;
+ *  2. **cancel the ViewModel's scope before the test body ends** ([runWithViewModel] does it), because
+ *     `runTest` finishes with its OWN `advanceUntilIdle()` and `viewModelScope` is not a child of the
+ *     test scope — an uncancelled hub would stall that teardown instead.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class AnalyticsViewModelTest {
@@ -179,219 +185,199 @@ class AnalyticsViewModelTest {
     private fun buildViewModel() =
         AnalyticsViewModel(analyticsRepository, correctionRepository, appPreferencesRepository)
 
+
+    /**
+     * Build the ViewModel, subscribe to [AnalyticsViewModel.uiState], settle, run [block], then tear
+     * BOTH down. Cancelling `viewModelScope` is not optional — see the harness note in the class
+     * KDoc: `runTest`'s own teardown drains the scheduler, and the hub's midnight re-anchor flow
+     * never runs dry while its scope is alive.
+     */
+    private fun TestScope.runWithViewModel(block: (AnalyticsViewModel) -> Unit) {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val viewModel = buildViewModel()
+        val collector = launch { viewModel.uiState.collect {} }
+        testScheduler.runCurrent()
+        try {
+            block(viewModel)
+        } finally {
+            collector.cancel()
+            viewModel.viewModelScope.cancel()
+        }
+    }
+
     @After
     fun tearDown() = Dispatchers.resetMain()
 
     @Test
     fun `defaults to the current pay week on the Money tab and maps the read-model into state`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         economicsByWindow[currentWeek()] = economics(net = 312.0, netPerHour = 24.0)
         storesByWindow[currentWeek()] = listOf(store("H-E-B", 120.0, 5), store("Chili's", 40.0, 2))
         stubSessions(listOf(session("s1", 90.0), session("s2", null)))
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertEquals(currentWeek(), ui.window)
-        assertEquals(WindowGranularity.WEEK, ui.window.granularity)
-        assertEquals(AnalyticsTab.Money, ui.selectedTab)
-        assertEquals(312.0, ui.economics.netProfit, 1e-9)
-        assertEquals(2, ui.topStores.size)
-        assertEquals(2, ui.recentSessions.size)
-        job.cancel()
+        runWithViewModel { viewModel ->
+            val ui = viewModel.uiState.value
+            assertEquals(currentWeek(), ui.window)
+            assertEquals(WindowGranularity.WEEK, ui.window.granularity)
+            assertEquals(AnalyticsTab.Money, ui.selectedTab)
+            assertEquals(312.0, ui.economics.netProfit, 1e-9)
+            assertEquals(2, ui.topStores.size)
+            assertEquals(2, ui.recentSessions.size)
+        }
     }
 
     /** The `›` arrow must be dead at the current window and live once the pager has moved back. */
     @Test
     fun `forward paging is disabled at the current window and enabled after stepping back`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
+        runWithViewModel { viewModel ->
+            assertTrue(viewModel.uiState.value.canStepBack)
+            assertFalse(viewModel.uiState.value.canStepForward)
 
-        assertTrue(viewModel.uiState.value.canStepBack)
-        assertFalse(viewModel.uiState.value.canStepForward)
+            viewModel.stepWindow(-1)
+            testScheduler.runCurrent()
 
-        viewModel.stepWindow(-1)
-        testScheduler.runCurrent()
-
-        assertEquals(lastWeek(), viewModel.uiState.value.window)
-        assertTrue(viewModel.uiState.value.canStepForward)
-        job.cancel()
+            assertEquals(lastWeek(), viewModel.uiState.value.window)
+            assertTrue(viewModel.uiState.value.canStepForward)
+        }
     }
 
     /** A forward step at the current window is a fail-closed no-op — never a future range. */
     @Test
     fun `stepping forward at the current window is ignored`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
+        runWithViewModel { viewModel ->
+            viewModel.stepWindow(1)
+            testScheduler.runCurrent()
 
-        viewModel.stepWindow(1)
-        testScheduler.runCurrent()
-
-        assertEquals(currentWeek(), viewModel.uiState.value.window)
-        assertEquals(AnalyticsWindowSelection.Relative(WindowGranularity.WEEK, 0), selectionFlow.value)
-        job.cancel()
+            assertEquals(currentWeek(), viewModel.uiState.value.window)
+            assertEquals(AnalyticsWindowSelection.Relative(WindowGranularity.WEEK, 0), selectionFlow.value)
+        }
     }
 
     @Test
     fun `stepWindow re-anchors economics and top stores to the paged window`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         economicsByWindow[currentWeek()] = economics(net = 312.0, netPerHour = 24.0)
         storesByWindow[currentWeek()] = listOf(store("H-E-B", 120.0, 5))
         economicsByWindow[lastWeek()] = economics(net = 1280.0, netPerHour = 22.0)
         storesByWindow[lastWeek()] = listOf(store("Target", 400.0, 12))
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
-        assertEquals(312.0, viewModel.uiState.value.economics.netProfit, 1e-9)
+        runWithViewModel { viewModel ->
+            assertEquals(312.0, viewModel.uiState.value.economics.netProfit, 1e-9)
 
-        viewModel.stepWindow(-1)
-        testScheduler.runCurrent()
+            viewModel.stepWindow(-1)
+            testScheduler.runCurrent()
 
-        val ui = viewModel.uiState.value
-        assertEquals(lastWeek(), ui.window)
-        assertEquals(1280.0, ui.economics.netProfit, 1e-9)
-        assertEquals("Target", ui.topStores.single().storeName)
-        job.cancel()
+            val ui = viewModel.uiState.value
+            assertEquals(lastWeek(), ui.window)
+            assertEquals(1280.0, ui.economics.netProfit, 1e-9)
+            assertEquals("Target", ui.topStores.single().storeName)
+        }
     }
 
     @Test
     fun `setGranularity switches to the current window of that granularity`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         economicsByWindow[currentMonth()] = economics(net = 2100.0, netPerHour = 21.0)
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
+        runWithViewModel { viewModel ->
+            viewModel.setGranularity(WindowGranularity.MONTH)
+            testScheduler.runCurrent()
 
-        viewModel.setGranularity(WindowGranularity.MONTH)
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertEquals(currentMonth(), ui.window)
-        assertEquals(2100.0, ui.economics.netProfit, 1e-9)
-        // Landing on a granularity always lands on ITS current window, so forward stays disabled.
-        assertFalse(ui.canStepForward)
-        job.cancel()
+            val ui = viewModel.uiState.value
+            assertEquals(currentMonth(), ui.window)
+            assertEquals(2100.0, ui.economics.netProfit, 1e-9)
+            // Landing on a granularity always lands on ITS current window, so forward stays disabled.
+            assertFalse(ui.canStepForward)
+        }
     }
 
     /** A committed calendar range persists as an absolute CUSTOM selection. */
     @Test
     fun `setCustomRange commits an absolute window and persists it`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         val start = today.minusDays(10)
         val end = today.minusDays(4)
         economicsByWindow[AnalyticsWindows.custom(start, end)] = economics(net = 77.0, netPerHour = 11.0)
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
+        runWithViewModel { viewModel ->
+            viewModel.setCustomRange(start, end)
+            testScheduler.runCurrent()
 
-        viewModel.setCustomRange(start, end)
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertEquals(WindowGranularity.CUSTOM, ui.window.granularity)
-        assertEquals(start, ui.window.startDate)
-        assertEquals(end, ui.window.endDateInclusive)
-        assertEquals(77.0, ui.economics.netProfit, 1e-9)
-        assertEquals(AnalyticsWindowSelection.Custom(start, end), selectionFlow.value)
-        job.cancel()
+            val ui = viewModel.uiState.value
+            assertEquals(WindowGranularity.CUSTOM, ui.window.granularity)
+            assertEquals(start, ui.window.startDate)
+            assertEquals(end, ui.window.endDateInclusive)
+            assertEquals(77.0, ui.economics.netProfit, 1e-9)
+            assertEquals(AnalyticsWindowSelection.Custom(start, end), selectionFlow.value)
+        }
     }
 
     /** A persisted selection is restored on construction — the across-restart half of the contract. */
     @Test
     fun `a persisted selection is restored instead of the default`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         selectionFlow.value = AnalyticsWindowSelection.Relative(WindowGranularity.WEEK, -2)
         val twoWeeksBack = AnalyticsWindows.step(currentWeek(), -2)
         economicsByWindow[twoWeeksBack] = economics(net = 42.0, netPerHour = 9.0)
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertEquals(twoWeeksBack, ui.window)
-        assertEquals(42.0, ui.economics.netProfit, 1e-9)
-        job.cancel()
+        runWithViewModel { viewModel ->
+            val ui = viewModel.uiState.value
+            assertEquals(twoWeeksBack, ui.window)
+            assertEquals(42.0, ui.economics.netProfit, 1e-9)
+        }
     }
 
     /** The recap hero's delta source: the previous equivalent window's economics ride the same fan-out. */
     @Test
     fun `previous-window economics are exposed for the delta chip`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         economicsByWindow[currentWeek()] = economics(net = 300.0, netPerHour = 20.0)
         economicsByWindow[lastWeek()] = economics(net = 200.0, netPerHour = 15.0)
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertEquals(300.0, ui.economics.netProfit, 1e-9)
-        assertEquals(200.0, ui.previousEconomics!!.netProfit, 1e-9)
-        job.cancel()
+        runWithViewModel { viewModel ->
+            val ui = viewModel.uiState.value
+            assertEquals(300.0, ui.economics.netProfit, 1e-9)
+            assertEquals(200.0, ui.previousEconomics!!.netProfit, 1e-9)
+        }
     }
 
     /** Lifetime has no predecessor, so the hero must get a null rather than a fabricated comparison. */
     @Test
     fun `lifetime exposes no previous-window economics`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         economicsByWindow[AnalyticsWindows.LIFETIME] = economics(net = 9000.0, netPerHour = 19.0)
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
+        runWithViewModel { viewModel ->
+            viewModel.setGranularity(WindowGranularity.LIFETIME)
+            testScheduler.runCurrent()
 
-        viewModel.setGranularity(WindowGranularity.LIFETIME)
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertTrue(ui.window.isLifetime)
-        assertEquals(9000.0, ui.economics.netProfit, 1e-9)
-        assertNull(ui.previousEconomics)
-        // Lifetime pages nowhere in either direction.
-        assertFalse(ui.canStepBack)
-        assertFalse(ui.canStepForward)
-        job.cancel()
+            val ui = viewModel.uiState.value
+            assertTrue(ui.window.isLifetime)
+            assertEquals(9000.0, ui.economics.netProfit, 1e-9)
+            assertNull(ui.previousEconomics)
+            // Lifetime pages nowhere in either direction.
+            assertFalse(ui.canStepBack)
+            assertFalse(ui.canStepForward)
+        }
     }
 
     @Test
     fun `setTab switches to Decisions and the decision read-model is present in state`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         economicsByWindow[currentWeek()] = economics(net = 100.0, netPerHour = 20.0)
         decisions = decisions(accepted = 3, declined = 5, timedOut = 2, acceptanceRate = 0.3)
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
+        runWithViewModel { viewModel ->
+            // Decisions are collected unconditionally, so they're in state even before the tab switch.
+            assertEquals(3, viewModel.uiState.value.decisions.accepted)
 
-        // Decisions are collected unconditionally, so they're in state even before the tab switch.
-        assertEquals(3, viewModel.uiState.value.decisions.accepted)
+            viewModel.setTab(AnalyticsTab.Decisions)
+            testScheduler.runCurrent()
 
-        viewModel.setTab(AnalyticsTab.Decisions)
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertEquals(AnalyticsTab.Decisions, ui.selectedTab)
-        assertEquals(currentWeek(), ui.window)
-        assertEquals(10, ui.decisions.received)
-        assertEquals(5, ui.decisions.declined)
-        assertEquals(0.3, ui.decisions.acceptanceRate!!, 1e-9)
-        assertEquals(12.5, ui.decisions.declinedEstNet, 1e-9)
-        job.cancel()
+            val ui = viewModel.uiState.value
+            assertEquals(AnalyticsTab.Decisions, ui.selectedTab)
+            assertEquals(currentWeek(), ui.window)
+            assertEquals(10, ui.decisions.received)
+            assertEquals(5, ui.decisions.declined)
+            assertEquals(0.3, ui.decisions.acceptanceRate!!, 1e-9)
+            assertEquals(12.5, ui.decisions.declinedEstNet, 1e-9)
+        }
     }
 
     @Test
     fun `patterns-tab sources (store cards + heatmap) are wired into state`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         // Override the @Before defaults with NON-DEFAULT values so the assertion is falsifiable — an
         // empty stub would equal the UiState defaults and prove nothing about the wiring.
         val heatmap = EarningsHeatmap.EMPTY.copy(minCoverageHours = 0.75)
@@ -399,29 +385,22 @@ class AnalyticsViewModelTest {
             .thenReturn(flowOf(listOf(storeReportCard("Wendys"))))
         whenever(analyticsRepository.earningsHeatmap(anyOrNull())).thenReturn(flowOf(heatmap))
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertEquals("Wendys", ui.storeReportCards.single().chainDisplay)
-        assertEquals(0.75, ui.earningsHeatmap.minCoverageHours, 1e-9)
-        job.cancel()
+        runWithViewModel { viewModel ->
+            val ui = viewModel.uiState.value
+            assertEquals("Wendys", ui.storeReportCards.single().chainDisplay)
+            assertEquals(0.75, ui.earningsHeatmap.minCoverageHours, 1e-9)
+        }
     }
 
     @Test
     fun `empty read-model maps to a safe zero-state`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
 
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.runCurrent()
-
-        val ui = viewModel.uiState.value
-        assertEquals(0.0, ui.economics.netProfit, 1e-9)
-        assertEquals(null, ui.economics.netPerHour)
-        assertTrue(ui.topStores.isEmpty())
-        assertTrue(ui.recentSessions.isEmpty())
-        job.cancel()
+        runWithViewModel { viewModel ->
+            val ui = viewModel.uiState.value
+            assertEquals(0.0, ui.economics.netProfit, 1e-9)
+            assertEquals(null, ui.economics.netPerHour)
+            assertTrue(ui.topStores.isEmpty())
+            assertTrue(ui.recentSessions.isEmpty())
+        }
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/MileageTaxModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/MileageTaxModelTest.kt
@@ -1,12 +1,14 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
-import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
+import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.Locale
@@ -14,9 +16,11 @@ import java.util.Locale
 /**
  * #689 — the MILEAGE & TAX card's pure copy logic: the year-labelled deduction line, the
  * unknown-year honest-fallback disclaimer (copy owned by `IrsMileage.fallbackNote`), and the
- * spans-years note derived from the period's real `PeriodBounds` window (so the Jan-straddling
- * Monday week is covered, not just Lifetime). Compose-free, per the [WaterfallModel] /
- * `WaterfallModelTest` precedent (test the logic, not the rendering).
+ * spans-years note. Since #970 the note (and the labelled year) derive from the selected
+ * **[AnalyticsWindows] window's own endpoints**, so the Jan-straddling Monday week and a driver-drawn
+ * custom range are both covered, and a paged-back window is priced at ITS year rather than at the
+ * device clock's. Compose-free, per the [WaterfallModel] / `WaterfallModelTest` precedent (test the
+ * logic, not the rendering).
  */
 class MileageTaxModelTest {
 
@@ -25,6 +29,9 @@ class MileageTaxModelTest {
     /** Epoch millis for noon on the given date in [utc] — pins the "device clock" per test. */
     private fun noonUtc(year: Int, month: Int, day: Int): Long =
         ZonedDateTime.of(year, month, day, 12, 0, 0, 0, utc).toInstant().toEpochMilli()
+
+    private fun window(granularity: WindowGranularity, today: LocalDate) =
+        AnalyticsWindows.current(granularity, today)
 
     // Formats.money* pins Locale.getDefault(); fix it (and restore — repo convention, see
     // FormatsTest) so the "$0.725/mi" assertions are deterministic without leaking Locale.US
@@ -39,7 +46,10 @@ class MileageTaxModelTest {
     @After fun restoreLocale() = Locale.setDefault(originalLocale)
 
     @Test fun knownYear_labelsThatYearsRate_noDisclaimer() {
-        val labels = MileageTaxModel.from(100.0, noonUtc(2026, 7, 15), utc, AnalyticsPeriod.THIS_WEEK)
+        val labels = MileageTaxModel.from(
+            100.0, noonUtc(2026, 7, 15), utc,
+            window(WindowGranularity.WEEK, LocalDate.of(2026, 7, 15)),
+        )
         assertTrue(labels.deductionLine.contains("IRS 2026"))
         assertTrue(labels.deductionLine.contains("$0.725/mi"))
         assertTrue(labels.deductionLine.contains("$72.50")) // 100 * 0.725
@@ -48,14 +58,20 @@ class MileageTaxModelTest {
     }
 
     @Test fun year2025_usesItsOwnRate() {
-        val labels = MileageTaxModel.from(100.0, noonUtc(2025, 6, 15), utc, AnalyticsPeriod.TODAY)
+        val labels = MileageTaxModel.from(
+            100.0, noonUtc(2025, 6, 15), utc,
+            window(WindowGranularity.DAY, LocalDate.of(2025, 6, 15)),
+        )
         assertTrue(labels.deductionLine.contains("IRS 2025"))
         assertTrue(labels.deductionLine.contains("$0.700/mi"))
         assertTrue(labels.deductionLine.contains("$70.00"))
     }
 
     @Test fun unknownYear_fallsBackToLatestRate_withDisclaimer() {
-        val labels = MileageTaxModel.from(100.0, noonUtc(2027, 6, 15), utc, AnalyticsPeriod.THIS_MONTH)
+        val labels = MileageTaxModel.from(
+            100.0, noonUtc(2027, 6, 15), utc,
+            window(WindowGranularity.MONTH, LocalDate.of(2027, 6, 15)),
+        )
         // 2027 unpublished → latest known rate (2026 = $0.725/mi), labelled honestly.
         assertTrue(labels.deductionLine.contains("IRS 2027"))
         assertTrue(labels.deductionLine.contains("$0.725/mi"))
@@ -68,7 +84,7 @@ class MileageTaxModelTest {
     }
 
     @Test fun lifetime_addsMaySpanYearsNote() {
-        val labels = MileageTaxModel.from(100.0, noonUtc(2026, 7, 15), utc, AnalyticsPeriod.LIFETIME)
+        val labels = MileageTaxModel.from(100.0, noonUtc(2026, 7, 15), utc, AnalyticsWindows.LIFETIME)
         assertEquals(
             "may span tax years — see the CSV export for per-year figures",
             labels.spansYearsNote,
@@ -77,24 +93,59 @@ class MileageTaxModelTest {
 
     @Test fun weekStraddlingNewYear_addsSpansYearsNote() {
         // Thu 2026-01-01 → the Monday-anchored week starts Mon 2025-12-29: the window spans tax
-        // years, so the note fires even though the period isn't Lifetime.
-        val labels = MileageTaxModel.from(100.0, noonUtc(2026, 1, 1), utc, AnalyticsPeriod.THIS_WEEK)
+        // years, so the note fires even though the window isn't Lifetime.
+        val labels = MileageTaxModel.from(
+            100.0, noonUtc(2026, 1, 1), utc,
+            window(WindowGranularity.WEEK, LocalDate.of(2026, 1, 1)),
+        )
         assertEquals(
             "spans tax years — see the CSV export for per-year figures",
             labels.spansYearsNote,
         )
-        // The deduction itself is still labelled (and priced) at the current year's rate.
+        // A year-straddling window falls back to the CURRENT year's rate and says so.
         assertTrue(labels.deductionLine.contains("IRS 2026"))
     }
 
     @Test fun singleYearWindows_haveNoSpansYearsNote() {
+        val today = LocalDate.of(2026, 7, 15)
         val midYear = noonUtc(2026, 7, 15)
-        assertNull(MileageTaxModel.from(100.0, midYear, utc, AnalyticsPeriod.TODAY).spansYearsNote)
-        assertNull(MileageTaxModel.from(100.0, midYear, utc, AnalyticsPeriod.THIS_WEEK).spansYearsNote)
-        assertNull(MileageTaxModel.from(100.0, midYear, utc, AnalyticsPeriod.THIS_MONTH).spansYearsNote)
-        // Jan 1 itself: Today and This-Month start at Jan 1 00:00 — same year, no note.
+        assertNull(MileageTaxModel.from(100.0, midYear, utc, window(WindowGranularity.DAY, today)).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, midYear, utc, window(WindowGranularity.WEEK, today)).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, midYear, utc, window(WindowGranularity.MONTH, today)).spansYearsNote)
+        // Jan 1 itself: Day and Month both start at Jan 1 — same year, no note.
+        val newYear = LocalDate.of(2026, 1, 1)
         val newYearsDay = noonUtc(2026, 1, 1)
-        assertNull(MileageTaxModel.from(100.0, newYearsDay, utc, AnalyticsPeriod.TODAY).spansYearsNote)
-        assertNull(MileageTaxModel.from(100.0, newYearsDay, utc, AnalyticsPeriod.THIS_MONTH).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, newYearsDay, utc, window(WindowGranularity.DAY, newYear)).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, newYearsDay, utc, window(WindowGranularity.MONTH, newYear)).spansYearsNote)
+    }
+
+    /**
+     * #970 — the pager can select a window in a PAST year. The deduction must then be priced and
+     * labelled at THAT year's rate, not at the device clock's: quoting 2026's $0.725 over a window
+     * of 2025 miles would be a wrong number wearing a confident label.
+     */
+    @Test fun pagedBackWindowInAnEarlierYear_isPricedAtThatYearsRate() {
+        val labels = MileageTaxModel.from(
+            100.0,
+            nowMillis = noonUtc(2026, 7, 15), // device clock says 2026 …
+            zone = utc,
+            window = window(WindowGranularity.MONTH, LocalDate.of(2025, 6, 15)), // … window is June 2025
+        )
+        assertTrue(labels.deductionLine.contains("IRS 2025"))
+        assertTrue(labels.deductionLine.contains("$0.700/mi"))
+        assertTrue(labels.deductionLine.contains("$70.00"))
+        assertNull(labels.spansYearsNote)
+    }
+
+    /** A driver-drawn custom range that crosses New Year gets the same honest note. */
+    @Test fun customRangeStraddlingNewYear_addsSpansYearsNote() {
+        val labels = MileageTaxModel.from(
+            100.0, noonUtc(2026, 7, 15), utc,
+            AnalyticsWindows.custom(LocalDate.of(2025, 12, 20), LocalDate.of(2026, 1, 10)),
+        )
+        assertEquals(
+            "spans tax years — see the CSV export for per-year figures",
+            labels.spansYearsNote,
+        )
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/RecapModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/RecapModelTest.kt
@@ -1,0 +1,109 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #970 — the recap hero's comparison rules (brief §3.3 + the §9 honesty bar). Compose-free, per the
+ * [WaterfallModel] precedent.
+ *
+ * Each rule exists to stop a specific dishonest reading:
+ *  - no previous window (Lifetime) must say so, not print `▲ 0%`;
+ *  - a previous window that earned nothing can't be a percentage denominator;
+ *  - a sub-half-percent wobble is noise, and rendering it as a trend would invite the driver to act
+ *    on it.
+ */
+class RecapModelTest {
+
+    @Test fun `a null previous window yields NONE`() {
+        assertEquals(RecapModel.Direction.NONE, RecapModel.delta(300.0, null).direction)
+        assertNull(RecapModel.delta(300.0, null).fraction)
+    }
+
+    @Test fun `a real increase yields UP with the signed fraction`() {
+        val delta = RecapModel.delta(currentNet = 300.0, previousNet = 200.0)
+        assertEquals(RecapModel.Direction.UP, delta.direction)
+        assertEquals(0.5, delta.fraction!!, 1e-9)
+    }
+
+    @Test fun `a real decrease yields DOWN with a negative fraction`() {
+        val delta = RecapModel.delta(currentNet = 150.0, previousNet = 200.0)
+        assertEquals(RecapModel.Direction.DOWN, delta.direction)
+        assertEquals(-0.25, delta.fraction!!, 1e-9)
+    }
+
+    @Test fun `an identical window is FLAT with no fraction`() {
+        val delta = RecapModel.delta(currentNet = 200.0, previousNet = 200.0)
+        assertEquals(RecapModel.Direction.FLAT, delta.direction)
+        assertNull(delta.fraction)
+    }
+
+    /** A sub-half-percent move is noise — reporting it as a trend would be a false signal. */
+    @Test fun `a sub-half-percent move reads as FLAT`() {
+        assertEquals(RecapModel.Direction.FLAT, RecapModel.delta(200.4, 200.0).direction)
+        assertEquals(RecapModel.Direction.FLAT, RecapModel.delta(199.6, 200.0).direction)
+        // …but just past the threshold it becomes a real direction.
+        assertEquals(RecapModel.Direction.UP, RecapModel.delta(202.0, 200.0).direction)
+        assertEquals(RecapModel.Direction.DOWN, RecapModel.delta(198.0, 200.0).direction)
+    }
+
+    /** Dividing by a zero previous window is the divide-by-zero the worded arm exists to avoid. */
+    @Test fun `earning after an empty previous window is FROM_ZERO, never a percentage`() {
+        val delta = RecapModel.delta(currentNet = 120.0, previousNet = 0.0)
+        assertEquals(RecapModel.Direction.FROM_ZERO, delta.direction)
+        assertNull(delta.fraction)
+    }
+
+    @Test fun `two empty windows in a row are FLAT`() {
+        assertEquals(RecapModel.Direction.FLAT, RecapModel.delta(0.0, 0.0).direction)
+    }
+
+    /** Sub-cent noise on either side is still "nothing", not a comparison. */
+    @Test fun `sub-cent amounts count as zero on both sides`() {
+        assertEquals(RecapModel.Direction.FLAT, RecapModel.delta(0.001, 0.001).direction)
+        assertEquals(RecapModel.Direction.FROM_ZERO, RecapModel.delta(50.0, 0.001).direction)
+    }
+
+    /** A negative previous net still compares — the magnitude is the denominator, so the sign is honest. */
+    @Test fun `recovering from a losing window reads as UP`() {
+        val delta = RecapModel.delta(currentNet = 5.0, previousNet = -10.0)
+        assertEquals(RecapModel.Direction.UP, delta.direction)
+        assertEquals(1.5, delta.fraction!!, 1e-9)
+    }
+
+    @Test fun `a losing window after a profitable one reads as DOWN`() {
+        val delta = RecapModel.delta(currentNet = -20.0, previousNet = 100.0)
+        assertEquals(RecapModel.Direction.DOWN, delta.direction)
+        assertEquals(-1.2, delta.fraction!!, 1e-9)
+    }
+
+    // ── isEmpty: "nothing recorded" vs "recorded zeros" ─────────────────
+
+    @Test fun `a window with no records at all is empty`() {
+        assertTrue(RecapModel.isEmpty(PeriodEconomics.EMPTY))
+    }
+
+    @Test fun `a window with deliveries is not empty even at zero gross`() {
+        val economics = PeriodEconomics.EMPTY.copy(
+            totals = PeriodTotals(earnings = 0.0, miles = 0.0, deliveries = 1, jobs = 1, onlineDuration = 0L),
+        )
+        assertFalse(RecapModel.isEmpty(economics))
+    }
+
+    /** Time online with nothing earned is a real (and worth stating) outcome, not an empty window. */
+    @Test fun `a window with online time but no earnings is not empty`() {
+        val economics = PeriodEconomics.EMPTY.copy(
+            totals = PeriodTotals(earnings = 0.0, miles = 0.0, deliveries = 0, jobs = 0, onlineDuration = 3_600_000L),
+        )
+        assertFalse(RecapModel.isEmpty(economics))
+    }
+
+    @Test fun `a window with gross is not empty`() {
+        assertFalse(RecapModel.isEmpty(PeriodEconomics.EMPTY.copy(grossEarnings = 12.0)))
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/WindowLabelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/WindowLabelTest.kt
@@ -1,0 +1,123 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
+import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.util.Locale
+
+/**
+ * #970 — the period pager's label logic (brief §3.1): which relation word fronts the window, and how
+ * its date range renders. Compose-free, per the [WaterfallModel] / [MileageTaxModel] precedent.
+ *
+ * The interesting part is calendar reasoning, not rendering: is this the current week, is it the one
+ * before, does the range leave the current year, does it straddle a month. Each of those decides a
+ * different string, and a wrong one is a label that lies about which window the numbers came from.
+ */
+class WindowLabelTest {
+
+    private val wednesday = LocalDate.of(2026, 7, 15)
+
+    // The range strings interpolate a localized month name; pin the locale (and restore it — repo
+    // convention, see FormatsTest) so assertions are deterministic in the shared test JVM.
+    private lateinit var originalLocale: Locale
+
+    @Before fun pinLocale() {
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After fun restoreLocale() = Locale.setDefault(originalLocale)
+
+    private fun current(granularity: WindowGranularity, today: LocalDate = wednesday) =
+        AnalyticsWindows.current(granularity, today)
+
+    // ── relation ────────────────────────────────────────────────────────
+
+    @Test fun `the window containing today is CURRENT`() {
+        for (granularity in listOf(WindowGranularity.DAY, WindowGranularity.WEEK, WindowGranularity.MONTH)) {
+            assertEquals(
+                "$granularity",
+                WindowRelation.CURRENT,
+                WindowLabel.relation(current(granularity), wednesday),
+            )
+        }
+    }
+
+    @Test fun `one step back is PREVIOUS`() {
+        for (granularity in listOf(WindowGranularity.DAY, WindowGranularity.WEEK, WindowGranularity.MONTH)) {
+            val window = AnalyticsWindows.step(current(granularity), -1)
+            assertEquals("$granularity", WindowRelation.PREVIOUS, WindowLabel.relation(window, wednesday))
+        }
+    }
+
+    @Test fun `two or more steps back is OLDER`() {
+        val window = AnalyticsWindows.step(current(WindowGranularity.WEEK), -2)
+        assertEquals(WindowRelation.OLDER, WindowLabel.relation(window, wednesday))
+    }
+
+    /**
+     * A driver-drawn range never gets a "this/last" word — even one that happens to contain today.
+     * The range they drew IS the label; putting a relation word in front of it would be the app
+     * renaming their selection.
+     */
+    @Test fun `a custom window is always OLDER even when it contains today`() {
+        val spansToday = AnalyticsWindows.custom(wednesday.minusDays(2), wednesday.plusDays(0))
+        assertEquals(WindowRelation.OLDER, WindowLabel.relation(spansToday, wednesday))
+    }
+
+    @Test fun `lifetime reports CURRENT and is titled by its own word`() {
+        assertEquals(WindowRelation.CURRENT, WindowLabel.relation(AnalyticsWindows.LIFETIME, wednesday))
+    }
+
+    // ── range ───────────────────────────────────────────────────────────
+
+    @Test fun `lifetime has no range`() {
+        assertNull(WindowLabel.range(AnalyticsWindows.LIFETIME, wednesday))
+    }
+
+    @Test fun `a week inside one month renders as a compact day span`() {
+        // Mon 2026-07-13 – Sun 2026-07-19.
+        assertEquals("Jul 13 – 19", WindowLabel.range(current(WindowGranularity.WEEK), wednesday))
+    }
+
+    @Test fun `a week straddling two months names both months`() {
+        // Mon 2026-06-29 – Sun 2026-07-05.
+        val window = AnalyticsWindows.current(WindowGranularity.WEEK, LocalDate.of(2026, 7, 1))
+        assertEquals("Jun 29 – Jul 5", WindowLabel.range(window, wednesday))
+    }
+
+    @Test fun `a day window renders as a single date`() {
+        assertEquals("Jul 15", WindowLabel.range(current(WindowGranularity.DAY), wednesday))
+    }
+
+    @Test fun `a month window in the current year renders as the bare month name`() {
+        assertEquals("July", WindowLabel.range(current(WindowGranularity.MONTH), wednesday))
+    }
+
+    /** The year is stated as soon as the window leaves today's year — never ambiguous when paged back. */
+    @Test fun `a month window in another year carries the year`() {
+        val window = AnalyticsWindows.current(WindowGranularity.MONTH, LocalDate.of(2025, 11, 4))
+        assertEquals("November 2025", WindowLabel.range(window, wednesday))
+    }
+
+    @Test fun `a window entirely in a previous year carries the year on its end`() {
+        val window = AnalyticsWindows.custom(LocalDate.of(2025, 3, 2), LocalDate.of(2025, 3, 8))
+        assertEquals("Mar 2 – Mar 8, 2025", WindowLabel.range(window, wednesday))
+    }
+
+    /** A range that straddles New Year states BOTH years — the one case a single year would mislead. */
+    @Test fun `a window straddling New Year carries both years`() {
+        val window = AnalyticsWindows.custom(LocalDate.of(2025, 12, 29), LocalDate.of(2026, 1, 4))
+        assertEquals("Dec 29, 2025 – Jan 4, 2026", WindowLabel.range(window, wednesday))
+    }
+
+    @Test fun `a single-day custom range renders as one date`() {
+        val window = AnalyticsWindows.custom(wednesday, wednesday)
+        assertEquals("Jul 15", WindowLabel.range(window, wednesday))
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -8,6 +8,7 @@ import cloud.trotter.dashbuddy.core.database.analytics.ScoreOutcomeRow
 import cloud.trotter.dashbuddy.core.database.analytics.SessionTotalsRow
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryNet
@@ -86,7 +87,30 @@ class AnalyticsRepository @Inject constructor(
      * across two days. The single bucketing owner is the DAO join (Principle 5).
      */
     fun periodEconomics(period: AnalyticsPeriod, platform: Platform? = null): Flow<PeriodEconomics> =
-        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+        economicsIn(periodBoundariesFlow(period), platform)
+
+    /**
+     * Frozen-net economics for an **arbitrary** [window] (#970 / brief §7.1) — the period pager's
+     * read. Byte-identical accounting to the [AnalyticsPeriod] overload above: both resolve to a
+     * `[start, end)` bounds pair and run the SAME [economicsIn] fold, so the plumbing has one owner
+     * and the enum path is a special case of this one (Principle 5).
+     *
+     * Unlike the rolling-enum path there is **no midnight re-anchor flow**: a paged window is an
+     * explicit span ("Jul 13–19"), and it must not silently become a different span while the driver
+     * is reading it. The hub re-resolves *which* window is current from `currentLocalDateFlow`
+     * instead, one level up — the anchor lives with the selection, not with the query.
+     */
+    fun periodEconomics(
+        window: AnalyticsWindow,
+        platform: Platform? = null,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Flow<PeriodEconomics> = economicsIn(flowOf(PeriodBounds.of(window, zone)), platform)
+
+    private fun economicsIn(
+        bounds: Flow<PeriodBounds.Bounds>,
+        platform: Platform?,
+    ): Flow<PeriodEconomics> =
+        bounds.flatMapLatest { (start, end) ->
             if (platform == null) {
                 combine(
                     analyticsDao.deliveryTotals(start, end),
@@ -149,7 +173,16 @@ class AnalyticsRepository @Inject constructor(
      * but a recorded `cashTip` surfaces as `net = 0 + cash`. Accepted: cash has no cost term to net out.
      */
     fun perStoreEconomics(period: AnalyticsPeriod): Flow<List<StoreEconomics>> =
-        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+        perStoreEconomicsIn(periodBoundariesFlow(period))
+
+    /** Arbitrary-window variant of [perStoreEconomics] (#970 §7.1) — same F9 chain rollup, fixed bounds. */
+    fun perStoreEconomics(
+        window: AnalyticsWindow,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Flow<List<StoreEconomics>> = perStoreEconomicsIn(flowOf(PeriodBounds.of(window, zone)))
+
+    private fun perStoreEconomicsIn(bounds: Flow<PeriodBounds.Bounds>): Flow<List<StoreEconomics>> =
+        bounds.flatMapLatest { (start, end) ->
             combine(
                 analyticsDao.deliveryTotalsByStore(start, end),
                 analyticsDao.storeChainDisplays(),
@@ -263,7 +296,16 @@ class AnalyticsRepository @Inject constructor(
      * PII surface: counts + frozen economics only.
      */
     fun decisionEconomics(period: AnalyticsPeriod): Flow<DecisionEconomics> =
-        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+        decisionEconomicsIn(periodBoundariesFlow(period))
+
+    /** Arbitrary-window variant of [decisionEconomics] (#970 §7.1) — the pager's offer aggregates. */
+    fun decisionEconomics(
+        window: AnalyticsWindow,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Flow<DecisionEconomics> = decisionEconomicsIn(flowOf(PeriodBounds.of(window, zone)))
+
+    private fun decisionEconomicsIn(bounds: Flow<PeriodBounds.Bounds>): Flow<DecisionEconomics> =
+        bounds.flatMapLatest { (start, end) ->
             combine(
                 analyticsDao.offerOutcomes(start, end),
                 analyticsDao.offerScoreOutcomes(start, end),
@@ -291,7 +333,16 @@ class AnalyticsRepository @Inject constructor(
      * time/miles only).
      */
     fun timeEconomics(period: AnalyticsPeriod): Flow<TimeEconomics> =
-        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+        timeEconomicsIn(periodBoundariesFlow(period))
+
+    /** Arbitrary-window variant of [timeEconomics] (#970 §7.1) — the pager's time/deadhead stats. */
+    fun timeEconomics(
+        window: AnalyticsWindow,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Flow<TimeEconomics> = timeEconomicsIn(flowOf(PeriodBounds.of(window, zone)))
+
+    private fun timeEconomicsIn(bounds: Flow<PeriodBounds.Bounds>): Flow<TimeEconomics> =
+        bounds.flatMapLatest { (start, end) ->
             combine(
                 analyticsDao.sessionTotals(start, end),
                 analyticsDao.deliveryTimeTotals(start, end),
@@ -321,13 +372,44 @@ class AnalyticsRepository @Inject constructor(
      */
     fun dailyEarnings(period: AnalyticsPeriod, zone: ZoneId = ZoneId.systemDefault()): Flow<List<DailyEarnings>> {
         if (period == AnalyticsPeriod.TODAY || period == AnalyticsPeriod.LIFETIME) return flowOf(emptyList())
-        return periodBoundariesFlow(period, zone).flatMapLatest { (start, end) ->
+        return dailyEarningsIn(periodBoundariesFlow(period, zone), zone)
+    }
+
+    /**
+     * Arbitrary-window variant of [dailyEarnings] (#970 §7.1) — the per-day axis behind the Money
+     * chart AND the recap hero's sparkline, for any paged or custom span.
+     *
+     * Same complete gap-filled axis and same session-anchored bucketing; each entry now also carries
+     * the day's **frozen net** ([DailyEarnings.net], §7.3) so the sparkline can plot kept money rather
+     * than gross.
+     *
+     * Returns an EMPTY list — the UI hides the chart/sparkline — when the axis would carry no
+     * information: an unbounded (LIFETIME) window whose days can't be enumerated, a single-day window
+     * (one bar says nothing the hero doesn't), or a span longer than [MAX_DAY_AXIS] days (a bounded
+     * ingestion guard: a multi-year custom range would build thousands of unreadable bars).
+     */
+    fun dailyEarnings(
+        window: AnalyticsWindow,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Flow<List<DailyEarnings>> {
+        val length = window.lengthDays ?: return flowOf(emptyList())
+        if (length <= 1L || length > MAX_DAY_AXIS) return flowOf(emptyList())
+        return dailyEarningsIn(flowOf(PeriodBounds.of(window, zone)), zone)
+    }
+
+    /** The shared gap-filled per-day fold behind both [dailyEarnings] overloads (#970 §7.1/§7.3). */
+    private fun dailyEarningsIn(
+        bounds: Flow<PeriodBounds.Bounds>,
+        zone: ZoneId,
+    ): Flow<List<DailyEarnings>> =
+        bounds.flatMapLatest { (start, end) ->
             combine(
                 analyticsDao.sessionGrossRows(start, end),
                 analyticsDao.noSessionDailyRows(start, end),
             ) { rows, noSessionRows ->
-                // The end bound is exactly the next period's local midnight (PeriodBounds), so iterate
-                // day-by-day up to (but excluding) the end instant's date — a complete, gap-filled axis.
+                // The end bound is exactly the window's exclusive local midnight (PeriodBounds), so
+                // iterate day-by-day up to (but excluding) the end instant's date — a complete,
+                // gap-filled axis.
                 val startDate = Instant.ofEpochMilli(start).atZone(zone).toLocalDate()
                 val endDate = Instant.ofEpochMilli(end).atZone(zone).toLocalDate()
                 val byDay = rows.groupBy { Instant.ofEpochMilli(it.startedAt).atZone(zone).toLocalDate() }
@@ -335,15 +417,20 @@ class AnalyticsRepository @Inject constructor(
                 buildList {
                     var date = startDate
                     while (date < endDate) {
-                        val sessionGross = byDay[date]?.sumOf { it.gross } ?: 0.0
-                        val noSessionGross = noSessionByDay[date]?.sumOf { it.gross } ?: 0.0
-                        add(DailyEarnings(date, sessionGross + noSessionGross))
+                        val sessions = byDay[date]
+                        val orphans = noSessionByDay[date]
+                        add(
+                            DailyEarnings(
+                                date = date,
+                                gross = (sessions?.sumOf { it.gross } ?: 0.0) + (orphans?.sumOf { it.gross } ?: 0.0),
+                                net = (sessions?.sumOf { it.net } ?: 0.0) + (orphans?.sumOf { it.net } ?: 0.0),
+                            ),
+                        )
                         date = date.plusDays(1)
                     }
                 }
             }
         }
-    }
 
     /** Recent dashes, newest first (future hub / #650). */
     fun recentSessions(limit: Int = 20): Flow<List<SessionRecord>> =
@@ -360,7 +447,16 @@ class AnalyticsRepository @Inject constructor(
      * PII surface (store names are driver-owned; no customer hashes on [DeliveryRecord]).
      */
     fun noSessionDeliveries(period: AnalyticsPeriod): Flow<List<DeliveryRecord>> =
-        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+        noSessionDeliveriesIn(periodBoundariesFlow(period))
+
+    /** Arbitrary-window variant of [noSessionDeliveries] (#970 §7.1). */
+    fun noSessionDeliveries(
+        window: AnalyticsWindow,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Flow<List<DeliveryRecord>> = noSessionDeliveriesIn(flowOf(PeriodBounds.of(window, zone)))
+
+    private fun noSessionDeliveriesIn(bounds: Flow<PeriodBounds.Bounds>): Flow<List<DeliveryRecord>> =
+        bounds.flatMapLatest { (start, end) ->
             analyticsDao.noSessionDeliveryRows(start, end).map { rows -> rows.map { it.toDomain() } }
         }
 
@@ -385,7 +481,16 @@ class AnalyticsRepository @Inject constructor(
      * data; no customer hashes.
      */
     fun orphanOfferGroups(period: AnalyticsPeriod): Flow<List<OrphanOfferGroup>> =
-        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+        orphanOfferGroupsIn(periodBoundariesFlow(period))
+
+    /** Arbitrary-window variant of [orphanOfferGroups] (#970 §7.1). */
+    fun orphanOfferGroups(
+        window: AnalyticsWindow,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Flow<List<OrphanOfferGroup>> = orphanOfferGroupsIn(flowOf(PeriodBounds.of(window, zone)))
+
+    private fun orphanOfferGroupsIn(bounds: Flow<PeriodBounds.Bounds>): Flow<List<OrphanOfferGroup>> =
+        bounds.flatMapLatest { (start, end) ->
             combine(
                 appEventDao.getEventsByType(AppEventType.JOB_ACCEPT_MISMATCH),
                 analyticsDao.acceptedOfferRecords(AppEventType.OFFER_ACCEPTED.name),
@@ -647,5 +752,12 @@ class AnalyticsRepository @Inject constructor(
     private companion object {
         /** ±window around an orphan's `completedAt` for the #660 piece-2 categorize picker (48 h). */
         private const val CANDIDATE_WINDOW_MILLIS = 48L * 60L * 60L * 1_000L
+
+        /**
+         * Longest day axis [dailyEarnings] will enumerate (#970) — a little over a year. Beyond it the
+         * per-day list stops being a chart and starts being a bounded-ingestion hazard, so the window
+         * variant returns an empty axis and the UI hides the card instead.
+         */
+        private const val MAX_DAY_AXIS = 400L
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/PeriodBounds.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/PeriodBounds.kt
@@ -1,13 +1,14 @@
 package cloud.trotter.dashbuddy.core.data.analytics
 
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
+import cloud.trotter.dashbuddy.domain.analytics.toWindow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import java.time.DayOfWeek
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
-import java.time.temporal.TemporalAdjusters
 
 /**
  * Query-time period boundaries for the analytics read model (#314 PR3).
@@ -16,35 +17,47 @@ import java.time.temporal.TemporalAdjusters
  * zone — no timezone is ever materialized into a row. Weeks are Monday-anchored to
  * match the DoorDash pay week. [of] is pure (inject `now`/`zone`), so the Monday
  * boundary and midnight/week re-anchor are directly testable without a wall clock.
+ *
+ * **Two entry points, one rule set (#970).** The arbitrary-window overload
+ * [of][PeriodBounds.of] is the primitive: it turns an [AnalyticsWindow]'s local-date span into
+ * epoch millis. The rolling [AnalyticsPeriod] overload derives its window through
+ * [toWindow] and calls the primitive — so the enum path and the pager path can never disagree about
+ * where Monday starts (Principle 5).
  */
 object PeriodBounds {
 
     data class Bounds(val start: Long, val end: Long)
 
+    /** The all-time bounds an unbounded (LIFETIME) window resolves to. */
+    val LIFETIME: Bounds = Bounds(0L, Long.MAX_VALUE)
+
+    /**
+     * The `[start, end)` epoch-millis bounds of [window] in [zone] — local midnight of the window's
+     * first day up to (exclusive) local midnight of the day after its last. An unbounded (LIFETIME)
+     * window is [LIFETIME].
+     */
+    fun of(window: AnalyticsWindow, zone: ZoneId): Bounds {
+        val start = window.startDate ?: return LIFETIME
+        val end = window.endDateExclusive ?: return LIFETIME
+        return Bounds(
+            start.atStartOfDay(zone).toInstant().toEpochMilli(),
+            end.atStartOfDay(zone).toInstant().toEpochMilli(),
+        )
+    }
+
     /**
      * The `[start, end)` window for [period], anchored at [nowMillis] in [zone].
      * TODAY = local midnight → next midnight; THIS_WEEK = Monday 00:00 → next Monday
      * 00:00; THIS_MONTH = 1st 00:00 → next month's 1st 00:00; LIFETIME = all time.
+     *
+     * Delegates to the [AnalyticsWindow] overload (#970) — one boundary rule set, two callers.
      */
-    fun of(period: AnalyticsPeriod, nowMillis: Long, zone: ZoneId): Bounds {
-        if (period == AnalyticsPeriod.LIFETIME) return Bounds(0L, Long.MAX_VALUE)
+    fun of(period: AnalyticsPeriod, nowMillis: Long, zone: ZoneId): Bounds =
+        of(period.toWindow(localDate(nowMillis, zone)), zone)
 
-        val today = Instant.ofEpochMilli(nowMillis).atZone(zone).toLocalDate()
-        val startDate = when (period) {
-            AnalyticsPeriod.TODAY -> today
-            AnalyticsPeriod.THIS_WEEK -> today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-            AnalyticsPeriod.THIS_MONTH -> today.with(TemporalAdjusters.firstDayOfMonth())
-            AnalyticsPeriod.LIFETIME -> error("handled above")
-        }
-        val startZdt = startDate.atStartOfDay(zone)
-        val endZdt = when (period) {
-            AnalyticsPeriod.TODAY -> startZdt.plusDays(1)
-            AnalyticsPeriod.THIS_WEEK -> startZdt.plusWeeks(1)
-            AnalyticsPeriod.THIS_MONTH -> startZdt.plusMonths(1)
-            AnalyticsPeriod.LIFETIME -> error("handled above")
-        }
-        return Bounds(startZdt.toInstant().toEpochMilli(), endZdt.toInstant().toEpochMilli())
-    }
+    /** The local calendar date [millis] falls on in [zone]. */
+    fun localDate(millis: Long, zone: ZoneId): LocalDate =
+        Instant.ofEpochMilli(millis).atZone(zone).toLocalDate()
 }
 
 /**
@@ -65,5 +78,27 @@ internal fun periodBoundariesFlow(
         emit(bounds)
         if (period == AnalyticsPeriod.LIFETIME) break
         delay((bounds.end - current).coerceAtLeast(1L))
+    }
+}
+
+/**
+ * The device's current **local date**, re-emitting at each local midnight (#970).
+ *
+ * The period pager's window is a *relative* selection ("this week", "one week back"), so the hub
+ * needs a reactive `today` to resolve it — and the forward-arrow's disabled state is derived from the
+ * same value. Same shape as [periodBoundariesFlow] (emit, sleep to the boundary, recompute), which is
+ * how the hub stays fresh across midnight without a per-second ticker (Reactive UI rule 4: the
+ * anchor changes once a day, so the flow ticks once a day). [now]/[zone] are injectable for tests.
+ */
+fun currentLocalDateFlow(
+    zone: ZoneId = ZoneId.systemDefault(),
+    now: () -> Long = System::currentTimeMillis,
+): Flow<LocalDate> = flow {
+    while (true) {
+        val current = now()
+        val today = PeriodBounds.localDate(current, zone)
+        emit(today)
+        val nextMidnight = today.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+        delay((nextMidnight - current).coerceAtLeast(1L))
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
@@ -1,6 +1,8 @@
 package cloud.trotter.dashbuddy.core.data.settings
 
 import cloud.trotter.dashbuddy.core.datastore.settings.AppPreferencesDataSource
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindowSelection
+import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
 import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
@@ -9,6 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
+import java.time.LocalDate
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -38,6 +41,38 @@ class AppPreferencesRepository @Inject constructor(
             FuelType.valueOf(savedType ?: FuelType.REGULAR.name)
         } catch (_: Exception) {
             FuelType.REGULAR
+        }
+    }
+
+    /**
+     * The analytics hub's persisted review window (#970) — the `‹ ›` pager's selection, restored
+     * across tab switches AND app restarts.
+     *
+     * **Fail-closed decode:** any unrecognized granularity, a relative selection with no offset, a
+     * custom selection missing an endpoint, or a backwards custom range all fall back to
+     * [AnalyticsWindowSelection.DEFAULT] (the current pay week) rather than throwing — a corrupt
+     * preference must never be able to crash the hub open. A **positive** stored offset is clamped to
+     * `0`: the pager can never select a future window, so a future offset can only be corruption.
+     */
+    val analyticsWindow: Flow<AnalyticsWindowSelection> =
+        dataSource.analyticsWindow.map { prefs -> decodeAnalyticsWindow(prefs) }
+
+    private fun decodeAnalyticsWindow(
+        prefs: AppPreferencesDataSource.AnalyticsWindowPrefs,
+    ): AnalyticsWindowSelection {
+        val granularity = prefs.granularity
+            ?.let { name -> WindowGranularity.entries.firstOrNull { it.name == name } }
+            ?: return AnalyticsWindowSelection.DEFAULT
+        return if (granularity == WindowGranularity.CUSTOM) {
+            val start = prefs.startEpochDay ?: return AnalyticsWindowSelection.DEFAULT
+            val end = prefs.endEpochDay ?: return AnalyticsWindowSelection.DEFAULT
+            if (end < start) {
+                AnalyticsWindowSelection.DEFAULT
+            } else {
+                AnalyticsWindowSelection.Custom(LocalDate.ofEpochDay(start), LocalDate.ofEpochDay(end))
+            }
+        } else {
+            AnalyticsWindowSelection.Relative(granularity, (prefs.offset ?: 0).coerceAtMost(0))
         }
     }
 
@@ -205,6 +240,26 @@ class AppPreferencesRepository @Inject constructor(
     suspend fun setProMode(enabled: Boolean) = dataSource.setProMode(enabled)
     suspend fun setTheme(theme: String) = dataSource.setTheme(theme)
     suspend fun setGlanceMode(enabled: Boolean) = dataSource.setGlanceMode(enabled)
+
+    /**
+     * #970 — persist the analytics review window. The DataStore is the single source of truth for the
+     * selection: the hub writes here and reads [analyticsWindow] back reactively (no optimistic local
+     * copy that could drift, Principle 5).
+     */
+    suspend fun setAnalyticsWindow(selection: AnalyticsWindowSelection) = when (selection) {
+        is AnalyticsWindowSelection.Relative -> dataSource.setAnalyticsWindow(
+            granularity = selection.granularity.name,
+            offset = selection.offset,
+            startEpochDay = null,
+            endEpochDay = null,
+        )
+        is AnalyticsWindowSelection.Custom -> dataSource.setAnalyticsWindow(
+            granularity = WindowGranularity.CUSTOM.name,
+            offset = null,
+            startEpochDay = selection.startDate.toEpochDay(),
+            endEpochDay = selection.endDateInclusive.toEpochDay(),
+        )
+    }
 
     /**
      * #428 Half B — set (or clear, null) the spoken-offer language override (BCP-47 tag). Null

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsWindowReadsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsWindowReadsTest.kt
@@ -1,0 +1,321 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
+import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
+import cloud.trotter.dashbuddy.domain.analytics.toWindow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * #970 §7.1/§7.2/§7.3 — the arbitrary-window read plumbing behind the period pager.
+ *
+ * Three properties, each of which the pager and recap hero depend on:
+ *  1. **The window path and the enum path agree.** For the same span, `periodEconomics(window)` /
+ *     `decisionEconomics` / `timeEconomics` / `dailyEarnings` return exactly what the existing
+ *     `AnalyticsPeriod` overloads return — the enum path is a special case of the window path, and
+ *     this is the regression fence around "existing callers see byte-identical results".
+ *  2. **Net per day decomposes period net.** Σ `DailyEarnings.net` over a window equals that
+ *     window's `PeriodEconomics.netProfit`, including cash tips, the unattributed remainder, and the
+ *     "(No session)" bucket — so the hero's sparkline plots the same money the headline states.
+ *  3. **The previous-equivalent window reads the window before.** The delta chip's source is a real
+ *     aggregate over the preceding span, not a re-read of the current one.
+ *
+ * Timestamps derive FROM [PeriodBounds] against the real clock, so assertions hold whenever the
+ * test runs (the repository's enum path reads the wall clock).
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsWindowReadsTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    private val zone: ZoneId = ZoneId.of("America/Chicago")
+    private val hour = 3_600_000L
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao, db.appEventDao())
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun session(
+        id: String,
+        startedAt: Long,
+        reportedEarnings: Double?,
+    ) = SessionRecordEntity(
+        sessionId = id,
+        platform = "doordash",
+        startedAt = startedAt,
+        endedAt = startedAt + hour,
+        lastEventAt = startedAt + hour,
+        endSource = "summary_screen",
+        startOdometer = 0.0,
+        lastOdometer = 5.0,
+        reportedEarnings = reportedEarnings,
+        reportedDurationMillis = hour,
+        offersReceived = 0,
+        offersAccepted = 0,
+        offersDeclined = 0,
+        offersTimeout = 0,
+        deliveries = 1,
+        jobsCompleted = 1,
+    )
+
+    private fun delivery(
+        seq: Long,
+        sessionId: String?,
+        completedAt: Long,
+        pay: Double?,
+        net: Double? = null,
+        cashTip: Double? = null,
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = "doordash",
+        jobId = "job-$seq",
+        taskId = "task-$seq",
+        storeName = "Wendys",
+        customerHash = null,
+        addressHash = null,
+        phaseStartedAt = completedAt - 600_000,
+        arrivedAt = null,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = pay,
+        payBasis = "DROP_SHARE",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = null,
+        realizedMinutes = null,
+        frozenCostPerMile = null,
+        netProfit = net,
+        costBasis = "NONE",
+        cashTip = cashTip,
+    )
+
+    /** Today's local date in the fixed test zone — the anchor every window derives from. */
+    private fun today(): LocalDate = PeriodBounds.localDate(System.currentTimeMillis(), zone)
+
+    private fun weekStart(): Long =
+        PeriodBounds.of(AnalyticsPeriod.THIS_WEEK, System.currentTimeMillis(), zone).start
+
+    private fun dayOfWeek(index: Long): Long =
+        Instant.ofEpochMilli(weekStart()).atZone(zone).toLocalDate()
+            .plusDays(index).atTime(12, 0).atZone(zone).toInstant().toEpochMilli()
+
+    // ── 1. Window path ≡ enum path ──────────────────────────────────────
+
+    /**
+     * The regression fence for "existing callers see byte-identical results": the current-week
+     * WINDOW must produce exactly what `AnalyticsPeriod.THIS_WEEK` produces, across every aggregate
+     * the pager rewired.
+     */
+    @Test
+    fun `the current-week window returns exactly what THIS_WEEK returns`() = runBlocking {
+        dao.upsertSession(session("S1", dayOfWeek(0), reportedEarnings = 50.0))
+        dao.upsertDelivery(delivery(1, "S1", completedAt = dayOfWeek(0), pay = 30.0, net = 21.0, cashTip = 3.0))
+        dao.upsertDelivery(delivery(2, "S1", completedAt = dayOfWeek(1), pay = 12.0, net = 8.0))
+        dao.upsertDelivery(delivery(9, sessionId = null, completedAt = dayOfWeek(2), pay = 8.0, net = 5.0))
+
+        val window = AnalyticsPeriod.THIS_WEEK.toWindow(today())
+
+        assertEquals(
+            repo.periodEconomics(AnalyticsPeriod.THIS_WEEK).first(),
+            repo.periodEconomics(window, null, zone).first(),
+        )
+        assertEquals(
+            repo.decisionEconomics(AnalyticsPeriod.THIS_WEEK).first(),
+            repo.decisionEconomics(window, zone).first(),
+        )
+        assertEquals(
+            repo.timeEconomics(AnalyticsPeriod.THIS_WEEK).first(),
+            repo.timeEconomics(window, zone).first(),
+        )
+        assertEquals(
+            repo.dailyEarnings(AnalyticsPeriod.THIS_WEEK, zone).first(),
+            repo.dailyEarnings(window, zone).first(),
+        )
+        assertEquals(
+            repo.perStoreEconomics(AnalyticsPeriod.THIS_WEEK).first(),
+            repo.perStoreEconomics(window, zone).first(),
+        )
+    }
+
+    /** The same equivalence for the month window (a different length + boundary rule). */
+    @Test
+    fun `the current-month window returns exactly what THIS_MONTH returns`() = runBlocking {
+        val monthStart = PeriodBounds.of(AnalyticsPeriod.THIS_MONTH, System.currentTimeMillis(), zone).start
+        dao.upsertSession(session("M1", monthStart + hour, reportedEarnings = 90.0))
+        dao.upsertDelivery(delivery(1, "M1", completedAt = monthStart + hour, pay = 60.0, net = 40.0))
+
+        val window = AnalyticsPeriod.THIS_MONTH.toWindow(today())
+        assertEquals(
+            repo.periodEconomics(AnalyticsPeriod.THIS_MONTH).first(),
+            repo.periodEconomics(window, null, zone).first(),
+        )
+        assertEquals(
+            repo.dailyEarnings(AnalyticsPeriod.THIS_MONTH, zone).first(),
+            repo.dailyEarnings(window, zone).first(),
+        )
+    }
+
+    /** Lifetime: the unbounded window resolves to the same all-time bounds the enum does. */
+    @Test
+    fun `the lifetime window returns exactly what LIFETIME returns`() = runBlocking {
+        dao.upsertSession(session("L1", weekStart() - 400L * 24 * hour, reportedEarnings = 12.0))
+        dao.upsertDelivery(
+            delivery(1, "L1", completedAt = weekStart() - 400L * 24 * hour, pay = 12.0, net = 9.0),
+        )
+
+        assertEquals(
+            repo.periodEconomics(AnalyticsPeriod.LIFETIME).first(),
+            repo.periodEconomics(AnalyticsWindows.LIFETIME, null, zone).first(),
+        )
+        assertEquals(PeriodBounds.LIFETIME, PeriodBounds.of(AnalyticsWindows.LIFETIME, zone))
+    }
+
+    // ── 2. Net per day decomposes period net (§7.3) ─────────────────────
+
+    /**
+     * The sparkline's contract: Σ per-day net == the window's frozen period net. The fixture mixes
+     * every term that reaches `PeriodEconomics.netProfit` — frozen `netProfit`, a cash tip, an
+     * unattributed remainder (reported > delivered), and a "(No session)" orphan — precisely because
+     * each one is a separate seam where a second copy of the accounting could drift.
+     */
+    @Test
+    fun `per-day net sums to the window's frozen period net`() = runBlocking {
+        // S1: reported 60 vs delivered 42 → 18 unattributed; one drop carries a 3.00 cash tip.
+        dao.upsertSession(session("S1", dayOfWeek(0), reportedEarnings = 60.0))
+        dao.upsertDelivery(delivery(1, "S1", completedAt = dayOfWeek(0), pay = 30.0, net = 21.0, cashTip = 3.0))
+        dao.upsertDelivery(delivery(2, "S1", completedAt = dayOfWeek(0), pay = 12.0, net = 8.0))
+        // S2: reported matches delivered exactly → no unattributed.
+        dao.upsertSession(session("S2", dayOfWeek(3), reportedEarnings = 20.0))
+        dao.upsertDelivery(delivery(3, "S2", completedAt = dayOfWeek(3), pay = 20.0, net = 14.0))
+        // An orphan with no session at all, buckets on its own completedAt day.
+        dao.upsertDelivery(delivery(9, sessionId = null, completedAt = dayOfWeek(5), pay = 8.0, net = 5.0, cashTip = 1.0))
+
+        val window = AnalyticsPeriod.THIS_WEEK.toWindow(today())
+        val days = repo.dailyEarnings(window, zone).first()
+        val economics = repo.periodEconomics(window, null, zone).first()
+
+        assertEquals(7, days.size)
+        assertEquals(economics.netProfit, days.sumOf { it.net }, 1e-9)
+        // …and gross still decomposes too (the pre-#970 property, unchanged).
+        assertEquals(economics.grossEarnings, days.sumOf { it.gross }, 1e-9)
+    }
+
+    /** Net lands on the SAME day the session's gross does — session-anchored, never split (#655). */
+    @Test
+    fun `per-day net is session-anchored on the start day`() = runBlocking {
+        val mondayDate = Instant.ofEpochMilli(weekStart()).atZone(zone).toLocalDate()
+        val tuesdayMidnight = mondayDate.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+        dao.upsertSession(session("M", tuesdayMidnight - 600_000, reportedEarnings = 30.0)) // 23:50 Monday
+        // The delivery completes AFTER midnight — still counts on Monday, like its gross.
+        dao.upsertDelivery(delivery(1, "M", completedAt = tuesdayMidnight + 600_000, pay = 30.0, net = 22.0))
+
+        val days = repo.dailyEarnings(AnalyticsPeriod.THIS_WEEK.toWindow(today()), zone).first()
+        assertEquals(22.0, days[0].net, 1e-9)
+        assertEquals(0.0, days[1].net, 1e-9)
+    }
+
+    /** A null-net row (no cost basis) contributes only its cash — never a fabricated zero-cost net. */
+    @Test
+    fun `a null-net delivery contributes only its cash tip to the day`() = runBlocking {
+        dao.upsertSession(session("S", dayOfWeek(0), reportedEarnings = null))
+        dao.upsertDelivery(delivery(1, "S", completedAt = dayOfWeek(0), pay = 10.0, net = null, cashTip = 2.0))
+
+        val days = repo.dailyEarnings(AnalyticsPeriod.THIS_WEEK.toWindow(today()), zone).first()
+        assertEquals(2.0, days[0].net, 1e-9)
+    }
+
+    // ── The day-axis guards ─────────────────────────────────────────────
+
+    /** A one-day window says nothing a bar chart can add, so the axis is empty by design. */
+    @Test
+    fun `dailyEarnings is empty for a single-day window`() = runBlocking {
+        val window = AnalyticsWindows.current(WindowGranularity.DAY, today())
+        assertTrue(repo.dailyEarnings(window, zone).first().isEmpty())
+    }
+
+    /** Lifetime has no enumerable days. */
+    @Test
+    fun `dailyEarnings is empty for the lifetime window`() = runBlocking {
+        assertTrue(repo.dailyEarnings(AnalyticsWindows.LIFETIME, zone).first().isEmpty())
+    }
+
+    /** A multi-year custom range is a bounded-ingestion hazard, not a chart — empty axis. */
+    @Test
+    fun `dailyEarnings is empty for an over-long custom window`() = runBlocking {
+        val window = AnalyticsWindows.custom(today().minusYears(3), today())
+        assertTrue(repo.dailyEarnings(window, zone).first().isEmpty())
+    }
+
+    /** …but a year-long range is still inside the cap and yields a full axis. */
+    @Test
+    fun `dailyEarnings still serves a range just inside the cap`() = runBlocking {
+        val window = AnalyticsWindows.custom(today().minusDays(200), today())
+        assertEquals(201, repo.dailyEarnings(window, zone).first().size)
+    }
+
+    // ── 3. The previous-equivalent window (§7.2) ────────────────────────
+
+    /**
+     * The delta chip's source: the previous window's aggregate must cover the span BEFORE the
+     * selected one — a re-read of the current window (the easy bug) would make every delta 0%.
+     */
+    @Test
+    fun `the previous window aggregates the preceding span, not the current one`() = runBlocking {
+        val thisWeek = AnalyticsPeriod.THIS_WEEK.toWindow(today())
+        val lastWeek = AnalyticsWindows.previous(thisWeek)!!
+
+        // 100 net this week …
+        dao.upsertSession(session("A", dayOfWeek(1), reportedEarnings = 140.0))
+        dao.upsertDelivery(delivery(1, "A", completedAt = dayOfWeek(1), pay = 140.0, net = 100.0))
+        // … and 40 net in the week before (a session started 7 days earlier).
+        dao.upsertSession(session("B", dayOfWeek(1) - 7 * 24 * hour, reportedEarnings = 55.0))
+        dao.upsertDelivery(
+            delivery(2, "B", completedAt = dayOfWeek(1) - 7 * 24 * hour, pay = 55.0, net = 40.0),
+        )
+
+        assertEquals(100.0, repo.periodEconomics(thisWeek, null, zone).first().netProfit, 1e-9)
+        assertEquals(40.0, repo.periodEconomics(lastWeek, null, zone).first().netProfit, 1e-9)
+    }
+
+    /** A paged-back window must not see the current window's records at all. */
+    @Test
+    fun `a paged-back window excludes the current window's records`() = runBlocking {
+        dao.upsertSession(session("A", dayOfWeek(1), reportedEarnings = 140.0))
+        dao.upsertDelivery(delivery(1, "A", completedAt = dayOfWeek(1), pay = 140.0, net = 100.0))
+
+        val lastWeek = AnalyticsWindows.step(AnalyticsPeriod.THIS_WEEK.toWindow(today()), -1)
+        val economics = repo.periodEconomics(lastWeek, null, zone).first()
+        assertEquals(0.0, economics.netProfit, 1e-9)
+        assertEquals(0, economics.totals.deliveries)
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -520,10 +520,15 @@ interface AnalyticsDao {
      * "(No session)" bucket's per-day chart input (#660), mirroring [sessionGrossRows] for rows that
      * join to no session at all. The repository buckets each onto the LOCAL DAY of its own
      * `completedAt` (there is no session start to anchor on).
+     *
+     * **`net` (#970 / brief §7.3):** the same row's FROZEN kept money — `netProfit + cashTip`, the
+     * exact terms [noSessionTotals] contributes to `PeriodEconomics.netProfit` — so the per-day net
+     * axis decomposes the period net instead of re-deriving it. Never recomputed (Principle 5).
      */
     @Query(
         """SELECT completedAt,
-                  (COALESCE(realizedPay, 0) + COALESCE(cashTip, 0)) AS gross
+                  (COALESCE(realizedPay, 0) + COALESCE(cashTip, 0)) AS gross,
+                  (COALESCE(netProfit, 0) + COALESCE(cashTip, 0)) AS net
            FROM delivery_records
            WHERE sessionId IS NULL AND completedAt >= :start AND completedAt < :end"""
     )
@@ -535,13 +540,26 @@ interface AnalyticsDao {
      * that session's Σ delivered pay (same definition as [grossAndUnattributed]; the LEFT JOIN is onto a
      * GROUP BY sessionId subquery, one row per session, no fan-out). Session-anchored by construction
      * (#655): a session's whole gross lands on its start instant's day.
+     *
+     * **`net` (#970 / brief §7.3):** the same session's FROZEN kept money, built from exactly the
+     * three terms `AnalyticsRepository.assemble` folds into `PeriodEconomics.netProfit` — Σ frozen
+     * `netProfit` + Σ `cashTip` + this session's `unattributed` remainder (the identical
+     * `reportedEarnings > deliveredPay` CASE [grossAndUnattributed] uses, cash-free comparison and
+     * all). So Σ per-day net over a window equals that window's period net by construction, with no
+     * second copy of the accounting and no re-costing (Principle 5, frozen economics).
      */
     @Query(
         """SELECT s.startedAt AS startedAt,
-                  COALESCE(s.reportedEarnings, d.deliveredPay, 0) + COALESCE(d.cashTip, 0) AS gross
+                  COALESCE(s.reportedEarnings, d.deliveredPay, 0) + COALESCE(d.cashTip, 0) AS gross,
+                  COALESCE(d.net, 0) + COALESCE(d.cashTip, 0)
+                    + CASE WHEN s.reportedEarnings IS NOT NULL
+                                AND s.reportedEarnings > COALESCE(d.deliveredPay, 0)
+                           THEN s.reportedEarnings - COALESCE(d.deliveredPay, 0)
+                           ELSE 0 END AS net
            FROM session_records s
            LEFT JOIN (
-             SELECT sessionId, SUM(realizedPay) AS deliveredPay, SUM(cashTip) AS cashTip
+             SELECT sessionId, SUM(realizedPay) AS deliveredPay, SUM(cashTip) AS cashTip,
+                    SUM(netProfit) AS net
              FROM delivery_records GROUP BY sessionId
            ) d ON d.sessionId = s.sessionId
            WHERE s.startedAt >= :start AND s.startedAt < :end

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -151,6 +151,12 @@ data class PlatformGrossTotalsRow(
 data class SessionGrossRow(
     val startedAt: Long,
     val gross: Double,
+    /**
+     * The session's FROZEN kept money (#970 §7.3) — Σ `netProfit` + Σ `cashTip` + this session's
+     * unattributed remainder, the same three terms `PeriodEconomics.netProfit` folds. Bucketed onto
+     * the same start day as [gross], so the per-day net axis decomposes the period net exactly.
+     */
+    val net: Double = 0.0,
 )
 
 /**
@@ -186,6 +192,9 @@ data class PlatformNoSessionTotalsRow(
 data class NoSessionDailyRow(
     val completedAt: Long,
     val gross: Double,
+    /** The row's FROZEN kept money (#970 §7.3) — `netProfit + cashTip`, the terms this bucket
+     *  contributes to `PeriodEconomics.netProfit`. */
+    val net: Double = 0.0,
 )
 
 /** Cross-platform session totals for a period: miles = Σ odo delta, onlineMillis = Σ duration, sessions = COUNT. */

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import cloud.trotter.dashbuddy.core.datastore.di.AppPreferences
@@ -76,7 +77,26 @@ class AppPreferencesDataSource @Inject constructor(
 
         // Tracks which EconomyField enum values the user has explicitly set
         val USER_SET_ECONOMY_FIELDS = stringSetPreferencesKey("user_set_economy_fields")
+
+        // ----- Analytics review window (#970) -----
+        // The hub's period pager selection, persisted so it survives tab switches AND app restarts.
+        // Lives in APP PREFS (not app_state) because it is a UI preference the driver chose — the
+        // same class of key as theme / glance mode — not machine state the state machine owns.
+        // Granularity is the `WindowGranularity` enum NAME; the offset applies to the relative
+        // granularities (0 = the current window) and the two epoch-day keys carry a CUSTOM range.
+        val ANALYTICS_WINDOW_GRANULARITY = stringPreferencesKey("analytics_window_granularity")
+        val ANALYTICS_WINDOW_OFFSET = intPreferencesKey("analytics_window_offset")
+        val ANALYTICS_WINDOW_START_DAY = longPreferencesKey("analytics_window_start_epoch_day")
+        val ANALYTICS_WINDOW_END_DAY = longPreferencesKey("analytics_window_end_epoch_day")
     }
+
+    /** The raw persisted analytics-window selection (#970); the repository decodes it to a domain type. */
+    data class AnalyticsWindowPrefs(
+        val granularity: String?,
+        val offset: Int?,
+        val startEpochDay: Long?,
+        val endEpochDay: Long?,
+    )
 
     // ============================================================================================
     // STREAMS
@@ -136,6 +156,16 @@ class AppPreferencesDataSource @Inject constructor(
 
     val userSetEconomyFields: Flow<Set<String>> =
         ds.data.map { it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet() }
+
+    /** #970 — the persisted analytics review-window selection, raw. Absent keys ⇒ all-null (default). */
+    val analyticsWindow: Flow<AnalyticsWindowPrefs> = ds.data.map {
+        AnalyticsWindowPrefs(
+            granularity = it[Keys.ANALYTICS_WINDOW_GRANULARITY],
+            offset = it[Keys.ANALYTICS_WINDOW_OFFSET],
+            startEpochDay = it[Keys.ANALYTICS_WINDOW_START_DAY],
+            endEpochDay = it[Keys.ANALYTICS_WINDOW_END_DAY],
+        )
+    }
 
     // ============================================================================================
     // ENCAPSULATED WRITE ACTIONS
@@ -209,6 +239,34 @@ class AppPreferencesDataSource @Inject constructor(
     suspend fun setTtsLanguageTag(tag: String?) {
         ds.edit {
             if (tag == null) it.remove(Keys.TTS_LANGUAGE_TAG) else it[Keys.TTS_LANGUAGE_TAG] = tag
+        }
+    }
+
+    /**
+     * #970 — persist the analytics review-window selection as ONE atomic edit, so a granularity
+     * switch can never land next to a stale custom range. A relative selection clears the two
+     * epoch-day keys; a custom range clears the offset. Fail-closed by construction: a partially
+     * written state is unreachable.
+     */
+    suspend fun setAnalyticsWindow(
+        granularity: String,
+        offset: Int?,
+        startEpochDay: Long?,
+        endEpochDay: Long?,
+    ) {
+        ds.edit {
+            it[Keys.ANALYTICS_WINDOW_GRANULARITY] = granularity
+            if (offset == null) it.remove(Keys.ANALYTICS_WINDOW_OFFSET) else it[Keys.ANALYTICS_WINDOW_OFFSET] = offset
+            if (startEpochDay == null) {
+                it.remove(Keys.ANALYTICS_WINDOW_START_DAY)
+            } else {
+                it[Keys.ANALYTICS_WINDOW_START_DAY] = startEpochDay
+            }
+            if (endEpochDay == null) {
+                it.remove(Keys.ANALYTICS_WINDOW_END_DAY)
+            } else {
+                it[Keys.ANALYTICS_WINDOW_END_DAY] = endEpochDay
+            }
         }
     }
 

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppCharts.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppCharts.kt
@@ -77,6 +77,49 @@ fun AppBarChart(bars: List<AppBar>, modifier: Modifier = Modifier, height: Dp = 
     }
 }
 
+/**
+ * Compact trend line — the recap hero's per-day sparkline (#970).
+ *
+ * Deliberately axis-less and label-less: a sparkline states *shape*, and the real number always sits
+ * beside it (never inferred from the line). Values may be negative (a day whose costs beat its pay),
+ * so the baseline is `min(0, min(values))` and the line is drawn against the full min→max span — a
+ * losing day visibly dips instead of clamping flat. A single point, an all-equal series, or an empty
+ * list draws a flat mid-height line rather than dividing by a zero span.
+ */
+@Composable
+fun AppSparkline(
+    values: List<Double>,
+    modifier: Modifier = Modifier,
+    color: Color = AppTheme.colors.accent,
+    height: Dp = 34.dp,
+    strokeWidth: Dp = 2.dp,
+) {
+    Canvas(modifier.height(height).fillMaxWidth()) {
+        if (values.isEmpty()) return@Canvas
+        val low = minOf(0.0, values.min())
+        val high = maxOf(values.max(), low)
+        val span = (high - low).takeIf { it > 0.0 }
+        val stroke = strokeWidth.toPx()
+        val usableHeight = (size.height - stroke).coerceAtLeast(1f)
+        fun yFor(value: Double): Float {
+            val fraction = span?.let { ((value - low) / it).toFloat() } ?: 0.5f
+            return (stroke / 2f) + usableHeight * (1f - fraction.coerceIn(0f, 1f))
+        }
+        if (values.size == 1) {
+            val y = yFor(values.first())
+            drawLine(color, Offset(0f, y), Offset(size.width, y), stroke, StrokeCap.Round)
+            return@Canvas
+        }
+        val step = size.width / (values.size - 1)
+        var previous = Offset(0f, yFor(values.first()))
+        for (index in 1 until values.size) {
+            val next = Offset(step * index, yFor(values[index]))
+            drawLine(color, previous, next, stroke, StrokeCap.Round)
+            previous = next
+        }
+    }
+}
+
 /** Circular progress gauge with a centred value + caption — ratings, on-time scorecard. */
 @Composable
 fun AppGaugeRing(

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsWindow.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsWindow.kt
@@ -1,0 +1,221 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
+
+/**
+ * The **arbitrary review window** the period-first analytics hub aggregates over (#970, redesign
+ * stage 1 of #969).
+ *
+ * This generalizes [AnalyticsPeriod] — which is four fixed *labels* pinned to "the current one" —
+ * into a pageable `[start, endExclusive)` range of **local calendar days**, so the hub's `‹ ›` pager
+ * can walk backwards ("last week", "the week before that") and the range picker can commit an
+ * arbitrary span. [AnalyticsPeriod] stays exactly as it was for the home glance (its four rolling
+ * labels are the right model there) and maps onto this one via [AnalyticsPeriod.toWindow], which is
+ * how the two keep ONE definition of the boundary rules (Principle 5).
+ *
+ * **Dates, not instants.** A window is expressed in `LocalDate`s and only becomes epoch-millis at the
+ * query edge (`PeriodBounds.of(window, zone)` in `:core:data`), so the zone stays a query-time input
+ * and none of this math needs a clock. Weeks are **Monday-anchored** (the DoorDash pay week), months
+ * are calendar months — the same rules `PeriodBounds` has always used.
+ */
+data class AnalyticsWindow(
+    val granularity: WindowGranularity,
+    /** First local day IN the window; `null` **iff** [granularity] is [WindowGranularity.LIFETIME]. */
+    val startDate: LocalDate?,
+    /** First local day AFTER the window (half-open); `null` iff [WindowGranularity.LIFETIME]. */
+    val endDateExclusive: LocalDate?,
+) {
+    init {
+        val lifetime = granularity == WindowGranularity.LIFETIME
+        require(lifetime == (startDate == null)) { "LIFETIME iff unbounded start" }
+        require(lifetime == (endDateExclusive == null)) { "LIFETIME iff unbounded end" }
+        if (startDate != null && endDateExclusive != null) {
+            require(endDateExclusive.isAfter(startDate)) { "window must contain at least one day" }
+        }
+    }
+
+    val isLifetime: Boolean get() = granularity == WindowGranularity.LIFETIME
+
+    /** Last local day IN the window (inclusive) — the label/calendar form. Null for LIFETIME. */
+    val endDateInclusive: LocalDate? get() = endDateExclusive?.minusDays(1)
+
+    /** Days spanned, or `null` for LIFETIME (unbounded — it has no length). */
+    val lengthDays: Long?
+        get() = if (startDate == null || endDateExclusive == null) {
+            null
+        } else {
+            ChronoUnit.DAYS.between(startDate, endDateExclusive)
+        }
+
+    /** True when [date] falls inside the half-open window (always true for LIFETIME). */
+    fun contains(date: LocalDate): Boolean {
+        val start = startDate ?: return true
+        val end = endDateExclusive ?: return true
+        return !date.isBefore(start) && date.isBefore(end)
+    }
+}
+
+/**
+ * The pager's **step size** — what `‹`/`›` move by, and what the chips row offers.
+ *
+ * [CUSTOM] is a range the driver committed from the picker; it has no natural period, so it steps by
+ * its own length. [LIFETIME] does not step at all.
+ */
+enum class WindowGranularity {
+    DAY,
+    WEEK,
+    MONTH,
+    LIFETIME,
+    CUSTOM,
+}
+
+/**
+ * The **persisted** selection behind [AnalyticsWindow] (#970).
+ *
+ * Deliberately NOT the resolved window: a [Relative] selection stores the granularity plus an integer
+ * offset from *the current* window (`0` = this week/today/this month), so reopening the hub tomorrow
+ * resolves to the new current window instead of restoring a stale absolute range. Only a driver-picked
+ * [Custom] range is absolute — that one IS a specific span and must come back verbatim.
+ */
+sealed interface AnalyticsWindowSelection {
+
+    /** [offset] `0` = the current window, `-1` = one step back, `+1` would be the future (never stored). */
+    data class Relative(val granularity: WindowGranularity, val offset: Int) : AnalyticsWindowSelection {
+        init {
+            require(granularity != WindowGranularity.CUSTOM) { "CUSTOM is not a relative granularity" }
+        }
+    }
+
+    /** A driver-committed absolute span, both ends inclusive as the calendar renders them. */
+    data class Custom(val startDate: LocalDate, val endDateInclusive: LocalDate) : AnalyticsWindowSelection {
+        init {
+            require(!endDateInclusive.isBefore(startDate)) { "range must not run backwards" }
+        }
+    }
+
+    /** Resolve to a concrete window against [today] (the device's current local date). */
+    fun resolve(today: LocalDate): AnalyticsWindow = when (this) {
+        is Relative -> AnalyticsWindows.step(AnalyticsWindows.current(granularity, today), offset)
+        is Custom -> AnalyticsWindows.custom(startDate, endDateInclusive)
+    }
+
+    companion object {
+        /** The hub's opening window when nothing is persisted — the current pay week (#315 default). */
+        val DEFAULT: AnalyticsWindowSelection = Relative(WindowGranularity.WEEK, 0)
+    }
+}
+
+/**
+ * Pure window math for the period pager (#970) — construction, stepping, and the
+ * **previous-equivalent window** the recap hero's delta chip compares against (brief §7.2).
+ *
+ * Every function is a pure `LocalDate` transform: no clock, no zone, no Android. `today` is always an
+ * explicit parameter, which is what makes the Monday-week rule and the month-boundary edges directly
+ * testable in `:domain`.
+ */
+object AnalyticsWindows {
+
+    /** The unbounded all-time window. */
+    val LIFETIME: AnalyticsWindow =
+        AnalyticsWindow(WindowGranularity.LIFETIME, startDate = null, endDateExclusive = null)
+
+    /**
+     * The **current** window at [granularity], anchored on [today]: the day containing today, the
+     * Monday-week containing today, the calendar month containing today, or all time.
+     *
+     * [WindowGranularity.CUSTOM] has no "current" form (a custom range is always an explicit span) —
+     * it is rejected; the picker calls [custom] instead.
+     */
+    fun current(granularity: WindowGranularity, today: LocalDate): AnalyticsWindow = when (granularity) {
+        WindowGranularity.LIFETIME -> LIFETIME
+        WindowGranularity.DAY -> AnalyticsWindow(granularity, today, today.plusDays(1))
+        WindowGranularity.WEEK -> {
+            val monday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            AnalyticsWindow(granularity, monday, monday.plusWeeks(1))
+        }
+        WindowGranularity.MONTH -> {
+            val first = today.withDayOfMonth(1)
+            AnalyticsWindow(granularity, first, first.plusMonths(1))
+        }
+        WindowGranularity.CUSTOM -> error("CUSTOM has no current window — use custom(start, endInclusive)")
+    }
+
+    /** A driver-committed range, both ends inclusive (the calendar's own vocabulary). */
+    fun custom(startDate: LocalDate, endDateInclusive: LocalDate): AnalyticsWindow {
+        require(!endDateInclusive.isBefore(startDate)) { "range must not run backwards" }
+        return AnalyticsWindow(WindowGranularity.CUSTOM, startDate, endDateInclusive.plusDays(1))
+    }
+
+    /**
+     * Move [window] by [steps] of its own granularity (negative = back, the `‹` arrow).
+     *
+     * DAY/WEEK/MONTH step by their calendar unit — so a month step is a *calendar* month (Mar 1 back
+     * one is Feb 1–29, not "31 days ago"). CUSTOM steps by its own day length, keeping the span size.
+     * LIFETIME does not move (it is the whole record; there is nothing to step to).
+     */
+    fun step(window: AnalyticsWindow, steps: Int): AnalyticsWindow {
+        if (steps == 0 || window.isLifetime) return window
+        val start = window.startDate ?: return window
+        val n = steps.toLong()
+        return when (window.granularity) {
+            WindowGranularity.DAY -> current(WindowGranularity.DAY, start.plusDays(n))
+            WindowGranularity.WEEK -> current(WindowGranularity.WEEK, start.plusWeeks(n))
+            WindowGranularity.MONTH -> current(WindowGranularity.MONTH, start.plusMonths(n))
+            WindowGranularity.CUSTOM -> {
+                val length = window.lengthDays ?: return window
+                val newStart = start.plusDays(length * n)
+                custom(newStart, newStart.plusDays(length - 1))
+            }
+            WindowGranularity.LIFETIME -> window
+        }
+    }
+
+    /**
+     * The **previous equivalent window** (brief §7.2) — the immediately preceding span of the same
+     * shape, which is what every delta chip compares against.
+     *
+     * `null` for LIFETIME: all-time has no predecessor, so the hero renders no delta rather than
+     * inventing a comparison (§9 — thin/absent data is stated, never smoothed over).
+     *
+     * The month case is deliberately calendar-aware and NOT a fixed-day subtraction: March's previous
+     * window is February (28 or 29 days), and January's is the previous December.
+     */
+    fun previous(window: AnalyticsWindow): AnalyticsWindow? =
+        if (window.isLifetime) null else step(window, -1)
+
+    /**
+     * Whether `›` is live. False at (and beyond) the window containing [today] — the brief's
+     * "forward disabled at the current window" — and always false for LIFETIME.
+     *
+     * The predicate is on the END bound, so it holds for a CUSTOM span too: a range that already
+     * reaches today (or the future) cannot page forward into empty calendar.
+     */
+    fun canStepForward(window: AnalyticsWindow, today: LocalDate): Boolean {
+        val end = window.endDateExclusive ?: return false
+        return !end.isAfter(today)
+    }
+
+    /** Whether `‹` is live — everything except LIFETIME can page back. */
+    fun canStepBack(window: AnalyticsWindow): Boolean = !window.isLifetime
+}
+
+/**
+ * The [AnalyticsWindow] equivalent of a home-glance [AnalyticsPeriod], anchored on [today].
+ *
+ * This is the SSOT bridge that lets `PeriodBounds` compute BOTH the enum path and the window path
+ * from one set of boundary rules (Principle 5) — the enum's TODAY/THIS_WEEK/THIS_MONTH/LIFETIME are
+ * exactly "the current DAY/WEEK/MONTH/LIFETIME window".
+ */
+fun AnalyticsPeriod.toWindow(today: LocalDate): AnalyticsWindow =
+    AnalyticsWindows.current(toGranularity(), today)
+
+/** The pager granularity this rolling period corresponds to. */
+fun AnalyticsPeriod.toGranularity(): WindowGranularity = when (this) {
+    AnalyticsPeriod.TODAY -> WindowGranularity.DAY
+    AnalyticsPeriod.THIS_WEEK -> WindowGranularity.WEEK
+    AnalyticsPeriod.THIS_MONTH -> WindowGranularity.MONTH
+    AnalyticsPeriod.LIFETIME -> WindowGranularity.LIFETIME
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/DailyEarnings.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/DailyEarnings.kt
@@ -12,8 +12,16 @@ import java.time.LocalDate
  * definition as the read-model's gross), attributed **wholly to the session's start day**
  * (session-anchored periods, #655): a dash begun 11:50pm counts entirely on that evening, never split
  * across midnight.
+ *
+ * [net] is the same day's **kept** money (#970 / brief §7.3) — the frozen per-delivery `netProfit`
+ * plus cash tips plus that session's unattributed remainder, i.e. the per-day decomposition of
+ * [PeriodEconomics.netProfit] under the identical session-anchored bucketing. It exists because the
+ * recap hero's sparkline must plot kept money, not gross: a gross sparkline flatters a day whose
+ * miles ate it. Σ [net] over a window's days therefore equals that window's `PeriodEconomics.netProfit`
+ * by construction (both fold the same frozen columns) — never recomputed, never re-costed.
  */
 data class DailyEarnings(
     val date: LocalDate,
     val gross: Double,
+    val net: Double = 0.0,
 )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
@@ -1,6 +1,8 @@
 package cloud.trotter.dashbuddy.domain.format
 
 import java.time.Instant
+import java.time.LocalDate
+import java.time.YearMonth
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -62,6 +64,30 @@ fun formatShortDate(
     DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
         .withLocale(locale)
         .format(Instant.ofEpochMilli(millis).atZone(zone))
+
+/**
+ * "Jul 13" — a month-and-day label for the analytics period pager / range picker (#970).
+ *
+ * Display copy, so it follows the [Formats] policy and localizes its month name through [locale].
+ * The field ORDER is a fixed `MMM d` pattern rather than a locale-derived skeleton: `java.time` has
+ * no skeleton API in pure Kotlin (Android's `getBestDateTimePattern` is not reachable from `:domain`),
+ * and a fixed order is the honest, greppable compromise until #428's i18n pass revisits it. One owner
+ * for the label — the pager, the picker's commit button, and the recap hero all call it (Principle 5).
+ */
+fun formatMonthDay(date: LocalDate, locale: Locale = Locale.getDefault()): String =
+    DateTimeFormatter.ofPattern("MMM d", locale).format(date)
+
+/** "Jul 13, 2026" — [formatMonthDay] plus the year, for a window that leaves the current year. */
+fun formatMonthDayYear(date: LocalDate, locale: Locale = Locale.getDefault()): String =
+    DateTimeFormatter.ofPattern("MMM d, yyyy", locale).format(date)
+
+/** "July 2026" — a month heading for the range picker's calendar pager (#970). */
+fun formatMonthYear(month: YearMonth, locale: Locale = Locale.getDefault()): String =
+    DateTimeFormatter.ofPattern("MMMM yyyy", locale).format(month)
+
+/** "July" — a bare month name, for a month window inside the current year (#970). */
+fun formatMonthName(month: YearMonth, locale: Locale = Locale.getDefault()): String =
+    DateTimeFormatter.ofPattern("MMMM", locale).format(month)
 
 /**
  * Compact 12-hour clock label for an **hour-of-day** (0..23): `0→"12a"`, `6→"6a"`, `12→"12p"`,

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsWindowsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsWindowsTest.kt
@@ -1,0 +1,335 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+/**
+ * #970 — the pure window math behind the analytics period pager (brief §3.1/§7.2).
+ *
+ * The load-bearing properties, all of which the pager and the recap hero's delta chip depend on:
+ *  - **Monday weeks.** A window's week starts Monday regardless of which weekday `today` is — the
+ *    same pay-week anchor `PeriodBounds` has always used.
+ *  - **Calendar months.** Stepping and the previous-equivalent window are *calendar* operations, so
+ *    March's predecessor is February (28 **or 29** days), and January's is the previous December.
+ *  - **Forward is fenced.** `canStepForward` is false at (and past) the window containing today, so
+ *    the pager can never select a future range.
+ *  - **Selections resolve relatively.** A `Relative` selection re-resolves against whatever `today`
+ *    is, which is what makes "this week" still mean this week after the app restarts a week later.
+ */
+class AnalyticsWindowsTest {
+
+    // A Wednesday, mid-month, mid-year — deliberately not a boundary, so a test that only passes on
+    // an edge case can't hide.
+    private val wednesday = LocalDate.of(2026, 7, 15)
+
+    // ── current() ───────────────────────────────────────────────────────
+
+    @Test fun `current day window is the single day containing today`() {
+        val window = AnalyticsWindows.current(WindowGranularity.DAY, wednesday)
+        assertEquals(wednesday, window.startDate)
+        assertEquals(wednesday, window.endDateInclusive)
+        assertEquals(1L, window.lengthDays)
+    }
+
+    @Test fun `current week window is Monday-anchored whatever weekday today is`() {
+        // Every day of the week resolves to the same Mon 2026-07-13 – Sun 2026-07-19 window.
+        val monday = LocalDate.of(2026, 7, 13)
+        for (offset in 0L..6L) {
+            val window = AnalyticsWindows.current(WindowGranularity.WEEK, monday.plusDays(offset))
+            assertEquals(monday, window.startDate)
+            assertEquals(DayOfWeek.MONDAY, window.startDate!!.dayOfWeek)
+            assertEquals(LocalDate.of(2026, 7, 19), window.endDateInclusive)
+            assertEquals(7L, window.lengthDays)
+        }
+    }
+
+    /** A Sunday must belong to the week that STARTED on Monday, not open a new one. */
+    @Test fun `sunday belongs to the week that started the previous monday`() {
+        val window = AnalyticsWindows.current(WindowGranularity.WEEK, LocalDate.of(2026, 7, 19))
+        assertEquals(LocalDate.of(2026, 7, 13), window.startDate)
+    }
+
+    @Test fun `current month window is the whole calendar month`() {
+        val window = AnalyticsWindows.current(WindowGranularity.MONTH, wednesday)
+        assertEquals(LocalDate.of(2026, 7, 1), window.startDate)
+        assertEquals(LocalDate.of(2026, 7, 31), window.endDateInclusive)
+        assertEquals(31L, window.lengthDays)
+    }
+
+    @Test fun `lifetime is unbounded and has no length`() {
+        val window = AnalyticsWindows.current(WindowGranularity.LIFETIME, wednesday)
+        assertTrue(window.isLifetime)
+        assertNull(window.startDate)
+        assertNull(window.endDateExclusive)
+        assertNull(window.lengthDays)
+        assertTrue(window.contains(LocalDate.of(1999, 1, 1)))
+    }
+
+    @Test fun `CUSTOM has no current window`() {
+        assertThrows(IllegalStateException::class.java) {
+            AnalyticsWindows.current(WindowGranularity.CUSTOM, wednesday)
+        }
+    }
+
+    // ── step() ──────────────────────────────────────────────────────────
+
+    @Test fun `stepping a week back lands on the previous Monday week`() {
+        val stepped = AnalyticsWindows.step(AnalyticsWindows.current(WindowGranularity.WEEK, wednesday), -1)
+        assertEquals(LocalDate.of(2026, 7, 6), stepped.startDate)
+        assertEquals(LocalDate.of(2026, 7, 12), stepped.endDateInclusive)
+    }
+
+    @Test fun `stepping a day back lands on yesterday`() {
+        val stepped = AnalyticsWindows.step(AnalyticsWindows.current(WindowGranularity.DAY, wednesday), -1)
+        assertEquals(LocalDate.of(2026, 7, 14), stepped.startDate)
+        assertEquals(1L, stepped.lengthDays)
+    }
+
+    /** A month step is a CALENDAR step: from a 31-day month back into a 30-day one. */
+    @Test fun `stepping a month back lands on the whole previous calendar month`() {
+        val stepped = AnalyticsWindows.step(AnalyticsWindows.current(WindowGranularity.MONTH, wednesday), -1)
+        assertEquals(LocalDate.of(2026, 6, 1), stepped.startDate)
+        assertEquals(LocalDate.of(2026, 6, 30), stepped.endDateInclusive)
+        assertEquals(30L, stepped.lengthDays)
+    }
+
+    @Test fun `stepping a month back across January lands in the previous December`() {
+        val january = AnalyticsWindows.current(WindowGranularity.MONTH, LocalDate.of(2026, 1, 10))
+        val stepped = AnalyticsWindows.step(january, -1)
+        assertEquals(LocalDate.of(2025, 12, 1), stepped.startDate)
+        assertEquals(LocalDate.of(2025, 12, 31), stepped.endDateInclusive)
+    }
+
+    @Test fun `a custom window steps by its own length and keeps that length`() {
+        val window = AnalyticsWindows.custom(LocalDate.of(2026, 7, 10), LocalDate.of(2026, 7, 14)) // 5 days
+        val back = AnalyticsWindows.step(window, -1)
+        assertEquals(LocalDate.of(2026, 7, 5), back.startDate)
+        assertEquals(LocalDate.of(2026, 7, 9), back.endDateInclusive)
+        assertEquals(5L, back.lengthDays)
+        assertEquals(WindowGranularity.CUSTOM, back.granularity)
+    }
+
+    @Test fun `lifetime never steps`() {
+        assertEquals(AnalyticsWindows.LIFETIME, AnalyticsWindows.step(AnalyticsWindows.LIFETIME, -3))
+        assertEquals(AnalyticsWindows.LIFETIME, AnalyticsWindows.step(AnalyticsWindows.LIFETIME, 3))
+    }
+
+    @Test fun `stepping by zero is the identity`() {
+        val window = AnalyticsWindows.current(WindowGranularity.WEEK, wednesday)
+        assertEquals(window, AnalyticsWindows.step(window, 0))
+    }
+
+    /** Stepping back N then forward N must return the original window — no drift across month lengths. */
+    @Test fun `stepping back then forward round-trips for every granularity`() {
+        for (granularity in listOf(WindowGranularity.DAY, WindowGranularity.WEEK, WindowGranularity.MONTH)) {
+            val window = AnalyticsWindows.current(granularity, wednesday)
+            for (steps in 1..14) {
+                val roundTrip = AnalyticsWindows.step(AnalyticsWindows.step(window, -steps), steps)
+                assertEquals("$granularity step $steps", window, roundTrip)
+            }
+        }
+    }
+
+    // ── previous() — the delta chip's comparison window (§7.2) ──────────
+
+    @Test fun `previous week is the immediately preceding Monday week`() {
+        val previous = AnalyticsWindows.previous(AnalyticsWindows.current(WindowGranularity.WEEK, wednesday))!!
+        assertEquals(LocalDate.of(2026, 7, 6), previous.startDate)
+        assertEquals(LocalDate.of(2026, 7, 12), previous.endDateInclusive)
+        assertEquals(7L, previous.lengthDays)
+    }
+
+    /** The month-boundary case the brief calls out: March's predecessor is a SHORTER February. */
+    @Test fun `previous month of March is February with its real length`() {
+        val march2026 = AnalyticsWindows.current(WindowGranularity.MONTH, LocalDate.of(2026, 3, 15))
+        val previous = AnalyticsWindows.previous(march2026)!!
+        assertEquals(LocalDate.of(2026, 2, 1), previous.startDate)
+        assertEquals(LocalDate.of(2026, 2, 28), previous.endDateInclusive)
+        assertEquals(28L, previous.lengthDays)
+    }
+
+    /** …and in a leap year it is 29 days, because the step is calendar-aware, not a fixed subtraction. */
+    @Test fun `previous month of March in a leap year is a 29-day February`() {
+        val march2028 = AnalyticsWindows.current(WindowGranularity.MONTH, LocalDate.of(2028, 3, 15))
+        val previous = AnalyticsWindows.previous(march2028)!!
+        assertEquals(LocalDate.of(2028, 2, 1), previous.startDate)
+        assertEquals(LocalDate.of(2028, 2, 29), previous.endDateInclusive)
+        assertEquals(29L, previous.lengthDays)
+    }
+
+    @Test fun `previous of a January month window is the previous December`() {
+        val january = AnalyticsWindows.current(WindowGranularity.MONTH, LocalDate.of(2026, 1, 31))
+        val previous = AnalyticsWindows.previous(january)!!
+        assertEquals(LocalDate.of(2025, 12, 1), previous.startDate)
+        assertEquals(LocalDate.of(2025, 12, 31), previous.endDateInclusive)
+    }
+
+    @Test fun `previous of a day window is yesterday`() {
+        val previous = AnalyticsWindows.previous(AnalyticsWindows.current(WindowGranularity.DAY, wednesday))!!
+        assertEquals(LocalDate.of(2026, 7, 14), previous.startDate)
+    }
+
+    /** A custom span compares against the immediately preceding span of the SAME length. */
+    @Test fun `previous of a custom window is the equally long span immediately before it`() {
+        val window = AnalyticsWindows.custom(LocalDate.of(2026, 7, 10), LocalDate.of(2026, 7, 16)) // 7 days
+        val previous = AnalyticsWindows.previous(window)!!
+        assertEquals(LocalDate.of(2026, 7, 3), previous.startDate)
+        assertEquals(LocalDate.of(2026, 7, 9), previous.endDateInclusive)
+        assertEquals(window.lengthDays, previous.lengthDays)
+    }
+
+    /** Lifetime has no predecessor — the hero must say so rather than fabricate a comparison (§9). */
+    @Test fun `lifetime has no previous window`() {
+        assertNull(AnalyticsWindows.previous(AnalyticsWindows.LIFETIME))
+    }
+
+    /** A previous window must abut its successor exactly — no gap, no overlap, for any granularity. */
+    @Test fun `previous window abuts the current one exactly`() {
+        for (granularity in listOf(WindowGranularity.DAY, WindowGranularity.WEEK, WindowGranularity.MONTH)) {
+            val window = AnalyticsWindows.current(granularity, wednesday)
+            val previous = AnalyticsWindows.previous(window)!!
+            assertEquals("$granularity", window.startDate, previous.endDateExclusive)
+        }
+        val custom = AnalyticsWindows.custom(LocalDate.of(2026, 7, 10), LocalDate.of(2026, 7, 16))
+        assertEquals(custom.startDate, AnalyticsWindows.previous(custom)!!.endDateExclusive)
+    }
+
+    // ── canStepForward / canStepBack — the arrow fences ─────────────────
+
+    @Test fun `forward is disabled at the current window and enabled once paged back`() {
+        for (granularity in listOf(WindowGranularity.DAY, WindowGranularity.WEEK, WindowGranularity.MONTH)) {
+            val current = AnalyticsWindows.current(granularity, wednesday)
+            assertFalse("$granularity", AnalyticsWindows.canStepForward(current, wednesday))
+            assertTrue("$granularity", AnalyticsWindows.canStepForward(AnalyticsWindows.step(current, -1), wednesday))
+        }
+    }
+
+    /** The fence is on the END bound, so a window merely CONTAINING today still can't page forward. */
+    @Test fun `a custom window that reaches today cannot page forward`() {
+        val spansToday = AnalyticsWindows.custom(wednesday.minusDays(3), wednesday)
+        assertFalse(AnalyticsWindows.canStepForward(spansToday, wednesday))
+        val endsYesterday = AnalyticsWindows.custom(wednesday.minusDays(3), wednesday.minusDays(1))
+        assertTrue(AnalyticsWindows.canStepForward(endsYesterday, wednesday))
+    }
+
+    @Test fun `lifetime pages in neither direction`() {
+        assertFalse(AnalyticsWindows.canStepForward(AnalyticsWindows.LIFETIME, wednesday))
+        assertFalse(AnalyticsWindows.canStepBack(AnalyticsWindows.LIFETIME))
+    }
+
+    @Test fun `every non-lifetime window can page back`() {
+        for (granularity in listOf(WindowGranularity.DAY, WindowGranularity.WEEK, WindowGranularity.MONTH)) {
+            assertTrue(AnalyticsWindows.canStepBack(AnalyticsWindows.current(granularity, wednesday)))
+        }
+        assertTrue(AnalyticsWindows.canStepBack(AnalyticsWindows.custom(wednesday, wednesday)))
+    }
+
+    // ── custom() + contains() ───────────────────────────────────────────
+
+    @Test fun `a custom range is inclusive of both endpoints`() {
+        val window = AnalyticsWindows.custom(LocalDate.of(2026, 7, 10), LocalDate.of(2026, 7, 12))
+        assertTrue(window.contains(LocalDate.of(2026, 7, 10)))
+        assertTrue(window.contains(LocalDate.of(2026, 7, 12)))
+        assertFalse(window.contains(LocalDate.of(2026, 7, 13)))
+        assertFalse(window.contains(LocalDate.of(2026, 7, 9)))
+        assertEquals(3L, window.lengthDays)
+    }
+
+    @Test fun `a single-day custom range is legal`() {
+        val window = AnalyticsWindows.custom(wednesday, wednesday)
+        assertEquals(1L, window.lengthDays)
+    }
+
+    @Test fun `a backwards custom range is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            AnalyticsWindows.custom(LocalDate.of(2026, 7, 12), LocalDate.of(2026, 7, 10))
+        }
+    }
+
+    @Test fun `an empty window is structurally impossible`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            AnalyticsWindow(WindowGranularity.CUSTOM, wednesday, wednesday)
+        }
+    }
+
+    // ── AnalyticsWindowSelection ────────────────────────────────────────
+
+    @Test fun `the default selection is the current pay week`() {
+        assertEquals(
+            AnalyticsWindows.current(WindowGranularity.WEEK, wednesday),
+            AnalyticsWindowSelection.DEFAULT.resolve(wednesday),
+        )
+    }
+
+    /**
+     * The reason a relative selection is persisted instead of an absolute window: reopening the hub
+     * a week later must resolve "this week" to the NEW week, not restore a stale range.
+     */
+    @Test fun `a relative selection re-resolves against whatever today is`() {
+        val selection = AnalyticsWindowSelection.Relative(WindowGranularity.WEEK, 0)
+        assertEquals(LocalDate.of(2026, 7, 13), selection.resolve(wednesday).startDate)
+        assertEquals(LocalDate.of(2026, 7, 20), selection.resolve(wednesday.plusWeeks(1)).startDate)
+    }
+
+    @Test fun `a relative offset resolves to that many windows back`() {
+        val selection = AnalyticsWindowSelection.Relative(WindowGranularity.WEEK, -2)
+        assertEquals(LocalDate.of(2026, 6, 29), selection.resolve(wednesday).startDate)
+    }
+
+    /** A custom selection is absolute — it must come back verbatim no matter when it is resolved. */
+    @Test fun `a custom selection resolves to the same span regardless of today`() {
+        val selection = AnalyticsWindowSelection.Custom(LocalDate.of(2026, 3, 2), LocalDate.of(2026, 3, 8))
+        val fromJuly = selection.resolve(wednesday)
+        val fromNextYear = selection.resolve(LocalDate.of(2027, 1, 1))
+        assertEquals(fromJuly, fromNextYear)
+        assertEquals(LocalDate.of(2026, 3, 2), fromJuly.startDate)
+        assertEquals(LocalDate.of(2026, 3, 8), fromJuly.endDateInclusive)
+    }
+
+    @Test fun `a relative selection cannot be CUSTOM`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            AnalyticsWindowSelection.Relative(WindowGranularity.CUSTOM, 0)
+        }
+    }
+
+    @Test fun `a backwards custom selection is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            AnalyticsWindowSelection.Custom(LocalDate.of(2026, 7, 12), LocalDate.of(2026, 7, 10))
+        }
+    }
+
+    // ── AnalyticsPeriod bridge (the PeriodBounds SSOT seam) ─────────────
+
+    /**
+     * The rolling home-glance enum must map onto exactly "the current window of that granularity" —
+     * this is what lets `PeriodBounds` compute both paths from one rule set without drift.
+     */
+    @Test fun `every AnalyticsPeriod maps to the current window of its granularity`() {
+        assertEquals(
+            AnalyticsWindows.current(WindowGranularity.DAY, wednesday),
+            AnalyticsPeriod.TODAY.toWindow(wednesday),
+        )
+        assertEquals(
+            AnalyticsWindows.current(WindowGranularity.WEEK, wednesday),
+            AnalyticsPeriod.THIS_WEEK.toWindow(wednesday),
+        )
+        assertEquals(
+            AnalyticsWindows.current(WindowGranularity.MONTH, wednesday),
+            AnalyticsPeriod.THIS_MONTH.toWindow(wednesday),
+        )
+        assertEquals(AnalyticsWindows.LIFETIME, AnalyticsPeriod.LIFETIME.toWindow(wednesday))
+    }
+
+    /** No period may map to CUSTOM — it is a driver-drawn shape only, unreachable from the enum. */
+    @Test fun `no rolling period maps to the CUSTOM granularity`() {
+        AnalyticsPeriod.entries.forEach {
+            assertTrue(it.name, it.toGranularity() != WindowGranularity.CUSTOM)
+        }
+    }
+}


### PR DESCRIPTION
Closes #970. Refs #969 (analytics & home redesign epic) — this is **stage 1 of 7**, and it blocks every later stage.

Spec: `docs/design/analytics-redesign-brief-2026-07-28.md` §3 (period control, range picker, recap hero), §7.1/§7.2/§7.3 (plumbing), §9 (copy/honesty rules).

Analytics stops being "four fixed labels" and becomes **period-first**: a `‹ ›` pager over an arbitrary window owns the top of the hub, the tabs below become detail views of whatever window is selected, and every period aggregate grew a start/end-parameterized twin so the pager and the calendar have something to read.

---

## Plumbing (§7.1 / §7.2 / §7.3)

**`AnalyticsWindow` (`:domain`, new).** A granularity (`DAY`/`WEEK`/`MONTH`/`LIFETIME`/`CUSTOM`) plus a half-open span of local **dates**. Dates, not instants — the zone stays a query-time input, so none of the calendar math needs a clock and all of it is directly unit-testable. `AnalyticsWindows` owns stepping, the **previous-equivalent window** (calendar-aware: March's predecessor is a 28-**or-29**-day February), and the `canStepForward` fence.

**One rule set, two callers.** `PeriodBounds.of(window, zone)` is now the primitive; `PeriodBounds.of(period, now, zone)` derives its window through the new `AnalyticsPeriod.toWindow(today)` and calls it. The enum path and the window path therefore cannot disagree about where Monday starts (Principle 5). Every repository aggregate follows the same shape — one private `…In(boundsFlow)` core, two public overloads:

| Read | Enum overload feeds it | Window overload feeds it |
|---|---|---|
| `periodEconomics` (+ per-platform) | `periodBoundariesFlow` (midnight re-anchoring) | `flowOf(bounds)` (fixed) |
| `perStoreEconomics` | ” | ” |
| `decisionEconomics` (offer aggregates) | ” | ” |
| `timeEconomics` (time/deadhead) | ” | ” |
| `dailyEarnings` | ” | ” |
| `noSessionDeliveries` | ” | ” |
| `orphanOfferGroups` | ” | ” |

The window overload deliberately does **not** re-anchor at midnight: a paged window is an explicit span ("Jul 13 – 19") and must not silently become a different one while the driver is reading it. The hub re-resolves *which* window is current one level up, from the new `currentLocalDateFlow` (emit, sleep to local midnight, recompute — the `periodBoundariesFlow` pattern).

**Byte-identical for existing callers** is fenced by test, not by assertion: `AnalyticsWindowReadsTest` asserts `periodEconomics(THIS_WEEK) == periodEconomics(thisWeekWindow)` and the same for decisions / time / daily / per-store, plus the month and lifetime equivalents. No existing `:core:data` test needed a single edit.

**Net per day (§7.3).** `DailyEarnings` gained `net` beside `gross`. `sessionGrossRows` computes it from the same frozen columns the period fold uses — Σ `netProfit` + Σ `cashTip` + that session's unattributed remainder — and `noSessionDailyRows` from `netProfit + cashTip`. So **Σ per-day net == the window's `PeriodEconomics.netProfit` by construction**, which is asserted directly against a fixture mixing all four terms. The sparkline plots kept money; a gross sparkline would flatter a day whose miles ate it.

`dailyEarnings` returns an empty axis for a single-day window, an unbounded one, or anything past `MAX_DAY_AXIS` (400 days) — a bounded-ingestion guard, since a multi-year custom range is not a chart.

Read-side only: no schema change, no `PROJECTOR_VERSION` bump, no economy dependency, `AnalyticsRepository` still DAO-only.

## UI (§3)

- **`PeriodPager`** — `‹ [ This week · Jul 13–19 ] ›` over Day/Week/Month/Lifetime/Custom… chips. `›` is dead at the current window, `‹` at Lifetime. `WindowLabel` (pure, tested) decides the relation word and the range text: the year appears only when the window leaves today's year, a week inside one month reads `Jul 13 – 19`, a straddling one `Jun 29 – Jul 5`, a New-Year-straddling range states both years.
- **`RangePickerSheet`** — presets (Today/Yesterday/This week/Last week/This month/Last month/Lifetime) + a Monday-first month-paged calendar with **earning dots** (opacity tracks that day's gross), future days disabled, range selection with a re-anchoring second tap, and a commit button that states what it will do (`Show Jul 13 – 19`). The dots reuse the same per-day read the Money chart uses — a dot and a bar can never disagree.
- **`RecapHero`** — kept money, the delta vs the previous equivalent window, a net sparkline, and one factual summary line (`$412.83 gross · 47 deliveries · 15h 49m online · 37% acceptance`).
- **Tabs unchanged** in this stage; they simply read the selected window. `TimeTab`'s mileage/tax card now derives its year and its spans-years note from the **window's own endpoints** instead of the device clock — before the pager existed those were the same answer, but paging back to last December would otherwise quote this year's IRS rate over last year's miles.

**Window persistence** lives in **app prefs** (`AppPreferencesDataSource`/`Repository`) — the same store as theme and glance mode, because this is a UI preference the driver chose, not machine state (`app_state` is the state machine's). It persists as an `AnalyticsWindowSelection`: `Relative(granularity, offset)` for the pageable granularities, `Custom(start, endInclusive)` only for a driver-drawn range. Relative-not-absolute is the point — reopening the hub next week still means *this* week rather than restoring a stale range. Decode is fail-closed to the current pay week (unknown granularity, missing endpoint, backwards range, or a positive/future offset all fall back).

**One design-system addition:** `AppSparkline` (`:core:designsystem`) — there was no trend-line component. Axis-less and label-less by design (a sparkline states shape; the real number sits beside it), negative-aware so a losing day dips instead of clamping flat.

## Copy & honesty (§9)

- The hero headline is net and is labelled **frozen at decision-time costs**.
- A delta is stated only when there is something real to compare against: Lifetime says "No earlier window to compare"; a previous window that earned nothing gets "Up from nothing in …" rather than a divide-by-zero percentage; a sub-half-percent move reads as "Same as …" rather than a spurious `▲ 0%`.
- The summary line is measured facts only — no projection, no promise.

## Tests

`./gradlew testDebugUnitTest :domain:test` — **green** (1210 `:app` tests across 82 classes, 0 failures). `./gradlew :app:lintVitalRelease` — **green**.

New: `AnalyticsWindowsTest` (`:domain`, 38) — Monday weeks from every weekday, calendar-month stepping across January, previous-equivalent window incl. the 28- and 29-day Februaries, step round-tripping, the forward fence, selection resolution, and the `AnalyticsPeriod` bridge. `AnalyticsWindowReadsTest` (`:core:data`, 12) — window ≡ enum, per-day net decomposes period net, the day-axis guards, previous-window reads. `WindowLabelTest` (14) and `RecapModelTest` (14) in `:app`.

**Existing tests I had to touch (2, both `:app`, both pinned the enum plumbing at the UI level — no `:core:data` or `:domain` test changed):**

1. `AnalyticsViewModelTest` — rewritten for the window API (the VM no longer has `setPeriod`/`selectedPeriod`). Also rewired its harness: the hub's midnight re-anchor is an unbounded *virtual-time* loop, so `advanceUntilIdle()` never terminates, and `runTest`'s own teardown drains the scheduler while `viewModelScope` is not a child of the test scope. It now settles with `runCurrent()` and cancels the ViewModel scope inside the body (`runWithViewModel`). Both rules are documented in the class KDoc — a 12-minute hang was the receipt.
2. `MileageTaxModelTest` — `MileageTaxModel.from` takes a window instead of a period; gained two cases for the new behavior (a paged-back window priced at its own year; a custom range straddling New Year).

---

### Design-goal review

1. **UDF** — the window is state flowing down (`AnalyticsUiState.window`/`today`/`canStepBack`/`canStepForward`, all derived in the VM) and intents flowing up (`stepWindow`/`setGranularity`/`setRelativeWindow`/`setCustomRange`/`setPickerMonth`). The UI never writes a repository; the DataStore is the selection's SSOT and the VM reads it back rather than holding an optimistic copy. Reducers untouched — this is entirely read-side.
2. **MAD** — Compose + Flow throughout; the window model is pure Kotlin in `:domain`; persistence is the existing Preferences DataStore behind its Hilt qualifier; no new dependency.
3. **Single responsibility** — new UI split into three files by concern (`PeriodPager` / `RangePickerSheet` / `RecapHero`) rather than grown onto `AnalyticsScreen`; each of the three carries its own pure, Compose-free model (`WindowLabel`, `RecapModel`) on the `WaterfallModel` precedent. `RangePickerSheet` is data-in/lambdas-out (its month + dots are hoisted; only the uncommitted range selection is sheet-local).
4. **Kotlin/Android** — sealed `AnalyticsWindowSelection` over a stringly-typed granularity+dates tuple; `require` invariants make an empty or backwards window structurally unconstructable; `SharingStarted.WhileSubscribed` for the derived state, `Eagerly` only where an intent must read a settled value.
5. **SSOT** — the headline claim of this PR. `PeriodBounds` has one boundary rule set with the enum path delegating to the window path; each aggregate has one `…In(boundsFlow)` core with two overloads; per-day net derives from the same frozen columns as period net (proved by the Σ test) rather than a second copy of the accounting; the calendar's earning dots reuse the Money chart's per-day read; every rendered date routes through the `:domain` format SSOT (`formatMonthDay`/`formatMonthDayYear`/`formatMonthYear`/`formatMonthName` added there, not at the call site).
6. **Security & privacy** — no new capture, network, PII, or effect surface. Everything added is a read over already-aggregated economics; the only new persisted values are a granularity name, an integer offset, and two epoch days. Frozen economics are read, never recomputed.
7. **Semantic logging** — one new log site, a WARN in `AnalyticsViewModel.persist` when a selection fails to persist, carrying a granularity name and an integer only (no PII, P7-safe). Tagged `AnalyticsVm`.
8. **Platform-agnostic core** — no `Platform` literal anywhere in the diff. `periodEconomics(window, platform)` keeps the existing registry-resolved `platform.wire` lookup unchanged.

**Reactive UI** — the hub re-anchors at local midnight via `currentLocalDateFlow` (once a day, which is exactly the rate the anchor changes) and re-emits on every projector commit via Room invalidation. No `rememberNow()` was added: every figure on this surface is a settled historical value, and the one time-derived thing (which window is "current", and therefore whether `›` is live) is derived in the VM from that flow rather than frozen at composition. Deliberate non-reactivity, documented in the repository: a paged window's bounds are fixed and must not drift under the reader.

**Known stage handoff (not a violation):** the Patterns tab still reads all-time while the pager sits above it. Brief §6 assigns the `ALL TIME` badge that declares this to **stage 5**; per the issue's scope this stage leaves Patterns' behavior untouched.

### Adversarial review

_Pending — to be run before merge per the #589 loop (`/code-review`, plus `/security-review` if the reviewer judges the DataStore/read-boundary changes warrant it)._

### Field-test checklist item (ready to transplant into `docs/field-testing/README.md`)

```
- **Analytics period pager + range picker + recap hero (#970, epic #969 stage 1).** Open
  Analytics. The top should be `‹ This week · Jul 13–19 ›` over Day/Week/Month/Lifetime/Custom…
  chips, with a recap hero under it (kept money, a delta vs the previous window, a sparkline, and
  one summary line). What to check: (a) `‹` walks back a week at a time and the numbers change
  with the label — never a label that moved while the numbers didn't; (b) `›` is greyed out on the
  current window and lights up once you've paged back; (c) tap the centre label → the sheet's
  calendar shows dots on days you actually dashed (brighter = earned more), future days are
  untappable, and `Show Jul 13 – 19` states the range you drew; (d) switch tabs and the window
  sticks; (e) force-stop the app, reopen — the window comes back, and "This week" still means the
  CURRENT week the next day, not the one you had selected; (f) the hero's delta reads sensibly
  against last week (and says "No earlier window to compare" on Lifetime).
  - Confirmed: 0/2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
