### PR TITLE
feature(analytics): #979 — Patterns: ALL-TIME badge, heatmap Rate/Hours toggle, store leaderboard (redesign stage 5/7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -706,6 +706,33 @@ strip and the Patterns grid can't drift apart. The review row reuses `ReviewFlag
 `NeedsALookCard` verbatim, scoped to the same week the block above it describes, with the action
 normalised to *navigate* into the hub (which owns the assign/attest dialogs) rather than inheriting an
 in-place label it can't honour. Read-side only — no schema change, no `PROJECTOR_VERSION` bump.
+**Patterns: ALL-TIME badge + heatmap toggle + store leaderboard (#979, stage 5 — brief §6):** UI-only
+over the already-free `storeReportCards()`/`earningsHeatmap()` reads — **zero** new queries, no schema
+change, no `PROJECTOR_VERSION` bump. An `ALL TIME` `AppChip` + declaring caption sit above the grid so
+the tab's lifetime scope reads as deliberate, not as ignoring the #970 pager above it. The heatmap
+gains a Rate/Hours `AppSegmented` toggle over the SAME grid: `EarningsHeatmapCell.coverageHours` was
+already computed alongside `.dollarsPerHour` and simply never rendered. Hours mode reuses
+`AppHeatScale.cellColor` UNCHANGED (Principle 5 — no second color path) by folding a genuinely-zero
+coverage cell to `null` before calling it, landing it on the same "no data" swatch a masked Rate cell
+already uses; Hours therefore has no Rate-equivalent "worked, no net" third state (coverage has no bad
+outcome) and gets its own legend/title/caption, while the Rate-only best-hour $/hr callout stays
+Rate-mode only. The store cards became a leaderboard (rank · name · the existing `StoreLocationChip` as
+the "area chip" — there is no city/neighborhood data anywhere in the schema, so this reuses the
+existing chain/location-key chip rather than minting one) with a proportional net bar scaled to the
+list's #1 (highest-net) store and `N deliveries · usual wait` inline, amber'd on an outlier wait. Sort
+chips By net / By wait / Recent reorder rows via the new pure `PatternsModel.sortedStores`; the bar
+scale (`PatternsModel.maxNet`) and the outlier fleet (`PatternsModel.isWaitOutlier`) are both computed
+over the FULL store list regardless of the active sort, so switching chips reorders rows without
+rescaling/reflagging them underneath the driver. **Outlier definition (no prior convention in the
+codebase to anchor to, so documented at the constant):** a store's own `p50DwellMillis` is flagged once
+it is `>= 1.5×` (`PatternsModel.OUTLIER_MULTIPLIER`) the FLEET's median `p50DwellMillis` — computed
+across every store currently on the leaderboard that carries a real dwell sample — gated on at least 3
+such stores (`PatternsModel.MIN_FLEET_SAMPLE_FOR_OUTLIER`, §9 thin-data honesty) so a 1–2-store board
+can never manufacture an outlier from a near-meaningless median. A store with no wait sample of its own
+is never flagged. "Recent" reuses `StoreReportCard.lastSeenAt` — the DAO's own existing
+`ORDER BY lastSeenAt DESC` — rather than a new query. `Platform` is available on `StoreReportCard.platform`
+per #315 but this pass doesn't render it on the row (out of the brief's row spec); no `Platform` literal
+was added.
 **The "(No session)" bucket (#660 piece 1):** `delivery_records` rows whose source event carried
 NO `sessionId` at all were already counted in net (`deliveryTotals`'s own-`completedAt` fallback, #655)
 but invisible to gross (`grossAndUnattributed`/`sessionGrossRows` iterate `session_records` only, so a

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsModel.kt
@@ -1,0 +1,115 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmapCell
+import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
+
+/**
+ * Pure, Compose-free logic for the Patterns tab's #979 leaderboard + heatmap toggle (redesign stage
+ * 5/7, brief §6). Compose-free on purpose (the [WindowLabel]/`MoneyWentModel` precedent) — the
+ * interesting part is sort/threshold reasoning, and it should be provable without rendering.
+ */
+object PatternsModel {
+
+    // ── Heatmap Rate/Hours toggle ───────────────────────────────────────
+
+    /** Which per-cell value the heatmap is currently tinted by — both are already computed on
+     *  [EarningsHeatmapCell] (brief §6: "thrown away at render"), this just picks one. */
+    enum class HeatmapMode { RATE, HOURS }
+
+    /**
+     * The value [mode] reads off [cell] for coloring. RATE reuses the existing masked
+     * [EarningsHeatmapCell.dollarsPerHour] (null below the coverage floor). HOURS has no floor/mask
+     * concept — every cell's [EarningsHeatmapCell.coverageHours] is a real measurement — so a
+     * genuinely-zero (never-dashed) hour is folded to `null` here on purpose: it lets the caller feed
+     * the result straight into [cloud.trotter.dashbuddy.core.designsystem.component.AppHeatScale.cellColor],
+     * whose `rate == null` branch already renders the "no data" swatch, which is exactly what "never
+     * dashed this hour" means in Hours mode. There is no Hours equivalent of Rate's third "worked, no
+     * net" state — coverage has no notion of a bad outcome, only more or less of it.
+     */
+    fun cellValue(cell: EarningsHeatmapCell, mode: HeatmapMode): Double? = when (mode) {
+        HeatmapMode.RATE -> cell.dollarsPerHour
+        HeatmapMode.HOURS -> cell.coverageHours.takeIf { it > 0.0 }
+    }
+
+    /** The color-scale top for Hours mode — the driver's own most-covered hour-of-week cell (mirrors
+     *  [EarningsHeatmap.maxDollarsPerHour] for Rate). Zero when the heatmap has no coverage at all. */
+    fun maxCoverageHours(heatmap: EarningsHeatmap): Double =
+        heatmap.cells.maxOfOrNull { it.coverageHours } ?: 0.0
+
+    // ── Store leaderboard ───────────────────────────────────────────────
+
+    /** Sort chips (brief §6): By net (best net first), By wait (shortest usual wait first — a
+     *  leaderboard's rank 1 is the best-performing row under whichever criterion is selected), Recent
+     *  (most recently visited first — the repository's own existing `ORDER BY lastSeenAt DESC`). */
+    enum class LeaderboardSort { NET, WAIT, RECENT }
+
+    /**
+     * [cards] ordered for the leaderboard under [sort]. A store with no usual-wait sample (no pickup
+     * dwell recorded yet) sorts to the BOTTOM of a By-wait ranking — an absent measurement is not a
+     * fast time, and floating it to the top would misreport a data gap as a win. Ties break on
+     * [StoreReportCard.chainDisplay] so the order is deterministic (never a re-shuffle on re-emit).
+     */
+    fun sortedStores(cards: List<StoreReportCard>, sort: LeaderboardSort): List<StoreReportCard> =
+        when (sort) {
+            LeaderboardSort.NET -> cards.sortedWith(compareByDescending<StoreReportCard> { it.net }.thenBy { it.chainDisplay })
+            LeaderboardSort.WAIT -> cards.sortedWith(
+                compareBy<StoreReportCard> { it.p50DwellMillis ?: Long.MAX_VALUE }.thenBy { it.chainDisplay },
+            )
+            LeaderboardSort.RECENT -> cards.sortedWith(compareByDescending<StoreReportCard> { it.lastSeenAt }.thenBy { it.chainDisplay })
+        }
+
+    /** The #1 (highest-net) store's net across [cards] — the proportional bar's scale top, held fixed
+     *  regardless of the currently selected [LeaderboardSort] so switching sort chips never rescales
+     *  the bars underneath the driver. Non-positive when no store has positive net. */
+    fun maxNet(cards: List<StoreReportCard>): Double = cards.maxOfOrNull { it.net } ?: 0.0
+
+    /**
+     * How far [net] fills the proportional bar relative to [maxNet] (the #1 store). A non-positive
+     * [net] or [maxNet] renders an empty bar — the bar communicates "how much of the best store's net"
+     * and a store that lost money (or ties/leads a field with no positive net at all) has nothing
+     * positive to show proportionally; its net FIGURE (rendered separately) still carries the real,
+     * possibly-negative number.
+     */
+    fun netBarFraction(net: Double, maxNet: Double): Float {
+        if (maxNet <= 0.0 || net <= 0.0) return 0f
+        return (net / maxNet).toFloat().coerceIn(0f, 1f)
+    }
+
+    /**
+     * Below this many stores carrying a real usual-wait sample, "outlier" has no honest fleet to
+     * compare against (§9 thin-data honesty) — every wait renders un-amber'd rather than the fleet
+     * median itself being a near-meaningless 1- or 2-store figure.
+     */
+    const val MIN_FLEET_SAMPLE_FOR_OUTLIER = 3
+
+    /**
+     * A store's usual wait counts as an outlier once it's at least this many times the FLEET median
+     * usual wait (computed across every store currently on the leaderboard with a real sample) —
+     * "notably slower than everywhere else you go," never an absolute clock-time judgment. 1.5× is a
+     * documented, deliberately-chosen threshold — there is no existing outlier convention anywhere
+     * else in the codebase to anchor to; retune here if the field data proves it too noisy/quiet.
+     */
+    const val OUTLIER_MULTIPLIER = 1.5
+
+    /**
+     * True when [card]'s own [StoreReportCard.p50DwellMillis] is an outlier against the fleet median
+     * of every OTHER sampled wait in [cards] (see [MIN_FLEET_SAMPLE_FOR_OUTLIER] / [OUTLIER_MULTIPLIER]
+     * for the honesty floor + the chosen threshold). A store with no wait sample of its own is never an
+     * outlier (nothing to flag).
+     */
+    fun isWaitOutlier(cards: List<StoreReportCard>, card: StoreReportCard): Boolean {
+        val wait = card.p50DwellMillis ?: return false
+        val samples = cards.mapNotNull { it.p50DwellMillis }
+        if (samples.size < MIN_FLEET_SAMPLE_FOR_OUTLIER) return false
+        val fleetMedian = medianOf(samples)
+        if (fleetMedian <= 0L) return false
+        return wait >= fleetMedian * OUTLIER_MULTIPLIER
+    }
+
+    private fun medianOf(values: List<Long>): Long {
+        val sorted = values.sorted()
+        val mid = sorted.size / 2
+        return if (sorted.size % 2 == 0) (sorted[mid - 1] + sorted[mid]) / 2 else sorted[mid]
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
@@ -45,6 +45,7 @@ import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppHeatScale
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
 import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
@@ -53,6 +54,8 @@ import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
 import cloud.trotter.dashbuddy.domain.format.formatShortDate
 import cloud.trotter.dashbuddy.domain.format.hourOfDayLabel
+import cloud.trotter.dashbuddy.ui.main.analytics.PatternsModel.HeatmapMode
+import cloud.trotter.dashbuddy.ui.main.analytics.PatternsModel.LeaderboardSort
 import java.time.DayOfWeek
 import java.time.format.TextStyle
 import java.util.Locale
@@ -79,8 +82,28 @@ fun PatternsTab(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        AllTimeBadge()
         HeatmapCard(heatmap)
         StoresCard(storeCards)
+    }
+}
+
+/**
+ * #979: declares this tab as always-lifetime — it ignores the #970 `‹ ›` pager above it by design
+ * (rate/pattern surfaces need the driver's whole history, not one window), which otherwise reads as a
+ * bug the first time a driver pages the header and nothing here moves.
+ */
+@Composable
+private fun AllTimeBadge() {
+    val c = AppTheme.colors
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        AppChip(text = stringResource(R.string.patterns_tab_all_time_badge))
+        Text(
+            text = stringResource(R.string.patterns_tab_all_time_caption),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 
@@ -93,17 +116,32 @@ private val DAY_ROWS = listOf(
 )
 
 /**
- * The net-$/hr hour×day heatmap: 7 day-rows × 24 hour-columns, each cell tinted by the driver's own
- * realized net $/hr for that hour-of-week. A cell below the coverage floor renders as
- * *insufficient* (near-empty), visually distinct from a genuinely-zero cell (worked, earned ~nothing).
- * The color ramp is scaled to the driver's own best hour, so it reads as "your best/worst times",
- * never an absolute-dollar claim.
+ * The hour×day heatmap: 7 day-rows × 24 hour-columns. #979 adds a Rate/Hours toggle over ONE grid —
+ * both values are already computed per cell ([EarningsHeatmapCell.dollarsPerHour] /
+ * [EarningsHeatmapCell.coverageHours]) and, pre-#979, only Rate was ever rendered (brief §6).
+ *
+ * **Rate** (unchanged): tinted by the driver's own realized net $/hr for that hour-of-week. A cell
+ * below the coverage floor renders as *insufficient* (near-empty), visually distinct from a
+ * genuinely-zero cell (worked, earned ~nothing) — the third state gets a `bad` border on its `badBg`
+ * fill. The ramp is scaled to the driver's own best hour, so it reads as "your best/worst times", never
+ * an absolute-dollar claim.
+ *
+ * **Hours** (new): tinted by how many hours of coverage that cell has, scaled to the driver's own
+ * most-covered hour-of-week. There is no "worked, no net" state here — coverage has no bad outcome,
+ * only more or less of it — so a genuinely-zero-coverage cell folds into the SAME "no data" swatch as
+ * an insufficient Rate cell ([PatternsModel.cellValue] does this on purpose, reusing [AppHeatScale]
+ * unchanged rather than adding a second color path).
  */
 @Composable
 private fun HeatmapCard(heatmap: EarningsHeatmap) {
     val c = AppTheme.colors
+    var mode by rememberSaveable { mutableStateOf(HeatmapMode.RATE) }
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = stringResource(R.string.patterns_tab_heatmap_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(
+            text = stringResource(if (mode == HeatmapMode.RATE) R.string.patterns_tab_heatmap_title else R.string.patterns_tab_heatmap_title_hours),
+            style = MaterialTheme.typography.labelMedium,
+            color = c.text3,
+        )
         Spacer(Modifier.height(10.dp))
 
         if (!heatmap.hasData) {
@@ -116,7 +154,19 @@ private fun HeatmapCard(heatmap: EarningsHeatmap) {
             return@AppCard
         }
 
+        val modeOptions = heatmapModeOptions()
+        val selectedModeLabel = modeOptions.first { it.mode == mode }.label
+        AppSegmented(
+            options = modeOptions.map { it.label },
+            selected = selectedModeLabel,
+            onSelect = { label -> modeOptions.firstOrNull { it.label == label }?.let { mode = it.mode } },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(Modifier.height(10.dp))
+
         val maxRate = heatmap.maxDollarsPerHour ?: 0.0
+        val maxHours = PatternsModel.maxCoverageHours(heatmap)
+        val maxForMode = if (mode == HeatmapMode.RATE) maxRate else maxHours
 
         // Grid: each day is a row of a fixed-width label + 24 weighted cells.
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -134,17 +184,17 @@ private fun HeatmapCard(heatmap: EarningsHeatmap) {
                     ) {
                         for (hour in 0 until EarningsHeatmap.HOURS) {
                             val cell = heatmap.cell(day.value - 1, hour)
-                            val rate = cell.dollarsPerHour
-                            // A covered-but-≤$0 cell ("worked, no net") gets a `bad` border on its badBg
-                            // fill so it reads as a distinct third state, not a dim tint (legible in both
-                            // themes with the fixed palette).
-                            val zeroRate = rate != null && rate <= 0.0
+                            val value = PatternsModel.cellValue(cell, mode)
+                            // "Worked, no net" is a Rate-only third state — Hours has no bad outcome to
+                            // border, only more/less coverage.
+                            val cellRate = cell.dollarsPerHour
+                            val zeroRate = mode == HeatmapMode.RATE && cellRate != null && cellRate <= 0.0
                             Box(
                                 modifier = Modifier
                                     .weight(1f)
                                     .aspectRatio(1f)
                                     .clip(RoundedCornerShape(2.dp))
-                                    .background(AppHeatScale.cellColor(cell.dollarsPerHour, maxRate, c))
+                                    .background(AppHeatScale.cellColor(value, maxForMode, c))
                                     .then(
                                         if (zeroRate) Modifier.border(1.dp, c.bad, RoundedCornerShape(2.dp))
                                         else Modifier,
@@ -158,30 +208,42 @@ private fun HeatmapCard(heatmap: EarningsHeatmap) {
         Spacer(Modifier.height(6.dp))
         HourAxis()
         Spacer(Modifier.height(12.dp))
-        HeatmapLegend(maxRate)
+        if (mode == HeatmapMode.RATE) HeatmapLegend(maxRate) else HeatmapHoursLegend()
 
-        // Best-hour callout — the single most-earning cell (driver's own experience). Reads the domain
-        // SSOT [EarningsHeatmap.bestCell], the same cell the color ramp is scaled to (Principle 5).
-        heatmap.bestCell?.let { best ->
-            Spacer(Modifier.height(10.dp))
-            Text(
-                text = stringResource(
-                    R.string.patterns_tab_heatmap_best_format,
-                    "${DayOfWeek.of(best.dayIndex + 1).getDisplayName(TextStyle.SHORT, Locale.getDefault())} ${hourOfDayLabel(best.hour)}",
-                    Formats.money(best.dollarsPerHour!!),
-                ),
-                style = MaterialTheme.typography.bodyMedium,
-                color = c.text,
-            )
+        // Best-hour callout is a Rate concept (the single most-earning cell) — showing a $/hr figure
+        // while the grid is tinted by coverage would read as mismatched, so it's Rate-mode only.
+        if (mode == HeatmapMode.RATE) {
+            heatmap.bestCell?.let { best ->
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    text = stringResource(
+                        R.string.patterns_tab_heatmap_best_format,
+                        "${DayOfWeek.of(best.dayIndex + 1).getDisplayName(TextStyle.SHORT, Locale.getDefault())} ${hourOfDayLabel(best.hour)}",
+                        Formats.money(best.dollarsPerHour!!),
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = c.text,
+                )
+            }
         }
         Spacer(Modifier.height(6.dp))
         Text(
-            text = stringResource(R.string.patterns_tab_heatmap_caption),
+            text = stringResource(if (mode == HeatmapMode.RATE) R.string.patterns_tab_heatmap_caption else R.string.patterns_tab_heatmap_caption_hours),
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
     }
 }
+
+/** The heatmap Rate/Hours segments paired with their resolved label (#428 Half A) — selection stays
+ *  keyed off the enum, never the resolved string. */
+private data class HeatmapModeOption(val mode: HeatmapMode, val label: String)
+
+@Composable
+private fun heatmapModeOptions(): List<HeatmapModeOption> = listOf(
+    HeatmapModeOption(HeatmapMode.RATE, stringResource(R.string.patterns_tab_heatmap_mode_rate)),
+    HeatmapModeOption(HeatmapMode.HOURS, stringResource(R.string.patterns_tab_heatmap_mode_hours)),
+)
 
 /** Four evenly-spaced clock ticks under the grid (offset past the day-label gutter). */
 @Composable
@@ -220,6 +282,24 @@ private fun HeatmapLegend(maxRate: Double) {
     }
 }
 
+/**
+ * The Hours-mode legend (#979): just the "no data" swatch (never dashed this hour) + the low→high
+ * coverage ramp — no covered-but-bad third state, since coverage has no bad outcome (see [HeatmapCard]
+ * KDoc).
+ */
+@Composable
+private fun HeatmapHoursLegend() {
+    val c = AppTheme.colors
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        LegendSwatch(c.surface3)
+        Text(text = stringResource(R.string.patterns_tab_heatmap_legend_hours_none), style = MaterialTheme.typography.labelSmall, color = c.text3)
+        Spacer(Modifier.width(8.dp))
+        Text(text = stringResource(R.string.patterns_tab_heatmap_legend_low), style = MaterialTheme.typography.labelSmall, color = c.text3)
+        listOf(0.0, 0.5, 1.0).forEach { f -> LegendSwatch(AppHeatScale.ramp(f.toFloat(), c)) }
+        Text(text = stringResource(R.string.patterns_tab_heatmap_legend_high), style = MaterialTheme.typography.labelSmall, color = c.text3)
+    }
+}
+
 @Composable
 private fun LegendSwatch(color: Color, border: Color? = null) {
     Box(
@@ -234,12 +314,13 @@ private fun LegendSwatch(color: Color, border: Color? = null) {
 // ── Store report cards ──────────────────────────────────────────────────
 
 /**
- * The per-store report cards, newest-visited first (the repository already orders by last-seen).
- *
- * #765: the card **face** is deliberately glanceable — store name + location chip and just the three
- * decision-driving numbers (net, usual wait, deliveries) in plain language (no "median"/"p95"
- * statistical vocabulary). Tapping a card opens [StoreDetailSheet] with the full detail (pickups,
- * gross, the dwell distribution with its precise stat terms, first/last seen). Selection is a
+ * The store **leaderboard** (#979, replacing the old stacked cards): one row per store — rank, name,
+ * area chip, a proportional net bar, `N deliveries · usual wait` inline, net figure, chevron. Sort
+ * chips (By net / By wait / Recent) reorder the rows via [PatternsModel.sortedStores]; the net bar's
+ * scale ([PatternsModel.maxNet]) and the outlier fleet ([PatternsModel.isWaitOutlier]) are both computed
+ * over the FULL [cards] list regardless of sort, so switching chips reorders rows without rescaling or
+ * re-flagging them underneath the driver. Tapping a row opens [StoreDetailSheet] with the full detail
+ * (pickups, gross, the dwell distribution with its precise stat terms, first/last seen). Selection is a
  * local [rememberSaveable] `selectedStoreKey` (UDF — state down, the tap event up); the sheet body
  * re-derives from the same [cards] list, so a projector re-emit keeps it fresh with no extra state
  * (a selection whose store leaves the list is explicitly cleared).
@@ -248,6 +329,7 @@ private fun LegendSwatch(color: Color, border: Color? = null) {
 private fun StoresCard(cards: List<StoreReportCard>) {
     val c = AppTheme.colors
     var selectedStoreKey by rememberSaveable { mutableStateOf<String?>(null) }
+    var sort by rememberSaveable { mutableStateOf(LeaderboardSort.NET) }
 
     // If the selected store leaves the list (e.g. a projector refold re-keys it), clear the
     // selection explicitly — otherwise the stale key would linger in rememberSaveable and could
@@ -278,9 +360,27 @@ private fun StoresCard(cards: List<StoreReportCard>) {
                 modifier = Modifier.padding(vertical = 4.dp),
             )
         } else {
-            cards.forEachIndexed { index, card ->
+            val sortOptions = leaderboardSortOptions()
+            val selectedSortLabel = sortOptions.first { it.sort == sort }.label
+            AppSegmented(
+                options = sortOptions.map { it.label },
+                selected = selectedSortLabel,
+                onSelect = { label -> sortOptions.firstOrNull { it.label == label }?.let { sort = it.sort } },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(12.dp))
+
+            val maxNet = PatternsModel.maxNet(cards)
+            val ranked = PatternsModel.sortedStores(cards, sort)
+            ranked.forEachIndexed { index, card ->
                 if (index > 0) Spacer(Modifier.height(14.dp))
-                StoreRow(card, onClick = { selectedStoreKey = card.storeKey })
+                LeaderboardRow(
+                    rank = index + 1,
+                    card = card,
+                    maxNet = maxNet,
+                    outlier = PatternsModel.isWaitOutlier(cards, card),
+                    onClick = { selectedStoreKey = card.storeKey },
+                )
             }
         }
     }
@@ -294,53 +394,106 @@ private fun StoresCard(cards: List<StoreReportCard>) {
     }
 }
 
-/**
- * The glanceable card **face** (#765): store name + location chip, a tap-affordance chevron, and the
- * three decision-driving numbers in plain language — net, "usual wait", deliveries. Everything else
- * (pickups, gross, the dwell distribution, first/last seen) lives in [StoreDetailSheet] behind a tap.
- * "Usual wait" is the median dwell rendered without the statistical label.
- */
-@OptIn(ExperimentalLayoutApi::class)
+/** The leaderboard sort chips paired with their resolved label (#428 Half A) — selection stays keyed
+ *  off the enum, never the resolved string. */
+private data class LeaderboardSortOption(val sort: LeaderboardSort, val label: String)
+
 @Composable
-private fun StoreRow(card: StoreReportCard, onClick: () -> Unit) {
+private fun leaderboardSortOptions(): List<LeaderboardSortOption> = listOf(
+    LeaderboardSortOption(LeaderboardSort.NET, stringResource(R.string.patterns_tab_leaderboard_sort_net)),
+    LeaderboardSortOption(LeaderboardSort.WAIT, stringResource(R.string.patterns_tab_leaderboard_sort_wait)),
+    LeaderboardSortOption(LeaderboardSort.RECENT, stringResource(R.string.patterns_tab_leaderboard_sort_recent)),
+)
+
+/**
+ * One leaderboard row (#979): rank digit, store name + area chip, a proportional net bar scaled to
+ * [maxNet] (the #1 store), `N deliveries · usual wait` inline (the wait figure ambers when [outlier] —
+ * see [PatternsModel.isWaitOutlier]), the net figure, and the existing tap-through chevron. Tapping
+ * opens [StoreDetailSheet] with the full stat-labeled detail — same drill-down as before #979, just a
+ * denser face.
+ */
+@Composable
+private fun LeaderboardRow(rank: Int, card: StoreReportCard, maxNet: Double, outlier: Boolean, onClick: () -> Unit) {
     val c = AppTheme.colors
-    // The row itself is the explicit button (role + onClickLabel); the chevron is decorative.
     val detailsLabel = stringResource(R.string.patterns_tab_store_details_cd, card.chainDisplay)
-    Column(
-        Modifier
+    val netColor = if (card.net >= 0.0) c.good else c.bad
+    val fraction = PatternsModel.netBarFraction(card.net, maxNet)
+
+    Row(
+        modifier = Modifier
             .fillMaxWidth()
             .clickable(onClickLabel = detailsLabel, role = Role.Button, onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = card.chainDisplay,
-                style = MaterialTheme.typography.bodyLarge,
-                color = c.text,
-                modifier = Modifier.weight(1f),
-            )
-            StoreLocationChip(card)
-            Spacer(Modifier.width(4.dp))
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = null,
-                tint = c.text3,
-                modifier = Modifier.size(20.dp),
-            )
+        Text(
+            text = stringResource(R.string.patterns_tab_leaderboard_rank_format, rank),
+            style = AppTheme.num.smNum,
+            color = c.text3,
+            modifier = Modifier.width(30.dp),
+        )
+        Column(Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = card.chainDisplay,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = c.text,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                Spacer(Modifier.width(8.dp))
+                StoreLocationChip(card)
+            }
+            Spacer(Modifier.height(6.dp))
+            // Proportional net bar — fraction-of-#1-store, so it stays a stable scale across sort chips.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(c.surface3),
+            ) {
+                if (fraction > 0f) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(fraction)
+                            .height(6.dp)
+                            .clip(RoundedCornerShape(3.dp))
+                            .background(netColor),
+                    )
+                }
+            }
+            Spacer(Modifier.height(6.dp))
+            val deliveriesWord = if (card.deliveries == 1) {
+                stringResource(R.string.time_tab_delivery_singular)
+            } else {
+                stringResource(R.string.time_tab_delivery_plural)
+            }
+            Row {
+                Text(
+                    text = "${Formats.commaInt(card.deliveries)} $deliveriesWord · ",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.text3,
+                )
+                Text(
+                    text = card.p50DwellMillis?.let { "${formatDuration(it)} ${stringResource(R.string.patterns_tab_leaderboard_wait_suffix)}" }
+                        ?: stringResource(R.string.patterns_tab_leaderboard_no_wait),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (outlier) c.warn else c.text3,
+                )
+            }
         }
-
-        Spacer(Modifier.height(8.dp))
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(24.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            StoreStat(
-                stringResource(R.string.patterns_tab_store_net_label),
-                Formats.money(card.net),
-                valueColor = if (card.net >= 0.0) c.good else c.bad,
-            )
-            StoreStat(
-                stringResource(R.string.patterns_tab_store_usual_wait_label),
-                card.p50DwellMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
-            )
-            StoreStat(stringResource(R.string.patterns_tab_store_deliveries_label), Formats.commaInt(card.deliveries))
-        }
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text = Formats.money(card.net),
+            style = AppTheme.num.smNum,
+            color = netColor,
+        )
+        Spacer(Modifier.width(4.dp))
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = c.text3,
+            modifier = Modifier.size(20.dp),
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,14 +304,23 @@
     <string name="time_tab_mileage_tax_disclosure">standard-mileage method — not the app\'s operating-cost model; confirm with a tax preparer.</string>
 
     <!-- main/analytics/PatternsTab.kt (#315 H5) -->
+    <!-- #979: declares the tab as always-lifetime, fixing the looks-like-a-bug relationship with the #970 pager. -->
+    <string name="patterns_tab_all_time_badge">All time</string>
+    <string name="patterns_tab_all_time_caption">patterns need history — this tab always reads your whole record</string>
     <string name="patterns_tab_heatmap_title">YOUR NET $/HR BY HOUR</string>
     <string name="patterns_tab_heatmap_caption">your own realized net $/hr, by hour and day — where your time actually pays. Lifetime.</string>
+    <!-- #979: heatmap Rate/Hours toggle — the Hours copy for the same grid, coloring by coverage instead of rate. -->
+    <string name="patterns_tab_heatmap_mode_rate">Rate</string>
+    <string name="patterns_tab_heatmap_mode_hours">Hours</string>
+    <string name="patterns_tab_heatmap_title_hours">YOUR HOURS WORKED BY HOUR</string>
+    <string name="patterns_tab_heatmap_caption_hours">how many hours you\'ve spent online in each hour-of-week slot, lifetime.</string>
     <string name="patterns_tab_heatmap_no_data">Not enough dashing yet to show a pattern. Dash a few more hours and your best times will fill in here.</string>
     <string name="patterns_tab_heatmap_best_format">Your best hour so far: %1$s — %2$s/hr</string>
     <string name="patterns_tab_heatmap_legend_low">lower</string>
     <string name="patterns_tab_heatmap_legend_high">higher</string>
     <string name="patterns_tab_heatmap_legend_insufficient">too little time</string>
     <string name="patterns_tab_heatmap_legend_zero">worked, no net</string>
+    <string name="patterns_tab_heatmap_legend_hours_none">never dashed this hour</string>
     <string name="patterns_tab_stores_title">YOUR STORES</string>
     <string name="patterns_tab_stores_manual_note">Manually-added deliveries and history we couldn\'t match to a store still count in your Money totals — they just don\'t show up as a store card here yet.</string>
     <string name="patterns_tab_no_stores">No stores visited yet.</string>
@@ -321,8 +330,6 @@
     <string name="patterns_tab_store_deliveries_label">Deliveries</string>
     <string name="patterns_tab_store_gross_label">Gross</string>
     <string name="patterns_tab_store_net_label">Net</string>
-    <!-- #765: card face shows "usual wait" (the median dwell, no stat vocabulary). -->
-    <string name="patterns_tab_store_usual_wait_label">Usual wait</string>
     <string name="patterns_tab_store_details_cd">Details for %1$s</string>
     <string name="patterns_tab_store_dwell_none">no pickup dwell recorded yet</string>
     <string name="patterns_tab_store_seen_format">first %1$s · last %2$s</string>
@@ -331,6 +338,13 @@
     <string name="patterns_tab_store_detail_median">Usual wait (median)</string>
     <string name="patterns_tab_store_detail_p95">Longest waits (p95)</string>
     <string name="patterns_tab_store_detail_avg">Average wait</string>
+    <!-- #979: store cards → leaderboard (brief §6) -->
+    <string name="patterns_tab_leaderboard_rank_format">#%1$d</string>
+    <string name="patterns_tab_leaderboard_sort_net">By net</string>
+    <string name="patterns_tab_leaderboard_sort_wait">By wait</string>
+    <string name="patterns_tab_leaderboard_sort_recent">Recent</string>
+    <string name="patterns_tab_leaderboard_wait_suffix">usual wait</string>
+    <string name="patterns_tab_leaderboard_no_wait">no wait recorded yet</string>
 
     <!-- setup/wizard/WizardScreen.kt -->
     <string name="wizard_screen_goal_option1_title">Cherry Picker</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsModelTest.kt
@@ -1,0 +1,187 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmapCell
+import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #979 — the Patterns tab leaderboard sort orders, the wait-outlier predicate, and the heatmap
+ * Rate/Hours toggle's cell-value selection. Compose-free, per the [WindowLabel] precedent: the
+ * interesting part is sort/threshold reasoning, and it should be provable without rendering.
+ */
+class PatternsModelTest {
+
+    private fun card(
+        storeKey: String,
+        chainDisplay: String = storeKey,
+        net: Double = 0.0,
+        p50DwellMillis: Long? = null,
+        lastSeenAt: Long = 0L,
+        deliveries: Int = 1,
+    ) = StoreReportCard(
+        storeKey = storeKey,
+        platform = "doordash",
+        normalizedChain = chainDisplay,
+        chainDisplay = chainDisplay,
+        runningKey = "1",
+        address = null,
+        locationKnown = true,
+        pickups = deliveries,
+        deliveries = deliveries,
+        gross = net,
+        net = net,
+        avgDwellMillis = p50DwellMillis?.toDouble(),
+        p50DwellMillis = p50DwellMillis,
+        p95DwellMillis = p50DwellMillis,
+        firstSeenAt = 0L,
+        lastSeenAt = lastSeenAt,
+    )
+
+    // ── sortedStores ────────────────────────────────────────────────────
+
+    @Test fun `NET sorts highest net first`() {
+        val cards = listOf(card("a", net = 10.0), card("b", net = 30.0), card("c", net = 20.0))
+        val sorted = PatternsModel.sortedStores(cards, PatternsModel.LeaderboardSort.NET)
+        assertEquals(listOf("b", "c", "a"), sorted.map { it.storeKey })
+    }
+
+    @Test fun `NET breaks ties by name for determinism`() {
+        val cards = listOf(card("z", chainDisplay = "Zebra", net = 10.0), card("a", chainDisplay = "Apple", net = 10.0))
+        val sorted = PatternsModel.sortedStores(cards, PatternsModel.LeaderboardSort.NET)
+        assertEquals(listOf("Apple", "Zebra"), sorted.map { it.chainDisplay })
+    }
+
+    @Test fun `WAIT sorts shortest usual wait first`() {
+        val cards = listOf(
+            card("slow", p50DwellMillis = 900_000L),
+            card("fast", p50DwellMillis = 60_000L),
+            card("mid", p50DwellMillis = 300_000L),
+        )
+        val sorted = PatternsModel.sortedStores(cards, PatternsModel.LeaderboardSort.WAIT)
+        assertEquals(listOf("fast", "mid", "slow"), sorted.map { it.storeKey })
+    }
+
+    @Test fun `WAIT sorts a store with no wait sample to the bottom`() {
+        val cards = listOf(
+            card("unsampled", p50DwellMillis = null),
+            card("sampled", p50DwellMillis = 60_000L),
+        )
+        val sorted = PatternsModel.sortedStores(cards, PatternsModel.LeaderboardSort.WAIT)
+        assertEquals(listOf("sampled", "unsampled"), sorted.map { it.storeKey })
+    }
+
+    @Test fun `RECENT sorts most recently seen first`() {
+        val cards = listOf(card("old", lastSeenAt = 100L), card("new", lastSeenAt = 300L), card("mid", lastSeenAt = 200L))
+        val sorted = PatternsModel.sortedStores(cards, PatternsModel.LeaderboardSort.RECENT)
+        assertEquals(listOf("new", "mid", "old"), sorted.map { it.storeKey })
+    }
+
+    // ── maxNet / netBarFraction ─────────────────────────────────────────
+
+    @Test fun `maxNet is the highest net across the list`() {
+        val cards = listOf(card("a", net = 10.0), card("b", net = 55.0), card("c", net = -20.0))
+        assertEquals(55.0, PatternsModel.maxNet(cards), 0.0)
+    }
+
+    @Test fun `maxNet of an empty list is zero`() {
+        assertEquals(0.0, PatternsModel.maxNet(emptyList()), 0.0)
+    }
+
+    @Test fun `the number-1 store's own bar fraction is 1`() {
+        assertEquals(1f, PatternsModel.netBarFraction(net = 55.0, maxNet = 55.0), 0.0001f)
+    }
+
+    @Test fun `a store at half the leader's net renders a half bar`() {
+        assertEquals(0.5f, PatternsModel.netBarFraction(net = 25.0, maxNet = 50.0), 0.0001f)
+    }
+
+    @Test fun `negative net renders an empty bar, never a negative fraction`() {
+        assertEquals(0f, PatternsModel.netBarFraction(net = -10.0, maxNet = 50.0), 0.0001f)
+    }
+
+    @Test fun `a non-positive maxNet renders an empty bar for every store`() {
+        assertEquals(0f, PatternsModel.netBarFraction(net = 5.0, maxNet = 0.0), 0.0001f)
+    }
+
+    // ── isWaitOutlier ───────────────────────────────────────────────────
+
+    @Test fun `a store far above the fleet median wait is flagged an outlier`() {
+        val cards = listOf(
+            card("a", p50DwellMillis = 300_000L), // 5 min
+            card("b", p50DwellMillis = 320_000L),
+            card("slow", p50DwellMillis = 900_000L), // 15 min — 3x the ~5min median
+        )
+        val slow = cards.first { it.storeKey == "slow" }
+        assertTrue(PatternsModel.isWaitOutlier(cards, slow))
+    }
+
+    @Test fun `a store near the fleet median is not an outlier`() {
+        val cards = listOf(
+            card("a", p50DwellMillis = 300_000L),
+            card("b", p50DwellMillis = 320_000L),
+            card("c", p50DwellMillis = 310_000L),
+        )
+        val c = cards.first { it.storeKey == "c" }
+        assertFalse(PatternsModel.isWaitOutlier(cards, c))
+    }
+
+    @Test fun `below the minimum fleet sample, nothing is flagged an outlier`() {
+        // Only 2 stores carry a wait sample — below MIN_FLEET_SAMPLE_FOR_OUTLIER (3), so even a huge
+        // gap must not be called out (thin-data honesty, §9).
+        val cards = listOf(card("a", p50DwellMillis = 60_000L), card("slow", p50DwellMillis = 3_600_000L))
+        val slow = cards.first { it.storeKey == "slow" }
+        assertFalse(PatternsModel.isWaitOutlier(cards, slow))
+    }
+
+    @Test fun `a store with no wait sample of its own is never an outlier`() {
+        val cards = listOf(
+            card("a", p50DwellMillis = 60_000L),
+            card("b", p50DwellMillis = 65_000L),
+            card("none", p50DwellMillis = null),
+        )
+        val none = cards.first { it.storeKey == "none" }
+        assertFalse(PatternsModel.isWaitOutlier(cards, none))
+    }
+
+    @Test fun `exactly at the multiplier threshold counts as an outlier`() {
+        // fleet median with an odd sample count 300_000/300_000/300_000 -> median 300_000; 1.5x = 450_000.
+        val cards = listOf(
+            card("a", p50DwellMillis = 300_000L),
+            card("b", p50DwellMillis = 300_000L),
+            card("edge", p50DwellMillis = 450_000L),
+        )
+        val edge = cards.first { it.storeKey == "edge" }
+        assertTrue(PatternsModel.isWaitOutlier(cards, edge))
+    }
+
+    // ── heatmap Rate/Hours toggle ───────────────────────────────────────
+
+    private fun cell(dollarsPerHour: Double?, coverageHours: Double) =
+        EarningsHeatmapCell(dayIndex = 0, hour = 0, netDollars = 0.0, coverageHours = coverageHours, dollarsPerHour = dollarsPerHour)
+
+    @Test fun `RATE mode reads dollarsPerHour verbatim, including a masked null`() {
+        assertEquals(4.5, PatternsModel.cellValue(cell(4.5, 2.0), PatternsModel.HeatmapMode.RATE))
+        assertEquals(null, PatternsModel.cellValue(cell(null, 0.1), PatternsModel.HeatmapMode.RATE))
+    }
+
+    @Test fun `HOURS mode reads coverageHours, folding a genuine zero to null`() {
+        assertEquals(2.0, PatternsModel.cellValue(cell(null, 2.0), PatternsModel.HeatmapMode.HOURS))
+        assertEquals(null, PatternsModel.cellValue(cell(5.0, 0.0), PatternsModel.HeatmapMode.HOURS))
+    }
+
+    @Test fun `maxCoverageHours is the largest cell coverage in the grid`() {
+        val heatmap = EarningsHeatmap(
+            cells = listOf(cell(null, 1.0), cell(2.0, 3.5), cell(1.0, 0.2)),
+            minCoverageHours = EarningsHeatmap.EMPTY.minCoverageHours,
+        )
+        assertEquals(3.5, PatternsModel.maxCoverageHours(heatmap), 0.0)
+    }
+
+    @Test fun `maxCoverageHours of an empty grid is zero`() {
+        assertEquals(0.0, PatternsModel.maxCoverageHours(EarningsHeatmap(emptyList(), 0.5)), 0.0)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,28 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #979 — Patterns: ALL-TIME badge, heatmap Rate/Hours toggle, store leaderboard
+  (redesign stage 5).** Open Analytics → Patterns. Three things to check.
+  (a) **ALL TIME badge:** an `All time` chip sits at the very top with the caption "patterns need
+  history — this tab always reads your whole record" — and paging the header `‹ ›` pager above must
+  NOT move anything on this tab (Patterns always reads your whole history regardless of the
+  selected window; that's the point of the badge).
+  (b) **Heatmap Rate/Hours toggle:** a segmented control (Rate / Hours) sits above the grid. Rate is
+  the pre-existing net-$/hr coloring (unchanged). Hours re-colors the SAME grid by how many hours
+  you've spent online in each slot — an hour you've genuinely never worked should render as the same
+  dim "no data" swatch as an under-covered Rate cell (there's no red/bad state in Hours mode, only
+  more-or-less green). The legend and title/caption below the grid must switch with the toggle.
+  (c) **Store leaderboard:** the store cards are now dense ranked rows — `#1`, `#2`, … at the left,
+  name + location chip, a horizontal net bar, `N deliveries · <time> usual wait` underneath, the net
+  figure and chevron at the right. Sort chips **By net / By wait / Recent** re-rank the rows (rank
+  numbers should update; the bar lengths should NOT rescale when you switch chips — they stay
+  relative to your #1 store by net). A store whose usual wait is notably worse than everywhere else
+  you go should render that wait figure in amber/warn color; check it stays plain-colored on stores
+  with only 1-2 total stores having a wait sample (thin data must never manufacture an outlier).
+  Tapping a row must still open the same detail sheet as before. The "manually-added deliveries…"
+  footnote must still be there.
+  - Confirmed: 0/2
+
 - **🆕 NEW — #977 — Home is now "Today" (redesign stage 4).** Open the app's home screen (not the
   bubble). Top to bottom it should read: **date + a live clock + a status pill** (the pill's word is
   the same status vocabulary the old card showed — Ready / Looking for offers / Heading to Pickup…),


### PR DESCRIPTION
## Summary

Stage 5 of the analytics redesign epic #969 (`docs/design/analytics-redesign-brief-2026-07-28.md` §6, Patterns half):

- **ALL TIME badge** — an `All time` `AppChip` + the declaring caption `patterns need history — this tab always reads your whole record`, sitting above the heatmap. Fixes the "looks like a bug" relationship with the #970 `‹ ›` pager: Patterns always reads the driver's whole history, and now says so instead of silently ignoring the pager.
- **Heatmap Rate/Hours toggle** — one `AppSegmented` control switches the SAME 7×24 grid between the existing net-$/hr coloring (Rate, unchanged) and a new coverage-hours coloring (Hours). `EarningsHeatmapCell.coverageHours` was already computed alongside `.dollarsPerHour` and simply never rendered (brief: "thrown away at render"). Hours mode reuses `AppHeatScale.cellColor` **unchanged** — a genuinely-zero-coverage cell is folded to `null` before the call, landing it on the same "no data" swatch a masked Rate cell already uses, so no second color path was added. Hours has no Rate-equivalent "worked, no net" third state (coverage has no bad outcome) and gets its own legend/title/caption; the Rate-only best-hour $/hr callout stays Rate-mode only. The existing `too little time` / `worked, no net` legend is untouched on Rate.
- **Store cards → leaderboard** — dense ranked rows: rank, name + the existing `StoreLocationChip` as the area chip (see note below — there is no city/neighborhood data in the schema), a proportional net bar scaled to the list's #1 (highest-net) store, `N deliveries · usual wait` inline (ambers on an outlier wait), the net figure, and the pre-existing tap-through chevron/detail sheet. Sort chips **By net / By wait / Recent** reorder rows via a new pure `PatternsModel.sortedStores`. The bar scale and the outlier fleet are computed over the **full** store list regardless of the active sort, so switching chips reorders rows without rescaling or re-flagging them underneath the driver. The unmatched-deliveries footnote is preserved verbatim.

### Outlier definition (documented at its one owner, `PatternsModel.kt`)

There was no existing "outlier" concept anywhere in the codebase to anchor to, so this is a new, deliberately documented choice: a store's own `p50DwellMillis` is flagged once it is **≥ 1.5×** (`PatternsModel.OUTLIER_MULTIPLIER`) the **fleet median** `p50DwellMillis` — computed across every store currently on the leaderboard that carries a real dwell sample — gated on **≥ 3** such stores (`PatternsModel.MIN_FLEET_SAMPLE_FOR_OUTLIER`, §9 thin-data honesty) so a 1–2-store board can never manufacture an outlier from a near-meaningless median. A store with no wait sample of its own is never flagged. Both constants are tunable in one place if field data proves the threshold too noisy/quiet.

### Sort chips

- **By net** — highest net first (ties broken by name for determinism).
- **By wait** — shortest usual wait first (a store with no wait sample sorts last — an absent measurement is not a fast time).
- **Recent** — most recently visited first, reusing `StoreReportCard.lastSeenAt` (the DAO's own existing `ORDER BY lastSeenAt DESC` — no new query).

### Deviations from the literal brief text

- **"Trips"** → kept the tab's existing **"deliveries"** vocabulary (`time_tab_delivery_singular/plural`, already used elsewhere on this same tab) instead of introducing a new, unprecedented "trip" word.
- **Platform badge on rows** — `StoreReportCard.platform` exists (per #315) but is **not** rendered on the leaderboard row; the brief's row spec (rank/name/area chip/bar/stats/net/chevron) doesn't call for one and there's no existing precedent for a platform chip *and* a location chip crowding the same row face. Flagging per the task brief's instruction to report rather than silently add.
- **Area chip** — reused the existing `StoreLocationChip` (chain/location-key derived) verbatim. There is no city/neighborhood/ZIP field anywhere in the store-resolution schema (`StoreReportCard`/`StoreReportRow`) to build a true "area" chip from, so no new location data was minted.

## Read/write posture

Read-side only. No new DAO queries (confirmed against the brief's "Free — already computed, just not rendered" list), no schema change, no `PROJECTOR_VERSION` bump. New pure Compose-free `PatternsModel.kt` (the `WindowLabel` precedent) holds the sort orders, the net-bar fraction, the heatmap cell-value selection, and the wait-outlier predicate.

## Testing

- New `PatternsModelTest.kt` — 20 unit tests covering the three sort orders (including ties and null-wait-sorts-last), the net-bar fraction (including negative net and a non-positive max), the outlier predicate (including the thin-data floor and the no-own-sample branch), and the heatmap Rate/Hours cell-value selection.
- `./gradlew testDebugUnitTest :domain:test --max-workers=4` — green.
- `./gradlew :app:lintVitalRelease --max-workers=4` — green.

### Design-goal review

1. **UDF** — `PatternsModel` is pure (Compose-free, no Android deps); the tab stays data-in/lambdas-out. The new sort/heatmap-mode selections are local `rememberSaveable` UI state in `PatternsTab.kt`, matching the pre-existing `selectedStoreKey` precedent — no ViewModel/repository change needed since neither toggle re-reads data.
2. **MAD** — Compose-first (`AppSegmented`), no new dependencies.
3. **Single responsibility** — the new leaderboard/toggle logic went into a fresh pure `PatternsModel.kt` rather than growing `PatternsTab.kt` unboundedly; the tab file is 652 lines (was 500), still well under the #237-family 900-line concern threshold.
4. **Kotlin/Android practices** — `HeatmapMode`/`LeaderboardSort` are enums, not stringly-typed; ties in sorts are broken deterministically.
5. **SSOT** — `AppHeatScale` reused unchanged (no second color-ramp path for Hours mode); `StoreLocationChip`, `formatDuration`, `Formats.commaInt`, and the existing `time_tab_delivery_singular/plural` strings reused rather than re-implemented; `StoreReportCard.lastSeenAt` reused for "Recent" instead of a new query.
6. **Security & privacy** — no new capture surface, no new PII handling; store/merchant names were already established-safe to render (Principle 6 doesn't gate this UI). No network calls.
7. **Semantic logging** — no new log sites.
8. **Platform-agnostic core** — no new `Platform` literal; the diff doesn't touch `:core:state`/`:core:pipeline`/`:domain`/rule JSON at all (UI-only, `:app` module). `StoreReportCard.platform` is available but deliberately not rendered on the row (see Deviations above) — not a violation, just an unused-for-now field.
9. **Reactive UI** — Patterns stays an aggregate-historical surface (no `rememberNow()` ticker needed, matching the file's existing KDoc); nothing time-derived was added.

Closes #979. Refs #969.
