### PR TITLE
feature(plan): #981 — Weekly Plan: evidence-backed windows, plan-vs-random value, save + Sunday grade loop (redesign stage 6/7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,9 @@ period labels are duplicated by choice into the module — multi-consumer with t
 selector) and its `dashboard_screen_stat_*`/`common_period_*` labels were DELETED — the review
 windows live on the Analytics pager now — and `TodayHeader`/`TodayPlanCard`/`SoFarToday`/
 `WeekRecapCard` joined the module in their place, still pure data-in/lambdas-out over `:domain`
-types + `:core:designsystem`. One deliberate exception to the split: Home's review-items card is
+types + `:core:designsystem`; #981 added `WeeklyPlanPointerRow` (the seam #977 left), which keeps the
+module's honest-deps posture — no material-icons dependency, so its affordance is a `Plan →` text in
+the `Recap →` vocabulary rather than a chevron. One deliberate exception to the split: Home's review-items card is
 the analytics hub's own `NeedsALookCard`/`reviewItems` reused verbatim from `:app`, rendered by
 the host — the flag thresholds and their copy keep ONE owner rather than being copied into a
 feature module to satisfy placement).
@@ -208,9 +210,12 @@ Hilt/`:core:data`/`:core:state`.) **Remaining Phase-6 extractions: none — Phas
   concrete data layers.
 - **`:core:network`** — Retrofit clients, OkHttp interceptors, EIA gas price API integration.
 - **`:core:location`** — Play Services GPS tracking.
-- **`:core:datastore`** — Preferences DataStore (seven single-concern stores behind Hilt
+- **`:core:datastore`** — Preferences DataStore (eight single-concern stores behind Hilt
   qualifiers — app prefs, strategy, dev settings, odometer, app state, platforms,
-  rule-capability grants).
+  rule-capability grants, and the #981 **weekly plan**). The weekly-plan store is deliberately
+  NOT a Room table: a saved plan is a **user artifact** (nothing in `app_events` implies it, and
+  nothing can rebuild it), so it must not live in the read-model DB that a `PROJECTOR_VERSION`
+  bump wipes — see §5.
 - **`:core:designsystem`** — Brand system (no project deps): fixed dark/light palette (`AppColors`),
   Hanken Grotesk + Space Grotesk fonts (tabular numerals), `AppTheme` + `LocalGlance` (the public
   theme wrapper is `DashBuddyTheme`, the only `Dash`-named symbol kept — it's the app name, not a
@@ -733,6 +738,44 @@ is never flagged. "Recent" reuses `StoreReportCard.lastSeenAt` — the DAO's own
 `ORDER BY lastSeenAt DESC` — rather than a new query. `Platform` is available on `StoreReportCard.platform`
 per #315 but this pass doesn't render it on the row (out of the brief's row spec); no `Platform` literal
 was added.
+**Weekly Plan (#981, stage 6 — brief §8/§7.7):** the redesign's NEW surface, and the first thing in
+this section that is **not** a projection of the event log. Three pieces. (1) **The §7.7 read, and why
+it exists:** brief §8 ranks weekday×hour cells by **median** realized net $/hr, which `EarningsHeatmap`
+structurally cannot answer — it is a totals grid whose cell rate is `Σnet ÷ Σcoverage`, a
+coverage-weighted MEAN, with the individual days summed away, so neither a median nor a sample count is
+recoverable from it. `AnalyticsRepository.hourOfWeekSamples()` therefore feeds the **same two lifetime
+DAO reads** (`sessionSpans` + `deliveryNets`) to the pure `:domain` `HourOfWeekSampler`, which
+apportions them one calendar step earlier — into `(date, hour)` buckets instead of straight into
+`(weekday, hour)` totals — so a cell's samples ARE its own separate days. **No new query, no schema
+change, no `PROJECTOR_VERSION` bump.** It inherits the heatmap's union / apportionment / completion-hour
+rules verbatim (Principle 5), and its coverage floor is the heatmap's own
+`DEFAULT_MIN_COVERAGE_HOURS` expressed as a FRACTION (half the range asked about), so a 4h window needs
+2h of real presence before a day counts as a sample of it. (2) **The planner** (`WeeklyPlanner`, pure)
+implements §8's six lines: median ranking, `MIN_SAMPLE_DAYS`=3 separate days per cell, adjacency merge
+(the greedy tie-break is rate → **longest** → earliest day → earliest start; longest-first is what
+actually performs the merge — shortest-first would render one 4h run as two stapled 2h rows), the ≥2h
+floor + a 4h cap shared with `DayPlanner`, greedy fill to an hours or `$`-goal target
+(`MAX_PLAN_HOURS`=40 bounds the dollars arm), `median × hours` projection, and an
+overall-median-of-every-worked-hour random baseline. Every weekday holding no window is returned with a
+MEASURED reason (`NO_HISTORY`/`THIN_HISTORY`/`NO_CONTIGUOUS_RUN`/`NO_POSITIVE_RATE`/
+`TARGET_ALREADY_MET`/`REMOVED_BY_YOU`), never omitted. Driver edits are **replayed**, not applied: the
+ViewModel holds an ordered `List<PlanEdit>` and the base plan is recomputed every emission, so a moved
+window re-derives its rate at its NEW hours (or prices nothing, visibly) and a dropped window's range is
+banned so the re-fill takes the next-best hours instead of the same ones back. (3) **Storage + the
+loop:** `SavedWeeklyPlan` is FROZEN at save time (the driver is graded against the plan they were shown,
+the `delivery_records` doctrine applied to a commitment), encoded by the fail-closed `WeeklyPlanCodec`
+into the `weekly_plan` DataStore via `WeeklyPlanRepository` (keep the last 2 weeks). `WeeklyPlanWorker`
+is a **periodic 7-day** WorkManager job with its initial delay computed to the next Sunday 18:00 local
+by the pure `WeeklyPlanSchedule`, re-anchored on every app start (which is also what corrects the 1h DST
+drift a 7×24h interval accrues); it grades the finished week with the pure `WeeklyPlanGrader` (planned
+vs actual hours and dollars **inside the planned windows only**; money earned outside is reported
+separately, never folded in) and posts on its **own** notification channel — `weekly_plan_channel`, id
+104 — deliberately not `app_notice_channel`, because a recurring engagement nudge must be mutable
+without also muting the Pledge disclosures. Notification copy is counts and dollars only (P7). Home's
+pointer row reads the plan for the week the driver is IN (`weekStartOf`, not `planWeekStart` — on a
+Sunday those differ). `PatternsTab`'s heat grid was extracted to `HeatmapGrid` so "where the plan came
+from" renders the SAME grid with the picked cells outlined — the derivation's proof is the driver
+recognising the picture, which a lookalike would eventually stop being.
 **The "(No session)" bucket (#660 piece 1):** `delivery_records` rows whose source event carried
 NO `sessionId` at all were already counted in net (`deliveryTotals`'s own-`completedAt` fallback, #655)
 but invisible to gross (`grossAndUnattributed`/`sessionGrossRows` iterate `session_records` only, so a

--- a/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.domain.di.ApplicationScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import cloud.trotter.dashbuddy.worker.DailyGasPriceWorker
+import cloud.trotter.dashbuddy.worker.WeeklyPlanWorker
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
@@ -178,6 +179,10 @@ class DashBuddyApplication : Application(), Configuration.Provider {
             ExistingPeriodicWorkPolicy.KEEP,
             dailyWorkRequest
         )
+        // #981 — the Sunday-evening Weekly Plan nudge. Re-anchored on every launch (the delay is
+        // computed from the wall clock), which is also what corrects a DST drift in the 7-day period.
+        WeeklyPlanWorker.schedule(this)
+
         Timber.i("Background workers verified and scheduled.")
     }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/notice/WeeklyPlanChannel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/notice/WeeklyPlanChannel.kt
@@ -1,0 +1,47 @@
+package cloud.trotter.dashbuddy.notice
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import cloud.trotter.dashbuddy.R
+
+/**
+ * The "Weekly plan" notification channel (#981 / brief §8's trigger) — the Sunday-evening nudge and
+ * the grade of the week just finished.
+ *
+ * **Its own channel, deliberately not [AppNoticeChannel].** A channel name IS the user's mute control,
+ * and these two families are not the same promise. `AppNoticeChannel` carries one-off, honest
+ * disclosures about how the app is working on this device — things a driver would want even if they
+ * want nothing else. This is a **recurring engagement** notification: welcome, useful, and something a
+ * driver is entitled to silence *without* also silencing a locale-boundary or recognition-health
+ * notice. Filing an engagement nudge under a disclosure channel would make muting the nudge cost them
+ * the disclosures — so it gets its own switch.
+ *
+ * **Default importance, not high.** It is a Sunday-evening suggestion, not an offer alert: it should
+ * appear in the shade without interrupting whatever the driver is doing.
+ */
+object WeeklyPlanChannel {
+
+    /** Stable channel id. Do not rename — the user's mute state is keyed on it. */
+    const val ID = "weekly_plan_channel"
+
+    /**
+     * The notification id, in the same small-constant space the bubble (1), offer fallback (2),
+     * odometer (101) and the [AppNoticeChannel] notices (102, 103) occupy. Per-offer ids live in the
+     * disjoint `[2^30, 2^31)` namespace, so fixed small ids cannot collide.
+     */
+    const val NOTIFICATION_ID = 104
+
+    /** Create (or refresh) the channel — cheap and idempotent by platform contract, called at post time. */
+    fun ensure(context: Context, notificationManager: NotificationManager) {
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                ID,
+                context.getString(R.string.weekly_plan_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description = context.getString(R.string.weekly_plan_channel_description)
+            },
+        )
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/notice/WeeklyPlanNotifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/notice/WeeklyPlanNotifier.kt
@@ -1,0 +1,96 @@
+package cloud.trotter.dashbuddy.notice
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import androidx.core.app.NotificationCompat
+import android.content.Context
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanGrade
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.ui.main.MainActivity
+import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Posts the Sunday-evening Weekly Plan notification (#981 / brief §8), deep-linking into the screen.
+ *
+ * **The grade is the point.** Brief §8 item 6: "next Sunday's notification grades the previous plan
+ * (planned vs actual hours and dollars). That loop is what makes the notification worth keeping
+ * enabled." So when there is a finished plan to grade, the grade IS the headline — four of the
+ * driver's own numbers — and the invitation to plan the week ahead is the second line. With nothing to
+ * grade it is just the invitation.
+ *
+ * **PII posture (principle 7):** every value in this copy is a count or a dollar figure derived from
+ * the driver's own aggregates. No store names, no customer data, no screen text — nothing that could
+ * be PII is reachable from here, by construction.
+ *
+ * **Fail-open.** A notification the OS refuses (POST_NOTIFICATIONS not granted, channel muted) must
+ * not take the worker down with it: the whole post is wrapped, and a failure logs and returns.
+ */
+@Singleton
+class WeeklyPlanNotifier @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val notificationManager: NotificationManager,
+) {
+
+    /** [grade] is last week's plan measured against the record, or null when there is nothing to grade. */
+    fun postWeeklyNudge(grade: WeeklyPlanGrade?) {
+        try {
+            post(grade)
+        } catch (t: Throwable) {
+            // Deliberately broad and not rethrown (#909): an engagement notification is never worth a
+            // crashed background job.
+            Timber.tag(TAG).e(t, "Weekly plan notification could not be posted (#981)")
+        }
+    }
+
+    private fun post(grade: WeeklyPlanGrade?) {
+        WeeklyPlanChannel.ensure(context, notificationManager)
+
+        val title = context.getString(R.string.weekly_plan_notice_title)
+        val text = grade?.let { gradeLine(it) } ?: context.getString(R.string.weekly_plan_notice_text_plain)
+
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_CODE,
+            MainActivity.routeIntent(context, Screen.WeeklyPlan.route),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(context, WeeklyPlanChannel.ID)
+            .setSmallIcon(R.drawable.bag_red_idle)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setContentIntent(contentIntent)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(WeeklyPlanChannel.NOTIFICATION_ID, notification)
+    }
+
+    /**
+     * The grade headline: hours worked against hours planned, dollars kept against dollars projected —
+     * stated, never scored. A week the driver did not work any of their windows says exactly that
+     * rather than reporting "0 of 12 hours" as if it were a near miss.
+     */
+    private fun gradeLine(grade: WeeklyPlanGrade): String = if (grade.unworked) {
+        context.getString(R.string.weekly_plan_notice_grade_unworked_format, grade.plannedHours)
+    } else {
+        context.getString(
+            R.string.weekly_plan_notice_grade_format,
+            Formats.decimal(grade.actualHours),
+            grade.plannedHours,
+            Formats.money(grade.actualKept),
+            Formats.money(grade.projectedKept),
+        )
+    }
+
+    private companion object {
+        const val TAG = "WeeklyPlan"
+        const val REQUEST_CODE = 981
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -24,6 +24,7 @@ import cloud.trotter.dashbuddy.ui.main.analytics.AnalyticsScreen
 import cloud.trotter.dashbuddy.ui.main.analytics.SessionDetailScreen
 import cloud.trotter.dashbuddy.ui.main.dashboard.DashboardScreen
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import cloud.trotter.dashbuddy.ui.main.plan.WeeklyPlanScreen
 import timber.log.Timber
 import cloud.trotter.dashbuddy.ui.main.ratings.RatingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.AboutScreen
@@ -112,6 +113,13 @@ class MainActivity : ComponentActivity() {
                                 onOpenSession = { sessionId ->
                                     navController.navigate(Screen.SessionDetail.route(sessionId))
                                 }
+                            )
+                        }
+
+                        // --- WEEKLY PLAN (#981 — the Sunday notification's deep-link target) ---
+                        composable(Screen.WeeklyPlan.route) {
+                            WeeklyPlanScreen(
+                                onBack = { navController.popBackStack() }
                             )
                         }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/HeatmapGrid.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/HeatmapGrid.kt
@@ -1,0 +1,120 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.component.AppHeatScale
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.format.hourOfDayLabel
+import cloud.trotter.dashbuddy.ui.main.analytics.PatternsModel.HeatmapMode
+import java.time.DayOfWeek
+import java.time.format.TextStyle
+import java.util.Locale
+
+/** Local day order: Monday-first, matching the app's Monday-anchored week (#655 / PeriodBounds). */
+internal val DAY_ROWS = listOf(
+    DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+    DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY,
+)
+
+/** Width of the day-label gutter, shared by the grid and its axis so the ticks line up. */
+private val DAY_LABEL_WIDTH = 30.dp
+
+/**
+ * The 7 day-rows × 24 hour-columns heat grid — extracted from `PatternsTab` (#979) so the Weekly Plan
+ * screen (#981, brief §8 item 4: "the lifetime heatmap with the picked cells outlined") renders the
+ * SAME grid the Patterns tab does rather than a lookalike.
+ *
+ * That reuse is the point: the plan claims to be derived from the driver's own record, and the way it
+ * proves that is by showing the *same picture* the Patterns tab shows, with the chosen cells ringed.
+ * Two independently-written grids would eventually disagree about a colour, a mask or a day order, and
+ * the proof would quietly stop being one (Principle 5).
+ *
+ * [outlined] rings a cell — the Weekly Plan's picked hours. `null` (the default) draws no outline, which
+ * is exactly the Patterns tab's behaviour, so extracting it changed nothing there.
+ */
+@Composable
+internal fun HeatmapGrid(
+    heatmap: EarningsHeatmap,
+    mode: HeatmapMode,
+    maxForMode: Double,
+    modifier: Modifier = Modifier,
+    outlined: ((dayIndex: Int, hour: Int) -> Boolean)? = null,
+) {
+    val c = AppTheme.colors
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        DAY_ROWS.forEach { day ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = day.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = c.text3,
+                    modifier = Modifier.width(DAY_LABEL_WIDTH),
+                )
+                Row(
+                    modifier = Modifier.weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(1.dp),
+                ) {
+                    for (hour in 0 until EarningsHeatmap.HOURS) {
+                        val dayIndex = day.value - 1
+                        val cell = heatmap.cell(dayIndex, hour)
+                        val value = PatternsModel.cellValue(cell, mode)
+                        // "Worked, no net" is a Rate-only third state — Hours has no bad outcome to
+                        // border, only more/less coverage.
+                        val cellRate = cell.dollarsPerHour
+                        val zeroRate = mode == HeatmapMode.RATE && cellRate != null && cellRate <= 0.0
+                        val isPicked = outlined?.invoke(dayIndex, hour) == true
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .aspectRatio(1f)
+                                .clip(RoundedCornerShape(2.dp))
+                                .background(AppHeatScale.cellColor(value, maxForMode, c))
+                                .then(
+                                    when {
+                                        // A picked cell wins the border: on this screen it is the
+                                        // information the grid exists to carry.
+                                        isPicked -> Modifier.border(1.dp, c.accent, RoundedCornerShape(2.dp))
+                                        zeroRate -> Modifier.border(1.dp, c.bad, RoundedCornerShape(2.dp))
+                                        else -> Modifier
+                                    },
+                                ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Four evenly-spaced clock ticks under the grid (offset past the day-label gutter). */
+@Composable
+internal fun HeatmapHourAxis() {
+    val c = AppTheme.colors
+    Row(Modifier.fillMaxWidth()) {
+        Spacer(Modifier.width(DAY_LABEL_WIDTH))
+        Row(modifier = Modifier.weight(1f), horizontalArrangement = Arrangement.SpaceBetween) {
+            // labelSmall, no raw fontSize override — matches the sibling AppBarChart axis-label treatment.
+            listOf(0, 6, 12, 18).forEach { h ->
+                Text(text = hourOfDayLabel(h), style = MaterialTheme.typography.labelSmall, color = c.text3)
+            }
+            Text(text = hourOfDayLabel(0), style = MaterialTheme.typography.labelSmall, color = c.text3)
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
@@ -107,13 +107,7 @@ private fun AllTimeBadge() {
     }
 }
 
-// ── Heatmap ─────────────────────────────────────────────────────────────
-
-/** Local day order: Monday-first, matching the app's Monday-anchored week (#655 / PeriodBounds). */
-private val DAY_ROWS = listOf(
-    DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
-    DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY,
-)
+// ── Heatmap ───────────────────────────────────────────────────────────
 
 /**
  * The hour×day heatmap: 7 day-rows × 24 hour-columns. #979 adds a Rate/Hours toggle over ONE grid —
@@ -168,45 +162,11 @@ private fun HeatmapCard(heatmap: EarningsHeatmap) {
         val maxHours = PatternsModel.maxCoverageHours(heatmap)
         val maxForMode = if (mode == HeatmapMode.RATE) maxRate else maxHours
 
-        // Grid: each day is a row of a fixed-width label + 24 weighted cells.
-        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-            DAY_ROWS.forEach { day ->
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = day.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = c.text3,
-                        modifier = Modifier.width(30.dp),
-                    )
-                    Row(
-                        modifier = Modifier.weight(1f),
-                        horizontalArrangement = Arrangement.spacedBy(1.dp),
-                    ) {
-                        for (hour in 0 until EarningsHeatmap.HOURS) {
-                            val cell = heatmap.cell(day.value - 1, hour)
-                            val value = PatternsModel.cellValue(cell, mode)
-                            // "Worked, no net" is a Rate-only third state — Hours has no bad outcome to
-                            // border, only more/less coverage.
-                            val cellRate = cell.dollarsPerHour
-                            val zeroRate = mode == HeatmapMode.RATE && cellRate != null && cellRate <= 0.0
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .aspectRatio(1f)
-                                    .clip(RoundedCornerShape(2.dp))
-                                    .background(AppHeatScale.cellColor(value, maxForMode, c))
-                                    .then(
-                                        if (zeroRate) Modifier.border(1.dp, c.bad, RoundedCornerShape(2.dp))
-                                        else Modifier,
-                                    ),
-                            )
-                        }
-                    }
-                }
-            }
-        }
+        // Grid + axis: the shared render the Weekly Plan screen also draws (#981), so the two
+        // surfaces can never disagree about a colour, a mask or the day order.
+        HeatmapGrid(heatmap = heatmap, mode = mode, maxForMode = maxForMode)
         Spacer(Modifier.height(6.dp))
-        HourAxis()
+        HeatmapHourAxis()
         Spacer(Modifier.height(12.dp))
         if (mode == HeatmapMode.RATE) HeatmapLegend(maxRate) else HeatmapHoursLegend()
 
@@ -244,22 +204,6 @@ private fun heatmapModeOptions(): List<HeatmapModeOption> = listOf(
     HeatmapModeOption(HeatmapMode.RATE, stringResource(R.string.patterns_tab_heatmap_mode_rate)),
     HeatmapModeOption(HeatmapMode.HOURS, stringResource(R.string.patterns_tab_heatmap_mode_hours)),
 )
-
-/** Four evenly-spaced clock ticks under the grid (offset past the day-label gutter). */
-@Composable
-private fun HourAxis() {
-    val c = AppTheme.colors
-    Row(Modifier.fillMaxWidth()) {
-        Spacer(Modifier.width(30.dp))
-        Row(modifier = Modifier.weight(1f), horizontalArrangement = Arrangement.SpaceBetween) {
-            // labelSmall, no raw fontSize override — matches the sibling AppBarChart axis-label treatment.
-            listOf(0, 6, 12, 18).forEach { h ->
-                Text(text = hourOfDayLabel(h), style = MaterialTheme.typography.labelSmall, color = c.text3)
-            }
-            Text(text = hourOfDayLabel(0), style = MaterialTheme.typography.labelSmall, color = c.text3)
-        }
-    }
-}
 
 /**
  * Color-scale legend, three states so the grid is readable: the *insufficient* swatch ("too little

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -45,6 +45,7 @@ import cloud.trotter.dashbuddy.feature.dashboard.components.StatusCard
 import cloud.trotter.dashbuddy.feature.dashboard.components.TodayHeader
 import cloud.trotter.dashbuddy.feature.dashboard.components.TodayPlanCard
 import cloud.trotter.dashbuddy.feature.dashboard.components.WeekRecapCard
+import cloud.trotter.dashbuddy.feature.dashboard.components.WeeklyPlanPointerRow
 import cloud.trotter.dashbuddy.ui.main.analytics.NeedsALookCard
 import cloud.trotter.dashbuddy.ui.main.analytics.ReviewAction
 import cloud.trotter.dashbuddy.ui.main.analytics.reviewItems
@@ -186,10 +187,16 @@ fun DashboardScreen(
                     TodayPlanCard(today = uiState.today, heatmap = uiState.heatmap)
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    // SEAM — weekly-plan pointer (brief §2 row 3, stage 6 / #969). It renders ONLY
-                    // when a saved plan exists for the current week, and saved plans do not exist
-                    // yet: stage 6 owns both the storage and this row. Deliberately nothing here —
-                    // a placeholder row would be dead UI promising a screen that isn't built.
+                    // Weekly-plan pointer (brief §2 row 3, #981) — rendered ONLY when the driver
+                    // has saved a plan for the week they are in. No plan, no row: an empty
+                    // placeholder would advertise a screen they have not asked for.
+                    uiState.weeklyPlan?.let { plan ->
+                        WeeklyPlanPointerRow(
+                            plan = plan,
+                            onOpen = { onNavigate(Screen.WeeklyPlan.route) },
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
 
                     SoFarToday(economics = uiState.todayEconomics)
                     Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
@@ -6,6 +6,7 @@ import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.SavedWeeklyPlan
 import java.time.LocalDate
 
 /**
@@ -70,4 +71,9 @@ data class DashboardUiState(
      * chore from yesterday must not vanish just because Home's headline is "today".
      */
     val orphanOfferGroups: List<OrphanOfferGroup> = emptyList(),
+    /**
+     * The plan the driver saved for the week they are currently in (#981), or null when there is
+     * none — the pointer row renders only when this is non-null, per brief §2 row 3.
+     */
+    val weeklyPlan: SavedWeeklyPlan? = null,
 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.WeeklyPlanRepository
 import cloud.trotter.dashbuddy.core.data.analytics.currentLocalDateFlow
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
@@ -14,6 +15,8 @@ import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindowSelection
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindows
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
+import cloud.trotter.dashbuddy.domain.analytics.SavedWeeklyPlan
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanSchedule
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
 import cloud.trotter.dashbuddy.domain.state.AppState
@@ -67,6 +70,7 @@ class DashboardViewModel @Inject constructor(
     private val analyticsRepository: AnalyticsRepository,
     private val appPreferencesRepository: AppPreferencesRepository,
     private val bubbleManager: BubbleManager,
+    private val weeklyPlanRepository: WeeklyPlanRepository,
 ) : ViewModel() {
 
     /** The device's local date, re-emitting at midnight — the anchor the week + weekday resolve against. */
@@ -87,8 +91,12 @@ class DashboardViewModel @Inject constructor(
             previousEconomics(week),
             analyticsRepository.dailyEarnings(week),
             analyticsRepository.orphanOfferGroups(week),
-        ) { economics, previous, daily, orphanOffers ->
-            WeekData(day, economics, previous, daily, orphanOffers)
+            // #981 — the weekly-plan pointer row. Deliberately the week the driver is IN
+            // (`weekStartOf`), not the week a plan saved right now would target: on a Sunday those
+            // differ, and Home is describing today.
+            weeklyPlanRepository.planFor(WeeklyPlanSchedule.weekStartOf(day)),
+        ) { economics, previous, daily, orphanOffers, plan ->
+            WeekData(day, economics, previous, daily, orphanOffers, plan)
         }
     }
 
@@ -113,6 +121,7 @@ class DashboardViewModel @Inject constructor(
             previousWeekEconomics = week.previousEconomics,
             weekDailyEarnings = week.dailyEarnings,
             orphanOfferGroups = week.orphanOfferGroups,
+            weeklyPlan = week.weeklyPlan,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DashboardUiState())
 
@@ -197,6 +206,7 @@ class DashboardViewModel @Inject constructor(
         val previousEconomics: PeriodEconomics?,
         val dailyEarnings: List<DailyEarnings>,
         val orphanOfferGroups: List<OrphanOfferGroup>,
+        val weeklyPlan: SavedWeeklyPlan?,
     )
 
     private companion object {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -13,6 +13,13 @@ sealed class Screen(val route: String) {
     data object Analytics : Screen("analytics")
 
     /**
+     * Weekly Plan (#981, redesign stage 6) — reached from the Sunday-evening notification's deep link
+     * and from the Home pointer row, never from a tab. Static route: it takes no arguments, which is
+     * what lets it sit in [allRoutes] and be a legal deep-link target.
+     */
+    data object WeeklyPlan : Screen("plan/week")
+
+    /**
      * Per-dash drill-down (#650) — the read-only session detail for one dash. The [route] template
      * carries the sessionId; [route] (the fun) URL-encodes it since a session id can hold arbitrary
      * characters. The screen reads the id back from `SavedStateHandle`.
@@ -46,7 +53,7 @@ sealed class Screen(val route: String) {
         // lazy: a plain initializer runs during Screen's class-init, BEFORE the nested data
         // objects exist (touching any Screen.X triggers it) → ExceptionInInitializerError.
         val allRoutes: Set<String> by lazy { setOf(
-            Dashboard.route, Analytics.route, SettingsHome.route, AboutSettings.route,
+            Dashboard.route, Analytics.route, WeeklyPlan.route, SettingsHome.route, AboutSettings.route,
             StrategySettings.route, EvidenceSettings.route, DataExport.route,
             ConsentSettings.route,
             EconomySettings.route, GeneralSettings.route, DeveloperSettings.route,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanCards.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanCards.kt
@@ -1,0 +1,451 @@
+package cloud.trotter.dashbuddy.ui.main.plan
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.PlanTarget
+import cloud.trotter.dashbuddy.domain.analytics.PlannedWindow
+import cloud.trotter.dashbuddy.domain.analytics.UnpickedDay
+import cloud.trotter.dashbuddy.domain.analytics.UnpickedReason
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlan
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanner
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.hourRangeLabel
+
+// ── 1. Target selector (brief §8 item 1) ───────────────────────────────────
+
+/**
+ * `8h · 12h · 20h · $ goal` — what the driver is asking the planner for.
+ *
+ * The three hour presets come from [PlanTarget.HOUR_PRESETS] (one owner for the option set), and the
+ * dollar goal opens a prompt rather than pretending to be a fourth preset: it is a number only the
+ * driver knows.
+ */
+@Composable
+fun TargetSelectorCard(target: PlanTarget, onSelect: (PlanTarget) -> Unit) {
+    val c = AppTheme.colors
+    var showGoalPrompt by rememberSaveable { mutableStateOf(false) }
+
+    val hourLabels = PlanTarget.HOUR_PRESETS.map { stringResource(R.string.weekly_plan_target_hours_format, it) }
+    val goalLabel = stringResource(R.string.weekly_plan_target_dollars)
+    val options = hourLabels + goalLabel
+    val selectedLabel = when (target) {
+        is PlanTarget.Hours -> hourLabels.getOrNull(PlanTarget.HOUR_PRESETS.indexOf(target.hours)) ?: goalLabel
+        is PlanTarget.Dollars -> goalLabel
+    }
+
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.weekly_plan_target_title),
+            style = MaterialTheme.typography.labelMedium,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(10.dp))
+        AppSegmented(
+            options = options,
+            selected = selectedLabel,
+            onSelect = { label ->
+                // Selection stays keyed off the option INDEX, never a resolved-string comparison
+                // that could collide across locales (#428 Half A).
+                val index = options.indexOf(label)
+                if (index in PlanTarget.HOUR_PRESETS.indices) {
+                    onSelect(PlanTarget.Hours(PlanTarget.HOUR_PRESETS[index]))
+                } else {
+                    showGoalPrompt = true
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (target is PlanTarget.Dollars) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.weekly_plan_target_dollars_selected, Formats.money(target.amount)),
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
+            )
+        }
+    }
+
+    if (showGoalPrompt) {
+        DollarGoalDialog(
+            initial = (target as? PlanTarget.Dollars)?.amount,
+            onDismiss = { showGoalPrompt = false },
+            onConfirm = {
+                onSelect(PlanTarget.Dollars(it))
+                showGoalPrompt = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun DollarGoalDialog(initial: Double?, onDismiss: () -> Unit, onConfirm: (Double) -> Unit) {
+    var text by rememberSaveable { mutableStateOf(initial?.let { Formats.money0(it).removePrefix("$") } ?: "") }
+    val amount = text.toDoubleOrNull()
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.weekly_plan_goal_dialog_title)) },
+        text = {
+            Column {
+                Text(
+                    text = stringResource(R.string.weekly_plan_goal_dialog_body),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it.filter { ch -> ch.isDigit() || ch == '.' } },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    label = { Text(stringResource(R.string.weekly_plan_goal_dialog_label)) },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { amount?.let(onConfirm) },
+                enabled = amount != null && amount > 0.0,
+            ) { Text(stringResource(R.string.weekly_plan_goal_dialog_confirm)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.weekly_plan_goal_dialog_cancel)) }
+        },
+    )
+}
+
+// ── 2. Headline value + the plan-vs-random comparison (brief §8 item 2) ────
+
+/**
+ * `12 hours on your best windows ≈ $280 kept`, and directly below it what the same hours are worth
+ * placed at random.
+ *
+ * **The comparison is never dropped.** Brief §8 calls it "the whole pitch", and it is also the only
+ * thing that makes the headline honest: a projection with nothing to compare it against invites the
+ * driver to read it as money the app is promising them. When the record can't produce a baseline, the
+ * card says *that* — it never shows the headline alone.
+ */
+@Composable
+fun PlanValueCard(plan: WeeklyPlan) {
+    val c = AppTheme.colors
+    val hours = stringResource(R.string.weekly_plan_hours_format, plan.totalHours)
+
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.weekly_plan_value_headline_format, hours, Formats.money(plan.projectedKept)),
+            style = MaterialTheme.typography.titleMedium,
+            color = c.text,
+        )
+        Spacer(Modifier.height(8.dp))
+
+        val randomKept = plan.randomKept
+        val worth = plan.planWorth
+        Text(
+            text = when {
+                randomKept == null || worth == null ->
+                    stringResource(R.string.weekly_plan_value_no_baseline)
+
+                worth > 0.0 -> stringResource(
+                    R.string.weekly_plan_value_comparison_format,
+                    hours, Formats.money(randomKept), Formats.money(worth),
+                )
+
+                else -> stringResource(
+                    R.string.weekly_plan_value_comparison_no_gain_format,
+                    hours, Formats.money(randomKept),
+                )
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = c.text2,
+        )
+
+        if (plan.shortfallHours > 0) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(
+                    R.string.weekly_plan_value_shortfall_format,
+                    plan.totalHours,
+                    (plan.target as? PlanTarget.Hours)?.hours ?: plan.totalHours,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
+            )
+        }
+        if (plan.hasUnpricedHours) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(
+                    R.string.weekly_plan_value_unpriced_format,
+                    plan.totalHours - plan.pricedHours,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+        // §9's projection rule, verbatim and unconditional — rendered on every state of this card.
+        Text(
+            text = stringResource(R.string.weekly_plan_provenance),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+    }
+}
+
+// ── 3. Suggested windows (brief §8 item 3) ────────────────────────────────
+
+/**
+ * One row per placed window — weekday, time range, the evidence behind it, and what it projects —
+ * followed by the weekdays that were NOT picked, dimmed, each with the measured reason.
+ *
+ * **Interaction.** Swipe a row away to drop it (the planner re-fills from the next-best hours it can
+ * stand behind), and nudge it an hour earlier or later with the arrows. The brief asks for "drag to
+ * move a window"; in a vertical list of rows a drag gesture reads as *reordering the list*, which is
+ * the one thing moving a window must not mean — the arrows say "move in time" unambiguously, work
+ * one-handed, and produce exactly the same [cloud.trotter.dashbuddy.domain.analytics.PlanEdit].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SuggestedWindowsCard(
+    plan: WeeklyPlan,
+    onMove: (PlannedWindow, Int) -> Unit,
+    onDrop: (PlannedWindow) -> Unit,
+    onUndo: () -> Unit,
+) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.weekly_plan_windows_title),
+                style = MaterialTheme.typography.labelMedium,
+                color = c.text3,
+                modifier = Modifier.weight(1f),
+            )
+            if (plan.edits.isNotEmpty()) {
+                TextButton(onClick = onUndo) { Text(stringResource(R.string.weekly_plan_undo)) }
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+
+        if (plan.windows.isEmpty()) {
+            Text(
+                text = stringResource(R.string.weekly_plan_windows_none),
+                style = MaterialTheme.typography.bodyMedium,
+                color = c.text2,
+            )
+        }
+
+        plan.windows.forEach { window ->
+            key(window) {
+                SwipeToDismissBox(
+                    state = rememberSwipeToDismissBoxState(),
+                    // Keyed by the window, so the state is per-row and a dropped row takes its own
+                    // swipe state with it rather than leaving it on whatever slides up into its place.
+                    onDismiss = { value ->
+                        if (value == SwipeToDismissBoxValue.EndToStart) onDrop(window)
+                    },
+                    enableDismissFromStartToEnd = false,
+                    backgroundContent = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(c.badBg)
+                                .padding(horizontal = 16.dp),
+                            contentAlignment = Alignment.CenterEnd,
+                        ) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = stringResource(R.string.weekly_plan_window_drop),
+                                tint = c.bad,
+                            )
+                        }
+                    },
+                ) {
+                    WindowRow(window = window, onMove = onMove)
+                }
+            }
+            Spacer(Modifier.height(10.dp))
+        }
+
+        plan.notPicked.forEach { day ->
+            NotPickedRow(day)
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun WindowRow(window: PlannedWindow, onMove: (PlannedWindow, Int) -> Unit) {
+    val c = AppTheme.colors
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(c.surface)
+            .padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = "${weekdayPlural(window.dayIndex)} ${hourRangeLabel(window.startHour, window.endHourExclusive)}",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = c.text,
+                )
+                if (window.isBest) {
+                    AppChip(
+                        text = stringResource(R.string.weekly_plan_window_best),
+                        color = c.good,
+                        container = c.goodBg,
+                    )
+                }
+                if (window.moved) {
+                    AppChip(text = stringResource(R.string.weekly_plan_window_moved))
+                }
+            }
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = evidenceLine(window),
+                style = MaterialTheme.typography.bodySmall,
+                color = if (window.dollarsPerHour == null || window.hasThinEvidence) c.warn else c.text3,
+            )
+        }
+        Text(
+            text = if (window.dollarsPerHour == null) {
+                stringResource(R.string.weekly_plan_window_unpriced_value)
+            } else {
+                Formats.money(window.projectedKept)
+            },
+            style = MaterialTheme.typography.bodyLarge,
+            color = c.text,
+        )
+        IconButton(onClick = { onMove(window, -1) }) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = stringResource(R.string.weekly_plan_window_earlier),
+                tint = c.text3,
+            )
+        }
+        IconButton(onClick = { onMove(window, +1) }) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = stringResource(R.string.weekly_plan_window_later),
+                tint = c.text3,
+            )
+        }
+    }
+}
+
+/**
+ * `your Fridays: $26.40/hr over 6 Fridays` — the brief's evidence line, measured in the unit the
+ * record can actually count.
+ *
+ * The brief writes "over 14 dashes"; a dash count is structurally unrecoverable from the aggregates
+ * (session spans are unioned and apportioned before any of this exists), so the honest unit is the
+ * number of that weekday's own days behind the median — the same hours-not-dashes discipline #977's
+ * Home strip settled on. A window with no record behind it says so instead of quoting anything.
+ */
+@Composable
+private fun evidenceLine(window: PlannedWindow): String {
+    val weekday = weekdayPlural(window.dayIndex)
+    val rate = window.dollarsPerHour ?: return stringResource(R.string.weekly_plan_window_no_evidence)
+    return stringResource(
+        R.string.weekly_plan_window_evidence_format,
+        weekday,
+        Formats.money(rate),
+        window.sampleCount,
+        weekday,
+    )
+}
+
+/** A weekday the plan left alone, dimmed, with the reason it was left alone. */
+@Composable
+private fun NotPickedRow(day: UnpickedDay) {
+    val c = AppTheme.colors
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .alpha(NOT_PICKED_ALPHA),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = weekdayPlural(day.dayIndex),
+                style = MaterialTheme.typography.bodyMedium,
+                color = c.text2,
+            )
+            Text(
+                text = unpickedReasonText(day),
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
+            )
+        }
+        AppChip(text = stringResource(R.string.weekly_plan_not_picked))
+    }
+}
+
+@Composable
+private fun unpickedReasonText(day: UnpickedDay): String {
+    val weekday = weekdayPlural(day.dayIndex)
+    return when (day.reason) {
+        UnpickedReason.NO_HISTORY -> stringResource(R.string.weekly_plan_reason_no_history, weekday)
+        UnpickedReason.THIN_HISTORY ->
+            stringResource(R.string.weekly_plan_reason_thin_format, day.daysOnRecord, weekday)
+
+        UnpickedReason.NO_CONTIGUOUS_RUN ->
+            stringResource(R.string.weekly_plan_reason_no_run_format, WeeklyPlanner.MIN_WINDOW_HOURS, weekday)
+
+        UnpickedReason.NO_POSITIVE_RATE -> stringResource(R.string.weekly_plan_reason_no_positive, weekday)
+        UnpickedReason.TARGET_ALREADY_MET -> stringResource(R.string.weekly_plan_reason_target_met)
+        UnpickedReason.REMOVED_BY_YOU -> stringResource(R.string.weekly_plan_reason_removed)
+    }
+}
+
+/** Windows the plan didn't pick stay legible but visibly out of it — the brief's dimmed rows. */
+private const val NOT_PICKED_ALPHA = 0.55f

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanExtras.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanExtras.kt
@@ -1,0 +1,244 @@
+package cloud.trotter.dashbuddy.ui.main.plan
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlan
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanGrade
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatMonthDay
+import cloud.trotter.dashbuddy.ui.main.analytics.HeatmapGrid
+import cloud.trotter.dashbuddy.ui.main.analytics.HeatmapHourAxis
+import cloud.trotter.dashbuddy.ui.main.analytics.PatternsModel
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
+
+// ── 4. Where the plan came from (brief §8 item 4) ──────────────────────────
+
+/**
+ * The driver's lifetime heatmap with the picked cells outlined — "the plan must be visibly derived
+ * from the user's own data, never a black box".
+ *
+ * It renders the **same** [HeatmapGrid] the Patterns tab does (extracted for exactly this, #979/#981):
+ * a lookalike grid would eventually drift from the one the driver recognises, and the recognition is
+ * the whole proof.
+ */
+@Composable
+fun PlanProvenanceCard(heatmap: EarningsHeatmap, plan: WeeklyPlan) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.weekly_plan_provenance_title),
+            style = MaterialTheme.typography.labelMedium,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(10.dp))
+        HeatmapGrid(
+            heatmap = heatmap,
+            mode = PatternsModel.HeatmapMode.RATE,
+            maxForMode = heatmap.maxDollarsPerHour ?: 0.0,
+            outlined = { dayIndex, hour -> plan.covers(dayIndex, hour) },
+        )
+        Spacer(Modifier.height(6.dp))
+        HeatmapHourAxis()
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = stringResource(R.string.weekly_plan_provenance_caption),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+    }
+}
+
+// ── 5. Growth rows, present but locked (brief §8 item 5) ───────────────────
+
+/**
+ * The two rows the brief asks to be **designed in now so the screen doesn't need reworking later**:
+ * area demand (the subscription pull) and a year-over-year comparison.
+ *
+ * They are deliberately inert — dashed, dimmed, unclickable — and carry **no data at all**. A locked
+ * row showing plausible-looking numbers would be the single worst thing on this screen: every other
+ * figure here is the driver's own record, and one fabricated neighbour would make all of them suspect.
+ * Each says only what it *would* be and what it is waiting on.
+ */
+@Composable
+fun GrowthRows() {
+    LockedRow(
+        badge = stringResource(R.string.weekly_plan_growth_plus_badge),
+        title = stringResource(R.string.weekly_plan_growth_area_title),
+        body = stringResource(R.string.weekly_plan_growth_area_body),
+        alpha = PLUS_ALPHA,
+    )
+    Spacer(Modifier.height(12.dp))
+    LockedRow(
+        badge = stringResource(R.string.weekly_plan_growth_year_badge),
+        title = stringResource(R.string.weekly_plan_growth_year_title),
+        body = stringResource(R.string.weekly_plan_growth_year_body),
+        alpha = YEAR_ALPHA,
+    )
+}
+
+@Composable
+private fun LockedRow(badge: String, title: String, body: String, alpha: Float) {
+    val c = AppTheme.colors
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .alpha(alpha),
+        border = BorderStroke(1.dp, c.line),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                AppChip(text = badge)
+                Text(text = title, style = MaterialTheme.typography.bodyLarge, color = c.text)
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(text = body, style = MaterialTheme.typography.bodySmall, color = c.text3)
+        }
+    }
+}
+
+/** The brief's exact opacities: 60% for the PLUS row, 45% for the year-over-year one. */
+private const val PLUS_ALPHA = 0.60f
+private const val YEAR_ALPHA = 0.45f
+
+// ── 6. Save (brief §8 item 6) ──────────────────────────────────────────────
+
+/** Save (or update) this week's plan — what the Home pointer reads and next Sunday grades. */
+@Composable
+fun SavePlanCard(isSaved: Boolean, canSave: Boolean, onSave: () -> Unit) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Button(modifier = Modifier.fillMaxWidth(), onClick = onSave, enabled = canSave) {
+            Text(
+                stringResource(
+                    if (isSaved) R.string.weekly_plan_save_update else R.string.weekly_plan_save_button,
+                ),
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.weekly_plan_save_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+    }
+}
+
+// ── The grading loop's visible half ────────────────────────────────────────
+
+/**
+ * Last week's plan measured against what actually happened — the same four numbers the Sunday
+ * notification leads with, so tapping through never shows a different story than the shade did.
+ *
+ * Stated, never scored: no letter grade, no percentage, no judgement. A week the driver skipped
+ * entirely says exactly that.
+ */
+@Composable
+fun LastWeekGradeCard(grade: WeeklyPlanGrade) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.weekly_plan_grade_title, formatMonthDay(grade.weekStart)),
+            style = MaterialTheme.typography.labelMedium,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(8.dp))
+        if (grade.unworked) {
+            Text(
+                text = stringResource(R.string.weekly_plan_grade_unworked_format, grade.plannedHours),
+                style = MaterialTheme.typography.bodyMedium,
+                color = c.text,
+            )
+        } else {
+            Text(
+                text = stringResource(
+                    R.string.weekly_plan_grade_hours_format,
+                    Formats.decimal(grade.actualHours),
+                    grade.plannedHours,
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = c.text,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(
+                    R.string.weekly_plan_grade_money_format,
+                    Formats.money(grade.actualKept),
+                    Formats.money(grade.projectedKept),
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (grade.moneyMet) c.good else c.text2,
+            )
+        }
+        if (grade.keptOutsideWindows > 0.0) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(
+                    R.string.weekly_plan_grade_outside_format,
+                    Formats.money(grade.keptOutsideWindows),
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
+            )
+        }
+    }
+}
+
+/** The pre-data state: say there is no record rather than render an empty plan that looks like a bad week. */
+@Composable
+fun NoRecordCard() {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.weekly_plan_no_record_title),
+            style = MaterialTheme.typography.titleSmall,
+            color = c.text,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = stringResource(R.string.weekly_plan_no_record_body),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+    }
+}
+
+// ── Shared labels ──────────────────────────────────────────────────────────
+
+/**
+ * "Mondays" — the weekday in its recurring-plural form, the shape every evidence line on this screen
+ * needs (`your Fridays: …`). The name is localized by `java.time`; the pluralization is its own
+ * one-argument string so a translator can replace the English `+s` rule rather than fight code — the
+ * same split #977's Home strip uses.
+ */
+@Composable
+internal fun weekdayPlural(dayIndex: Int): String {
+    val name = DayOfWeek.of(dayIndex.coerceIn(0, 6) + 1).getDisplayName(TextStyle.FULL, Locale.getDefault())
+    return stringResource(R.string.weekly_plan_weekday_plural_format, name)
+}
+
+/** "Aug 3" — the week's Monday, through the analytics pager's own month-day label (Principle 5). */
+internal fun weekLabel(weekStart: LocalDate): String = formatMonthDay(weekStart)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanScreen.kt
@@ -1,0 +1,139 @@
+package cloud.trotter.dashbuddy.ui.main.plan
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+
+/**
+ * **Weekly Plan** (#981 / brief §8) — the redesign's new surface and its retention hook: a set of
+ * hour windows drawn from the driver's own record, with the value of following the plan stated next to
+ * the value of not bothering.
+ *
+ * Order, top to bottom, exactly as specced:
+ *  1. last week's grade (when there is one — the loop that earns the notification its place);
+ *  2. the target selector (`8h · 12h · 20h · $ goal`);
+ *  3. the headline value **and** the plan-vs-random comparison — never one without the other;
+ *  4. the suggested windows, each with its evidence line, a `BEST` pill on the top one, and the
+ *     weekdays that were NOT picked with the measured reason;
+ *  5. "where the plan came from" — the same lifetime heatmap the Patterns tab renders, with the
+ *     picked cells outlined;
+ *  6. the locked growth rows (area demand, year-over-year), carrying no data because there is none;
+ *  7. Save this plan.
+ *
+ * **Honesty rules (§9), rendered not assumed.** Every projection says whose data it is and that it is
+ * not a promise; a window quotes the number of the driver's own days behind it; thin history is stated
+ * instead of being smoothed; and with no record at all the screen says so rather than showing an empty
+ * plan that looks like a bad week.
+ *
+ * UDF: immutable state down, intents up (`setTarget`/`moveWindow`/`dropWindow`/`savePlan`). No
+ * `rememberNow()` ticker — a week's plan holds nothing that goes stale while it is looked at; the
+ * ViewModel's record flow and midnight anchor keep it fresh.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WeeklyPlanScreen(
+    onBack: () -> Unit,
+    viewModel: WeeklyPlanViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.weekly_plan_screen_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+                .fillMaxSize(),
+        ) {
+            WeekHeader(weekStart = uiState.weekStart)
+            Spacer(Modifier.height(16.dp))
+
+            uiState.lastWeekGrade?.let { grade ->
+                LastWeekGradeCard(grade)
+                Spacer(Modifier.height(16.dp))
+            }
+
+            if (!uiState.loading && !uiState.hasRecord) {
+                // No record at all: an empty plan would read as "your week is worth nothing".
+                NoRecordCard()
+                Spacer(Modifier.height(16.dp))
+            }
+
+            TargetSelectorCard(target = uiState.target, onSelect = viewModel::setTarget)
+            Spacer(Modifier.height(16.dp))
+
+            if (uiState.hasRecord) {
+                PlanValueCard(plan = uiState.plan)
+                Spacer(Modifier.height(16.dp))
+
+                SuggestedWindowsCard(
+                    plan = uiState.plan,
+                    onMove = viewModel::moveWindow,
+                    onDrop = viewModel::dropWindow,
+                    onUndo = viewModel::undoLastEdit,
+                )
+                Spacer(Modifier.height(16.dp))
+
+                PlanProvenanceCard(heatmap = uiState.heatmap, plan = uiState.plan)
+                Spacer(Modifier.height(16.dp))
+
+                SavePlanCard(
+                    isSaved = uiState.isSaved,
+                    canSave = uiState.plan.windows.isNotEmpty(),
+                    onSave = { viewModel.savePlan() },
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+
+            GrowthRows()
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+/** `Week of Mon, Aug 3` — which week the driver is planning, stated before anything claims anything. */
+@Composable
+private fun WeekHeader(weekStart: java.time.LocalDate) {
+    val c = AppTheme.colors
+    Text(
+        text = stringResource(R.string.weekly_plan_week_of_format, weekLabel(weekStart)),
+        style = MaterialTheme.typography.titleMedium,
+        color = c.text,
+    )
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanUiState.kt
@@ -1,0 +1,38 @@
+package cloud.trotter.dashbuddy.ui.main.plan
+
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.analytics.PlanTarget
+import cloud.trotter.dashbuddy.domain.analytics.SavedWeeklyPlan
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlan
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanGrade
+import java.time.LocalDate
+
+/**
+ * Immutable state for the Weekly Plan screen (#981 / brief §8).
+ *
+ * Everything on it is either the driver's own record ([heatmap]), a derivation of it ([plan]), or
+ * something they themselves committed to ([savedPlan]) — there is no room in this type for a number
+ * that came from anywhere else, which is the point.
+ */
+data class WeeklyPlanUiState(
+    /** True until the first record read lands — the screen shows nothing rather than an empty plan. */
+    val loading: Boolean = true,
+    /** The target the driver selected; drives [plan]. */
+    val target: PlanTarget = PlanTarget.DEFAULT,
+    /** The plan derived from the record for [target], with the driver's edits replayed. */
+    val plan: WeeklyPlan = WeeklyPlan.empty(PlanTarget.DEFAULT),
+    /** The lifetime heatmap — "where the plan came from", with the picked cells outlined. */
+    val heatmap: EarningsHeatmap = EarningsHeatmap.EMPTY,
+    /** Monday of the week this plan is for. */
+    val weekStart: LocalDate = LocalDate.now(),
+    /** The plan already saved for [weekStart], if any — the Home pointer's source. */
+    val savedPlan: SavedWeeklyPlan? = null,
+    /** Last week's plan graded against what actually happened; null until there is one to grade. */
+    val lastWeekGrade: WeeklyPlanGrade? = null,
+) {
+    /** True once the driver has any hour on record at all — everything else states thin data instead. */
+    val hasRecord: Boolean get() = plan.randomPlacementRate != null
+
+    /** True when a plan for this week is already saved (the button says *update*, not *save*). */
+    val isSaved: Boolean get() = savedPlan != null
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanViewModel.kt
@@ -1,0 +1,145 @@
+package cloud.trotter.dashbuddy.ui.main.plan
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.WeeklyPlanRepository
+import cloud.trotter.dashbuddy.core.data.analytics.currentLocalDateFlow
+import cloud.trotter.dashbuddy.domain.analytics.HourOfWeekSamples
+import cloud.trotter.dashbuddy.domain.analytics.PlanEdit
+import cloud.trotter.dashbuddy.domain.analytics.PlanTarget
+import cloud.trotter.dashbuddy.domain.analytics.PlannedWindow
+import cloud.trotter.dashbuddy.domain.analytics.SavedWeeklyPlan
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanGrader
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanSchedule
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanner
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+/**
+ * The Weekly Plan screen's ViewModel (#981 / brief §8).
+ *
+ * **UDF, with the derivation kept pure.** The ViewModel holds only what the driver has *chosen* — the
+ * target and an ordered list of [PlanEdit]s — and recomputes the whole plan from the record on every
+ * emission via the pure [WeeklyPlanner]. Nothing is mutated in place, so a moved window re-derives its
+ * evidence at its new hours instead of carrying a number measured somewhere else, and the state can
+ * never drift from what the algorithm would produce.
+ *
+ * **Reactive by construction:** the record is a Room-invalidation `Flow`, so a dash folded while the
+ * screen is open re-plans it; the local-date flow re-anchors the plan week at midnight without a
+ * restart (the #970/#977 pattern). No `rememberNow()` clock is needed — a week's plan is not a ticking
+ * value.
+ *
+ * **Privacy:** the whole surface is aggregate economics and hour-of-week counts. No store names, no
+ * customer data, no PII of any kind reaches it (Principle 6), and it emits no logs.
+ */
+@HiltViewModel
+class WeeklyPlanViewModel @Inject constructor(
+    private val analyticsRepository: AnalyticsRepository,
+    private val weeklyPlanRepository: WeeklyPlanRepository,
+) : ViewModel() {
+
+    /** UDF intent target — the driver's chosen target. Transient: a plan is saved, a target is not. */
+    private val target = MutableStateFlow(PlanTarget.DEFAULT)
+
+    /**
+     * The driver's edits, in order, replayed over a freshly-derived base plan. Cleared whenever the
+     * target changes: the windows an 8-hour plan holds are not the windows a 20-hour plan holds, so
+     * replaying "drop the third one" across that switch would move a window the driver never touched.
+     */
+    private val edits = MutableStateFlow<List<PlanEdit>>(emptyList())
+
+    /** The device's local date, re-emitting at midnight — what decides which week is being planned. */
+    private val today: StateFlow<LocalDate> = currentLocalDateFlow()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, LocalDate.now())
+
+    val uiState: StateFlow<WeeklyPlanUiState> = combine(
+        target,
+        edits,
+        today,
+        analyticsRepository.hourOfWeekSamples(),
+        combine(analyticsRepository.earningsHeatmap(), weeklyPlanRepository.savedPlans) { heatmap, saved ->
+            heatmap to saved
+        },
+    ) { target, edits, day, samples, (heatmap, savedPlans) ->
+        val weekStart = WeeklyPlanSchedule.planWeekStart(day)
+        WeeklyPlanUiState(
+            loading = false,
+            target = target,
+            plan = WeeklyPlanner.plan(samples, target, edits),
+            heatmap = heatmap,
+            weekStart = weekStart,
+            savedPlan = savedPlans.firstOrNull { it.weekStart == weekStart },
+            lastWeekGrade = gradeOfLastFinishedPlan(savedPlans, samples, day),
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), WeeklyPlanUiState())
+
+    /** Change the target; the plan re-derives and the driver's edits are dropped with it. */
+    fun setTarget(newTarget: PlanTarget) {
+        if (target.value == newTarget) return
+        target.value = newTarget
+        edits.value = emptyList()
+    }
+
+    /** Drop a window; the planner re-fills from the next-best candidate that isn't in dropped territory. */
+    fun dropWindow(window: PlannedWindow) {
+        edits.value = edits.value + PlanEdit.Drop(window.dayIndex, window.startHour)
+    }
+
+    /**
+     * Move a window [deltaHours] earlier (negative) or later (positive).
+     *
+     * This is the brief's "drag to move a window", as a pair of one-hour nudges. A true drag gesture
+     * would have to express *moving a window along a time axis* — not reordering a list — and in a
+     * vertically-scrolling list of rows that reads as a reorder, which is the one thing it must not
+     * mean. The nudge is unambiguous, reachable one-handed while parked, and hits the same intent.
+     */
+    fun moveWindow(window: PlannedWindow, deltaHours: Int) {
+        edits.value = edits.value + PlanEdit.Shift(window.dayIndex, window.startHour, deltaHours)
+    }
+
+    /** Undo the most recent edit — the drop/move affordances would otherwise be one-way. */
+    fun undoLastEdit() {
+        edits.value = edits.value.dropLast(1)
+    }
+
+    /**
+     * Save the plan as it currently stands, frozen (see [SavedWeeklyPlan]).
+     *
+     * [savedAtMillis] is the device clock at the save edge — the one wall-clock read this feature's
+     * UI layer makes, kept here at the edge rather than inside the pure derivation (Principle 1).
+     */
+    fun savePlan(savedAtMillis: Long = System.currentTimeMillis()) {
+        val state = uiState.value
+        if (state.loading) return
+        viewModelScope.launch {
+            weeklyPlanRepository.save(SavedWeeklyPlan.from(state.plan, state.weekStart, savedAtMillis))
+        }
+    }
+
+    /**
+     * The most recent saved plan whose week has fully ended, graded against the record.
+     *
+     * "Fully ended" is load-bearing: grading a week still being worked would report a shortfall the
+     * driver has not had the chance to work off yet.
+     */
+    private fun gradeOfLastFinishedPlan(
+        savedPlans: List<SavedWeeklyPlan>,
+        samples: HourOfWeekSamples,
+        today: LocalDate,
+    ) = savedPlans
+        .filter { !it.weekStart.plusWeeks(1).isAfter(today) }
+        .maxByOrNull { it.weekStart }
+        ?.let { WeeklyPlanGrader.grade(it, samples) }
+
+    private companion object {
+        const val STOP_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/worker/WeeklyPlanWorker.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/worker/WeeklyPlanWorker.kt
@@ -1,0 +1,112 @@
+package cloud.trotter.dashbuddy.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.WeeklyPlanRepository
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanGrade
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanGrader
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanSchedule
+import cloud.trotter.dashbuddy.notice.WeeklyPlanNotifier
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+import timber.log.Timber
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+
+/**
+ * The Sunday-evening Weekly Plan nudge (#981 / brief §8's trigger), and the loop that makes it worth
+ * keeping enabled: before inviting the driver to plan the week ahead, it **grades the plan for the
+ * week just ending** against their own record.
+ *
+ * ### Scheduling
+ *
+ * WorkManager is already a dependency and already hosts a periodic job ([DailyGasPriceWorker]), so
+ * this needs no new mechanism, no exact-alarm permission, and no boot receiver: WorkManager persists
+ * its queue in its own database and re-schedules across reboot itself.
+ *
+ * The request is **periodic on a 7-day interval with an initial delay computed to the next Sunday
+ * 18:00 local** by the pure `:domain` [WeeklyPlanSchedule]. Periodic work is what re-arms itself
+ * safely — a one-time job that re-enqueued its own unique name would have to `REPLACE` work that is
+ * *currently running* (itself), which cancels the very run doing the enqueue.
+ *
+ * **Documented residual:** a 7-day interval is 7×24 h, so a DST change drifts the arrival by an hour
+ * (6 pm becomes 5 or 7) until the next app launch re-anchors it — [schedule] recomputes the delay from
+ * the wall clock every time. The brief asks for "Sunday ~6 PM"; an hour of drift twice a year is
+ * inside that, and buying exactness would mean an exact-alarm permission this feature has no business
+ * requesting.
+ *
+ * **Never takes the loop down with it.** The whole body is wrapped and the worker returns `success`
+ * even when the read or the notification failed — a background job that fails hard because one week's
+ * grade threw would silently end the feature (the #909 silent-death lesson in miniature).
+ */
+@HiltWorker
+class WeeklyPlanWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val analyticsRepository: AnalyticsRepository,
+    private val weeklyPlanRepository: WeeklyPlanRepository,
+    private val notifier: WeeklyPlanNotifier,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        try {
+            notifier.postWeeklyNudge(gradeForFinishedWeek())
+        } catch (t: Throwable) {
+            // Broad by intent (#909): nothing this job does is worth losing the weekly loop over.
+            Timber.tag(TAG).e(t, "Weekly plan nudge failed")
+        }
+        return Result.success()
+    }
+
+    /**
+     * Last week's saved plan measured against the record, or null when the driver saved none.
+     *
+     * Both reads are one-shot `first()` snapshots — a worker has no UI to keep collecting for — and
+     * the grade itself is the pure `:domain` [WeeklyPlanGrader] over the same lifetime samples the
+     * screen uses, so the notification and the screen can never quote different numbers.
+     */
+    private suspend fun gradeForFinishedWeek(): WeeklyPlanGrade? {
+        val today = Instant.ofEpochMilli(System.currentTimeMillis()).atZone(ZoneId.systemDefault()).toLocalDate()
+        val plan = weeklyPlanRepository.planForNow(WeeklyPlanSchedule.gradedWeekStart(today)) ?: return null
+        return WeeklyPlanGrader.grade(plan, analyticsRepository.hourOfWeekSamples().first())
+    }
+
+    companion object {
+        private const val TAG = "WeeklyPlan"
+
+        /** Unique work name — one weekly nudge schedule at a time. */
+        const val WORK_NAME = "weekly_plan_nudge"
+
+        private const val INTERVAL_DAYS = 7L
+
+        /**
+         * Arm (or re-anchor) the weekly nudge. Idempotent and safe to call on every app start.
+         *
+         * `CANCEL_AND_REENQUEUE` rather than `KEEP`: the delay is computed against the wall clock at
+         * call time, so a launch after a timezone change, a reboot, or a DST shift re-pins it to the
+         * real next Sunday instead of honouring whatever the old schedule had drifted to.
+         */
+        fun schedule(
+            context: Context,
+            nowMillis: Long = System.currentTimeMillis(),
+            zone: ZoneId = ZoneId.systemDefault(),
+        ) {
+            val delayMs = (WeeklyPlanSchedule.nextTriggerMillis(nowMillis, zone) - nowMillis).coerceAtLeast(0L)
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
+                PeriodicWorkRequestBuilder<WeeklyPlanWorker>(INTERVAL_DAYS, TimeUnit.DAYS)
+                    .setInitialDelay(delayMs, TimeUnit.MILLISECONDS)
+                    .build(),
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -676,4 +676,88 @@
     <string name="analytics_hero_summary_acceptance_format">%1$s acceptance</string>
     <string name="analytics_hero_summary_separator"> · </string>
     <string name="analytics_hero_no_data">Nothing recorded in this window</string>
+
+    <!-- ============================================================ -->
+    <!-- Weekly Plan (#981, redesign stage 6 — brief §8)              -->
+    <!-- ============================================================ -->
+    <string name="weekly_plan_screen_title">Weekly plan</string>
+    <string name="weekly_plan_week_of_format">Week of %1$s</string>
+    <string name="weekly_plan_weekday_plural_format">%1$ss</string>
+
+    <!-- Target selector -->
+    <string name="weekly_plan_target_title">How much do you want to work?</string>
+    <string name="weekly_plan_target_hours_format">%1$dh</string>
+    <string name="weekly_plan_target_dollars">$ goal</string>
+    <string name="weekly_plan_target_dollars_selected">Aiming for %1$s kept</string>
+    <string name="weekly_plan_goal_dialog_title">Set a goal</string>
+    <string name="weekly_plan_goal_dialog_body">How much do you want to keep this week? The plan places hours until your own record projects that much.</string>
+    <string name="weekly_plan_goal_dialog_label">Amount</string>
+    <string name="weekly_plan_goal_dialog_confirm">Plan it</string>
+    <string name="weekly_plan_goal_dialog_cancel">Cancel</string>
+
+    <!-- Headline value + the plan-vs-random comparison -->
+    <string name="weekly_plan_hours_format">%1$d hours</string>
+    <string name="weekly_plan_value_headline_format">%1$s on your best windows ≈ %2$s kept</string>
+    <string name="weekly_plan_value_comparison_format">The same %1$s placed at random ≈ %2$s — the plan is worth about %3$s</string>
+    <string name="weekly_plan_value_comparison_no_gain_format">The same %1$s placed at random ≈ %2$s — this plan doesn\'t beat working whenever</string>
+    <string name="weekly_plan_value_no_baseline">Not enough of your record yet to compare this against working whenever.</string>
+    <string name="weekly_plan_value_shortfall_format">Placed %1$d of your %2$d target hours — your record doesn\'t back any more than that yet.</string>
+    <string name="weekly_plan_value_unpriced_format">%1$d of these hours have no record behind them, so they project nothing.</string>
+    <string name="weekly_plan_provenance">From your own record, lifetime — a projection of what you have earned, not a promise of what you will.</string>
+
+    <!-- Suggested windows -->
+    <string name="weekly_plan_windows_title">Suggested windows</string>
+    <string name="weekly_plan_windows_none">Nothing in your record supports a window yet.</string>
+    <string name="weekly_plan_window_best">Best</string>
+    <string name="weekly_plan_window_moved">Moved</string>
+    <string name="weekly_plan_window_evidence_format">your %1$s: %2$s/hr over %3$d %4$s</string>
+    <string name="weekly_plan_window_no_evidence">no record of these hours — this window projects nothing</string>
+    <string name="weekly_plan_window_unpriced_value">—</string>
+    <string name="weekly_plan_window_earlier">Move an hour earlier</string>
+    <string name="weekly_plan_window_later">Move an hour later</string>
+    <string name="weekly_plan_window_drop">Drop this window</string>
+    <string name="weekly_plan_undo">Undo</string>
+    <string name="weekly_plan_not_picked">Not picked</string>
+    <string name="weekly_plan_reason_no_history">no %1$s on record yet</string>
+    <string name="weekly_plan_reason_thin_format">only %1$d %2$s on record</string>
+    <string name="weekly_plan_reason_no_run_format">no stretch of %1$d hours your %2$s back up</string>
+    <string name="weekly_plan_reason_no_positive">your %1$s haven\'t cleared $0 kept</string>
+    <string name="weekly_plan_reason_target_met">your target filled up with better-paying windows</string>
+    <string name="weekly_plan_reason_removed">you dropped this one</string>
+
+    <!-- Where the plan came from -->
+    <string name="weekly_plan_provenance_title">Where the plan came from</string>
+    <string name="weekly_plan_provenance_caption">Your whole record, hour by hour. The outlined cells are the hours the plan picked.</string>
+
+    <!-- Growth rows — locked, and carrying no data -->
+    <string name="weekly_plan_growth_plus_badge">Plus</string>
+    <string name="weekly_plan_growth_area_title">Demand around you</string>
+    <string name="weekly_plan_growth_area_body">When other drivers near you are earning — including hours you have never tried. Not built yet, and it will never be turned on without you asking.</string>
+    <string name="weekly_plan_growth_year_badge">Needs a year</string>
+    <string name="weekly_plan_growth_year_title">This week last year</string>
+    <string name="weekly_plan_growth_year_body">A year-over-year comparison, once you have a year of your own record to compare against.</string>
+
+    <!-- Save -->
+    <string name="weekly_plan_save_button">Save this plan</string>
+    <string name="weekly_plan_save_update">Update saved plan</string>
+    <string name="weekly_plan_save_note">Saved plans show up on your home screen each morning, and next Sunday this one gets measured against what actually happened.</string>
+
+    <!-- Grade -->
+    <string name="weekly_plan_grade_title">Your plan for the week of %1$s</string>
+    <string name="weekly_plan_grade_hours_format">You worked %1$s of the %2$d hours you planned.</string>
+    <string name="weekly_plan_grade_money_format">Those windows kept %1$s of the %2$s they projected.</string>
+    <string name="weekly_plan_grade_outside_format">Plus %1$s kept outside the plan.</string>
+    <string name="weekly_plan_grade_unworked_format">You didn\'t work any of your %1$d planned hours.</string>
+
+    <!-- Empty state -->
+    <string name="weekly_plan_no_record_title">No record to plan from yet</string>
+    <string name="weekly_plan_no_record_body">This screen plans from hours you have actually worked. Dash a few times and it will have something to say.</string>
+
+    <!-- Notification (its own channel, so it can be muted on its own) -->
+    <string name="weekly_plan_channel_name">Weekly plan</string>
+    <string name="weekly_plan_channel_description">A Sunday-evening look at how last week\'s plan went, and a plan for the week ahead.</string>
+    <string name="weekly_plan_notice_title">Your weekly plan</string>
+    <string name="weekly_plan_notice_text_plain">Plan the week ahead from your own best hours.</string>
+    <string name="weekly_plan_notice_grade_format">Last week: %1$s of %2$d planned hours worked, %3$s kept of %4$s projected. Tap to plan the week ahead.</string>
+    <string name="weekly_plan_notice_grade_unworked_format">Last week: none of your %1$d planned hours got worked. Tap to plan the week ahead.</string>
 </resources>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.ui.main.dashboard
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.WeeklyPlanRepository
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
@@ -16,6 +17,7 @@ import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmapCalculator
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmapCell
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.SavedWeeklyPlan
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.WindowGranularity
 import cloud.trotter.dashbuddy.domain.state.AppState
@@ -79,6 +81,10 @@ class DashboardViewModelTest {
     private val analyticsRepository: AnalyticsRepository = mock()
     private val appPreferencesRepository: AppPreferencesRepository = mock()
     private val bubbleManager: BubbleManager = mock()
+    private val weeklyPlanRepository: WeeklyPlanRepository = mock()
+
+    /** The plan the stubbed repository serves for the current week; null ⇒ Home renders no pointer. */
+    private var savedPlan: SavedWeeklyPlan? = null
 
     private val today: LocalDate get() = LocalDate.now()
     private val thisWeek: AnalyticsWindow get() = AnalyticsWindows.current(WindowGranularity.WEEK, today)
@@ -108,6 +114,9 @@ class DashboardViewModelTest {
             .thenAnswer { flowOf(dailyEarnings) }
         whenever(analyticsRepository.orphanOfferGroups(any<AnalyticsWindow>(), any<ZoneId>()))
             .thenAnswer { flowOf(orphanOfferGroups) }
+        // #981 — the weekly-plan pointer row's source. No saved plan by default, which is the
+        // state every pre-#981 assertion here was written against.
+        whenever(weeklyPlanRepository.planFor(any())).thenAnswer { flowOf(savedPlan) }
         whenever(appPreferencesRepository.analyticsWindow).thenReturn(selectionFlow)
         whenever(runBlocking { appPreferencesRepository.setAnalyticsWindow(any()) }).thenAnswer { invocation ->
             selectionFlow.value = invocation.getArgument(0)
@@ -153,6 +162,7 @@ class DashboardViewModelTest {
         analyticsRepository = analyticsRepository,
         appPreferencesRepository = appPreferencesRepository,
         bubbleManager = bubbleManager,
+        weeklyPlanRepository = weeklyPlanRepository,
     )
 
     /**

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/plan/WeeklyPlanViewModelTest.kt
@@ -1,0 +1,249 @@
+package cloud.trotter.dashbuddy.ui.main.plan
+
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.WeeklyPlanRepository
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.analytics.HourOfWeekSamples
+import cloud.trotter.dashbuddy.domain.analytics.PlanTarget
+import cloud.trotter.dashbuddy.domain.analytics.SampledDay
+import cloud.trotter.dashbuddy.domain.analytics.SavedWeeklyPlan
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanSchedule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+
+/**
+ * #981 — the Weekly Plan ViewModel: it holds only the driver's choices (target + edits) and recomputes
+ * the plan from the record, and it saves a FROZEN snapshot of exactly what was on screen.
+ *
+ * **Harness note — the midnight re-anchor is an unbounded virtual-time loop** (the documented
+ * `AnalyticsViewModelTest` / `DashboardViewModelTest` pattern, a 12-minute CI hang was its receipt).
+ * The ViewModel resolves its plan week against `currentLocalDateFlow`, which emits and then sleeps
+ * until the next local midnight, forever. Under a `StandardTestDispatcher` that delay is *virtual*, so
+ * anything draining the scheduler spins through midnight after midnight and never runs out of work.
+ * Hence: settle with **`runCurrent()`**, never `advanceUntilIdle()`, and **cancel the ViewModel's
+ * scope before the test body ends** ([runWithViewModel] does both) — `runTest` finishes with its own
+ * `advanceUntilIdle()` and `viewModelScope` is not a child of the test scope.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WeeklyPlanViewModelTest {
+
+    private val analyticsRepository: AnalyticsRepository = mock()
+    private val weeklyPlanRepository: WeeklyPlanRepository = mock()
+
+    /** The saved plans the stubbed repository serves; writes land here so a save round-trips. */
+    private val savedPlans = MutableStateFlow<List<SavedWeeklyPlan>>(emptyList())
+
+    /** A record with two clearly-ranked evenings: Fridays at $30/hr, Tuesdays at $12/hr. */
+    private val samples = HourOfWeekSamples(
+        buildList {
+            addAll(weekday(dayIndex = 4, hours = 17..20, rate = 30.0, occurrences = 4))
+            addAll(weekday(dayIndex = 1, hours = 17..20, rate = 12.0, occurrences = 4))
+        },
+    )
+
+    private fun weekday(dayIndex: Int, hours: IntRange, rate: Double, occurrences: Int): List<SampledDay> {
+        val monday = LocalDate.of(2026, 1, 5)
+        return (0 until occurrences).map { occ ->
+            val coverage = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+            val net = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+            for (h in hours) {
+                coverage[h] = 1.0
+                net[h] = rate
+            }
+            SampledDay(monday.plusDays((dayIndex + 7 * occ).toLong()), dayIndex, coverage, net)
+        }
+    }
+
+    @Before
+    fun setUp() {
+        whenever(analyticsRepository.hourOfWeekSamples(any())).thenAnswer { flowOf(samples) }
+        whenever(analyticsRepository.earningsHeatmap(any())).thenAnswer { flowOf(EarningsHeatmap.EMPTY) }
+        whenever(weeklyPlanRepository.savedPlans).thenReturn(savedPlans)
+        whenever(runBlocking { weeklyPlanRepository.save(any()) }).thenAnswer { invocation ->
+            val plan = invocation.getArgument<SavedWeeklyPlan>(0)
+            savedPlans.value = listOf(plan) + savedPlans.value.filterNot { it.weekStart == plan.weekStart }
+            Unit
+        }
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    /**
+     * Build the ViewModel, keep its `uiState` hot for the duration, and cancel its scope at the end —
+     * without which `runTest`'s teardown `advanceUntilIdle()` stalls on the midnight loop.
+     */
+    private fun TestScope.runWithViewModel(body: (WeeklyPlanViewModel) -> Unit) {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val viewModel = WeeklyPlanViewModel(analyticsRepository, weeklyPlanRepository)
+        val collector = launch { viewModel.uiState.collect { } }
+        testScheduler.runCurrent()
+        try {
+            body(viewModel)
+        } finally {
+            collector.cancel()
+            viewModel.viewModelScope.cancel()
+        }
+    }
+
+    @Test
+    fun `plans the driver's best windows for the default target`() = runTest {
+        runWithViewModel { viewModel ->
+            val state = viewModel.uiState.value
+            assertFalse(state.loading)
+            assertTrue(state.hasRecord)
+            // Fridays outrank Tuesdays, so the BEST window is a Friday one. (The list itself is in
+            // weekday order — a week reads chronologically — so "first placed" is not "first shown".)
+            assertEquals(4, state.plan.windows.first { it.isBest }.dayIndex)
+            assertTrue(state.plan.projectedKept > 0.0)
+        }
+    }
+
+    @Test
+    fun `the plan week is the Monday-anchored week the schedule owns`() = runTest {
+        runWithViewModel { viewModel ->
+            assertEquals(
+                WeeklyPlanSchedule.planWeekStart(LocalDate.now()),
+                viewModel.uiState.value.weekStart,
+            )
+        }
+    }
+
+    @Test
+    fun `changing the target re-plans and drops the edits made against the old one`() = runTest {
+        runWithViewModel { viewModel ->
+            val first = viewModel.uiState.value.plan.windows.first()
+            viewModel.dropWindow(first)
+            testScheduler.runCurrent()
+            assertEquals(1, viewModel.uiState.value.plan.edits.size)
+
+            viewModel.setTarget(PlanTarget.Hours(8))
+            testScheduler.runCurrent()
+
+            val state = viewModel.uiState.value
+            assertEquals(PlanTarget.Hours(8), state.target)
+            assertTrue(state.plan.edits.isEmpty())
+            assertTrue(state.plan.totalHours <= 8)
+        }
+    }
+
+    @Test
+    fun `dropping a window records an edit and re-plans without it`() = runTest {
+        runWithViewModel { viewModel ->
+            val dropped = viewModel.uiState.value.plan.windows.first()
+            viewModel.dropWindow(dropped)
+            testScheduler.runCurrent()
+
+            val windows = viewModel.uiState.value.plan.windows
+            assertTrue(windows.none { it.dayIndex == dropped.dayIndex && it.startHour == dropped.startHour })
+        }
+    }
+
+    @Test
+    fun `moving a window re-derives it at the new hours and marks it moved`() = runTest {
+        runWithViewModel { viewModel ->
+            val window = viewModel.uiState.value.plan.windows.first()
+            viewModel.moveWindow(window, -1)
+            testScheduler.runCurrent()
+
+            val moved = viewModel.uiState.value.plan.windows.first { it.moved }
+            assertEquals(window.startHour - 1, moved.startHour)
+        }
+    }
+
+    @Test
+    fun `undo removes the last edit only`() = runTest {
+        runWithViewModel { viewModel ->
+            val window = viewModel.uiState.value.plan.windows.first()
+            viewModel.moveWindow(window, -1)
+            testScheduler.runCurrent()
+            viewModel.dropWindow(viewModel.uiState.value.plan.windows.first())
+            testScheduler.runCurrent()
+            assertEquals(2, viewModel.uiState.value.plan.edits.size)
+
+            viewModel.undoLastEdit()
+            testScheduler.runCurrent()
+
+            assertEquals(1, viewModel.uiState.value.plan.edits.size)
+            assertTrue(viewModel.uiState.value.plan.windows.any { it.moved })
+        }
+    }
+
+    @Test
+    fun `saving freezes exactly what is on screen, and the pointer state reads it back`() = runTest {
+        runWithViewModel { viewModel ->
+            val shown = viewModel.uiState.value.plan
+            assertNull(viewModel.uiState.value.savedPlan)
+
+            viewModel.savePlan(savedAtMillis = 1_753_000_000_000L)
+            testScheduler.runCurrent()
+
+            val saved = savedPlans.value.single()
+            assertEquals(viewModel.uiState.value.weekStart, saved.weekStart)
+            assertEquals(shown.projectedKept, saved.projectedKept, 1e-9)
+            assertEquals(shown.totalHours, saved.totalHours)
+            assertEquals(shown.windows.map { it.startHour }, saved.windows.map { it.startHour })
+            // …and the state now reports it as saved, which is what flips the button copy.
+            assertTrue(viewModel.uiState.value.isSaved)
+        }
+    }
+
+    @Test
+    fun `a finished week's saved plan is graded, an unfinished one is not`() = runTest {
+        val thisWeek = WeeklyPlanSchedule.weekStartOf(LocalDate.now())
+        savedPlans.value = listOf(
+            SavedWeeklyPlan(
+                weekStart = thisWeek,
+                savedAtMillis = 0L,
+                target = PlanTarget.Hours(4),
+                windows = emptyList(),
+                projectedKept = 0.0,
+                randomKept = null,
+            ),
+        )
+        runWithViewModel { viewModel ->
+            // The week in progress is deliberately not graded — a shortfall it can still work off.
+            assertNull(viewModel.uiState.value.lastWeekGrade)
+        }
+
+        savedPlans.value = listOf(savedPlans.value.single().copy(weekStart = thisWeek.minusWeeks(2)))
+        runWithViewModel { viewModel ->
+            assertNotNull(viewModel.uiState.value.lastWeekGrade)
+            assertEquals(thisWeek.minusWeeks(2), viewModel.uiState.value.lastWeekGrade!!.weekStart)
+        }
+    }
+
+    @Test
+    fun `an empty record reports no baseline instead of an empty plan that looks like a bad week`() = runTest {
+        whenever(analyticsRepository.hourOfWeekSamples(any())).thenAnswer { flowOf(HourOfWeekSamples.EMPTY) }
+        runWithViewModel { viewModel ->
+            val state = viewModel.uiState.value
+            assertFalse(state.hasRecord)
+            assertTrue(state.plan.windows.isEmpty())
+            assertNull(state.plan.planWorth)
+        }
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -16,6 +16,8 @@ import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmapCalculator
 import cloud.trotter.dashbuddy.domain.analytics.EstimateVsReality
+import cloud.trotter.dashbuddy.domain.analytics.HourOfWeekSampler
+import cloud.trotter.dashbuddy.domain.analytics.HourOfWeekSamples
 import cloud.trotter.dashbuddy.domain.analytics.OfferFilter
 import cloud.trotter.dashbuddy.domain.analytics.OfferListing
 import cloud.trotter.dashbuddy.domain.analytics.OfferOutcome
@@ -357,6 +359,33 @@ class AnalyticsRepository @Inject constructor(
             analyticsDao.deliveryNets(),
         ) { spans, nets ->
             EarningsHeatmapCalculator.compute(
+                spans = spans.map { SessionSpan(it.startMillis, it.endMillis) },
+                deliveries = nets.map { DeliveryNet(it.completedAt, it.netDollars) },
+                zone = zoneProvider(),
+            )
+        }.flowOn(Dispatchers.Default).distinctUntilChanged()
+
+    /**
+     * The same lifetime record as [earningsHeatmap], decomposed **per occurrence** — the distribution
+     * the Weekly Plan takes its medians and sample counts over (#981 / brief §7.7).
+     *
+     * This is the whole of §7.7's read-side plumbing, and it deliberately adds **no query**: brief §8
+     * ranks weekday×hour cells by MEDIAN net $/hr, which the heatmap grid structurally cannot answer
+     * (it is a totals grid whose cell rate is `Σnet ÷ Σcoverage`, a coverage-weighted mean, with the
+     * individual days summed away). [HourOfWeekSampler] consumes the identical two DAO reads one
+     * calendar step earlier — into `(date, hour)` buckets — so a cell's samples are its own separate
+     * days and both the median and "over N Fridays" fall out. No schema change, no
+     * `PROJECTOR_VERSION` bump, no economy dependency (net is the frozen stored value).
+     *
+     * Same shape as [earningsHeatmap] in every other respect: lifetime-scoped, [zoneProvider]
+     * evaluated per emission so a timezone move re-buckets on the next commit, apportionment off-main.
+     */
+    fun hourOfWeekSamples(zoneProvider: () -> ZoneId = { ZoneId.systemDefault() }): Flow<HourOfWeekSamples> =
+        combine(
+            analyticsDao.sessionSpans(),
+            analyticsDao.deliveryNets(),
+        ) { spans, nets ->
+            HourOfWeekSampler.compute(
                 spans = spans.map { SessionSpan(it.startMillis, it.endMillis) },
                 deliveries = nets.map { DeliveryNet(it.completedAt, it.netDollars) },
                 zone = zoneProvider(),

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/WeeklyPlanRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/WeeklyPlanRepository.kt
@@ -1,0 +1,62 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.core.datastore.plan.WeeklyPlanDataSource
+import cloud.trotter.dashbuddy.domain.analytics.SavedWeeklyPlan
+import cloud.trotter.dashbuddy.domain.analytics.WeeklyPlanCodec
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.time.LocalDate
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The driver's saved weekly plans (#981 / brief §8 item 6) — write side of the plan surface, read side
+ * of the Home pointer row and the Sunday grading worker.
+ *
+ * Thin by design: the store moves a string, the `:domain` [WeeklyPlanCodec] owns the shape (fail-closed
+ * in both directions), and this class owns exactly one policy — **how many plans are kept and which
+ * one wins for a week**. It is deliberately NOT part of `AnalyticsRepository`: a saved plan is a user
+ * artifact rather than a projection of the event log, and mixing it into the read-model repository
+ * would blur the "analytics is rebuildable, this is not" line that keeps a `PROJECTOR_VERSION` bump
+ * from deleting it (see `WeeklyPlanDataSource`).
+ */
+@Singleton
+class WeeklyPlanRepository @Inject constructor(
+    private val dataSource: WeeklyPlanDataSource,
+) {
+
+    /** Every kept plan, newest week first. Empty when nothing has ever been saved (or the blob is corrupt). */
+    val savedPlans: Flow<List<SavedWeeklyPlan>> =
+        dataSource.savedPlansJson.map { json ->
+            WeeklyPlanCodec.decode(json).sortedByDescending { it.weekStart }
+        }
+
+    /** The plan saved for the week starting [weekStart], or null. */
+    fun planFor(weekStart: LocalDate): Flow<SavedWeeklyPlan?> =
+        savedPlans.map { plans -> plans.firstOrNull { it.weekStart == weekStart } }
+
+    /** One-shot read of the plan for [weekStart] — the worker's path (it has no UI to keep collecting). */
+    suspend fun planForNow(weekStart: LocalDate): SavedWeeklyPlan? =
+        savedPlans.first().firstOrNull { it.weekStart == weekStart }
+
+    /**
+     * Persist [plan], replacing any existing plan for the same week and keeping at most
+     * [SavedWeeklyPlan.MAX_KEPT] of the most recent weeks.
+     *
+     * Re-saving a week is a plain overwrite: the driver rearranged their plan and the newer arrangement
+     * is the one they committed to, so it is also the one next Sunday grades.
+     */
+    suspend fun save(plan: SavedWeeklyPlan) {
+        val kept = (listOf(plan) + savedPlans.first().filterNot { it.weekStart == plan.weekStart })
+            .sortedByDescending { it.weekStart }
+            .take(SavedWeeklyPlan.MAX_KEPT)
+        dataSource.savePlansJson(WeeklyPlanCodec.encode(kept))
+    }
+
+    /** Drop the plan for [weekStart] (the driver clearing it), leaving the others untouched. */
+    suspend fun delete(weekStart: LocalDate) {
+        val kept = savedPlans.first().filterNot { it.weekStart == weekStart }
+        dataSource.savePlansJson(WeeklyPlanCodec.encode(kept))
+    }
+}

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/di/DataStoreModule.kt
@@ -54,6 +54,12 @@ object DataStoreModule {
 
     @Provides
     @Singleton
+    @WeeklyPlanPreferences
+    fun provideWeeklyPlanDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { context.preferencesDataStoreFile("weekly_plan") }
+
+    @Provides
+    @Singleton
     @RuleCapabilityPreferences
     fun provideRuleCapabilityDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
         PreferenceDataStoreFactory.create { context.preferencesDataStoreFile("rule_capability_grants") }

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/di/DataStoreQualifiers.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/di/DataStoreQualifiers.kt
@@ -29,3 +29,7 @@ annotation class PlatformPreferences
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class RuleCapabilityPreferences
+/** #981 — the driver's saved weekly plans (a user artifact, not a rebuildable projection). */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class WeeklyPlanPreferences

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/plan/WeeklyPlanDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/plan/WeeklyPlanDataSource.kt
@@ -1,0 +1,51 @@
+package cloud.trotter.dashbuddy.core.datastore.plan
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import cloud.trotter.dashbuddy.core.datastore.di.WeeklyPlanPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Storage for the driver's saved weekly plans (#981 / brief §7.7).
+ *
+ * **Why a DataStore and not a Room table.** A saved plan is a **user artifact**, not an observation:
+ * nothing in `app_events` implies it, and nothing can rebuild it. The analytics tables are explicitly
+ * a rebuildable projection that a `PROJECTOR_VERSION` bump WIPES (CLAUDE.md §5) — putting an
+ * unrebuildable artifact in there would mean a routine projector bump silently deletes the driver's
+ * plan and the grade it was owed. The alternative cost is also real: a Room table for one small
+ * per-week record buys a schema-version bump, an `AutoMigration`, an exported-schema regeneration and
+ * a `MigrationTestHelper` case, for data with no query surface beyond "give me the current one".
+ *
+ * So it lives in its own single-concern preferences store — the eighth, alongside app prefs, app
+ * state, dev settings, odometer, strategy, platforms and rule-capability grants — holding ONE
+ * JSON string encoded by the `:domain` `WeeklyPlanCodec` (the `LegState` precedent: the codec is pure
+ * and unit-tested, the store only moves the string).
+ *
+ * This layer deliberately knows nothing about the plan's shape; decoding (and its fail-closed
+ * behaviour) belongs to the codec, and the repository above is where the two meet.
+ */
+@Singleton
+class WeeklyPlanDataSource @Inject constructor(
+    @param:WeeklyPlanPreferences private val ds: DataStore<Preferences>,
+) {
+    private object Keys {
+        /** The encoded saved-plan list. Do not rename — a saved plan is keyed on it. */
+        val SAVED_PLANS = stringPreferencesKey("saved_plans_json")
+    }
+
+    /** The raw encoded blob, or null when the driver has never saved a plan. */
+    val savedPlansJson: Flow<String?> = ds.data.map { it[Keys.SAVED_PLANS] }
+
+    suspend fun savePlansJson(json: String) {
+        ds.edit { it[Keys.SAVED_PLANS] = json }
+    }
+
+    suspend fun clear() {
+        ds.edit { it.remove(Keys.SAVED_PLANS) }
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,46 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #981 — Weekly Plan + the Sunday notification (redesign stage 6).** A whole new screen,
+  reached two ways: the Sunday-evening notification, and (once you save a plan) a row on Home.
+  Six things to check.
+  (a) **Getting there:** Home shows no plan row until you save one. Reach the screen the first time
+  by waiting for the Sunday ~6 PM notification ("Your weekly plan") and tapping it — it must open
+  the Weekly Plan screen, not the home screen. Its notification channel is its own: check
+  Settings → Apps → DashBuddy → Notifications lists a **Weekly plan** channel separate from
+  **App notices**, and muting one must not mute the other.
+  (b) **The numbers are two, always:** the headline `N hours on your best windows ≈ $X kept` must
+  ALWAYS be followed by the comparison line `The same N hours placed at random ≈ $Y — the plan is
+  worth about $Z`. A headline with no comparison under it is the bug to report. If your record is
+  too thin for a baseline it must say so in words instead of showing the headline alone. The line
+  `From your own record, lifetime — a projection of what you have earned, not a promise…` must be
+  on the card in every state.
+  (c) **The windows are evidence-backed:** each row reads `Fridays 5–9 PM`, an evidence line
+  `your Fridays: $26.40/hr over 6 Fridays`, and a projected figure. The count is **days, not
+  dashes** — that's deliberate. One row carries a `BEST` chip. Below the picked rows, every weekday
+  that did NOT make the plan appears dimmed with `NOT PICKED` and a reason
+  ("only 2 Sundays on record", "your target filled up with better-paying windows", …). A weekday
+  silently missing from both lists is a bug.
+  (d) **Editing:** swipe a row left to drop it — the plan must re-fill from *different* hours, not
+  put the same window back, and that weekday should now say "you dropped this one". The `‹ ›`
+  arrows nudge a window an hour earlier/later, and the evidence line + projected figure must
+  **change to the new hours' own numbers** (moving onto hours you've never worked must show
+  "no record of these hours — this window projects nothing" and a `—`, never carry the old rate
+  along). `Undo` reverses the last change only.
+  (e) **Where the plan came from:** the lifetime heatmap (same grid as Analytics → Patterns) with
+  the picked cells **outlined** in accent. Cross-check one outlined cell against the window list —
+  they must agree.
+  (f) **Save + the loop:** tap `Save this plan`. Go Home: a `Your week is planned · Nh across M
+  windows · $X projected` row must now appear (and its numbers must match what you saved). The
+  following Sunday's notification should lead with the grade —
+  `Last week: 7.5 of 12 planned hours worked, $180.00 kept of $280.00 projected` — and the screen
+  should show the same four numbers in a card at the top. Skipping the week entirely must read
+  "You didn't work any of your N planned hours", not "0 of 12".
+  Also check: the two locked rows at the bottom (**PLUS** area demand, **NEEDS A YEAR** year-over-
+  year) are dimmed, dashed and carry **no numbers at all** — a fabricated figure there would be the
+  worst bug on the screen.
+  - Confirmed: 0/2
+
 - **🆕 NEW — #979 — Patterns: ALL-TIME badge, heatmap Rate/Hours toggle, store leaderboard
   (redesign stage 5).** Open Analytics → Patterns. Three things to check.
   (a) **ALL TIME badge:** an `All time` chip sits at the very top with the caption "patterns need

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/HourOfWeekSamples.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/HourOfWeekSamples.kt
@@ -1,0 +1,261 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * The driver's own record decomposed into **per-occurrence** hour buckets (#981 / brief §7.7) — the
+ * distribution the Weekly Plan's *medians* are taken over.
+ *
+ * ### Why this exists (the §7.7 plumbing, stated plainly)
+ *
+ * Brief §8 asks the planner to "rank weekday×hour cells by **median** realized net $/hr". The
+ * [EarningsHeatmap] the Patterns tab and the Home strip read cannot answer that: it is a **totals**
+ * grid — it apportions every session span and lands every delivery's net into 168 accumulators, and
+ * its cell rate is `Σnet ÷ Σcoverage`, a coverage-weighted MEAN. Once those sums exist the individual
+ * occurrences are gone, so no median (and no sample COUNT) is recoverable from it.
+ *
+ * The honest minimum plumbing is therefore this: keep the SAME two lifetime reads the heatmap already
+ * uses (`AnalyticsDao.sessionSpans` + `AnalyticsDao.deliveryNets`) and apportion them one calendar
+ * step earlier — into **(date, hour)** buckets instead of straight into (weekday, hour) totals. A
+ * weekday×hour cell's samples are then its individual dates, and both the median and "over N Fridays"
+ * fall out. **No new query, no new column, no schema change, no `PROJECTOR_VERSION` bump** — the same
+ * rows, decomposed one level finer.
+ *
+ * ### Semantics inherited verbatim from [EarningsHeatmapCalculator] (Principle 5)
+ *
+ *  - **Denominator:** spans are merged into a wall-clock **union** first (concurrent platforms and a
+ *    crashed-open overlap count once), then apportioned across the wall-clock hours they overlap in
+ *    fractional hours.
+ *  - **Numerator:** each delivery's (frozen `netProfit` + `cashTip`) lands **whole** in the bucket of
+ *    its `completedAt`. A drop that completes at 8:05 pm credits the 8 pm hour even if the run that
+ *    earned it was 5–8 pm — the same boundary behaviour the heatmap has always had, kept identical on
+ *    purpose so the plan and the Patterns grid can never tell the driver two different stories.
+ *  - **Coverage floor:** an occurrence is only a *sample* once the driver was present for at least
+ *    [MIN_COVERAGE_FRACTION] of the range being asked about. One delivery across three minutes of
+ *    presence is a 20×/hr artifact, not evidence.
+ *
+ * Pure `:domain`: no Android, no wall clock — the zone and the timestamps are passed in, so every
+ * behaviour here is exhaustively unit-testable.
+ */
+data class HourOfWeekSamples(
+    /** One entry per calendar date carrying any coverage or any net, ascending by date. */
+    val days: List<SampledDay>,
+) {
+
+    /**
+     * Every occurrence of the weekday [dayIndex] (0=Monday..6=Sunday) at hours
+     * `[startHour, endHourExclusive)` that clears the coverage floor, as
+     * `Σ that date's net over the range ÷ Σ that date's coverage over the range`.
+     *
+     * One returned value = one real day the driver worked that range. The list's SIZE is the sample
+     * count the surface quotes ("over 6 Fridays"); its MEDIAN is the rate the plan projects with.
+     */
+    fun occurrenceRates(dayIndex: Int, startHour: Int, endHourExclusive: Int): List<Double> {
+        val hours = (endHourExclusive - startHour).coerceAtLeast(0)
+        if (hours <= 0) return emptyList()
+        val floor = MIN_COVERAGE_FRACTION * hours
+        val out = ArrayList<Double>()
+        for (day in days) {
+            if (day.dayIndex != dayIndex) continue
+            var coverage = 0.0
+            var net = 0.0
+            for (h in startHour until endHourExclusive) {
+                if (h !in 0 until EarningsHeatmap.HOURS) continue
+                coverage += day.coverageHours[h]
+                net += day.netDollars[h]
+            }
+            // Fail-closed: below the floor the ratio is noise, not a measurement — the occurrence
+            // is not a sample at all (it is not counted, and its rate is never averaged in).
+            if (coverage >= floor && coverage > 0.0) out += net / coverage
+        }
+        return out
+    }
+
+    /**
+     * The number of distinct dates of weekday [dayIndex] on which the driver was online **at all**.
+     *
+     * This is the count the thin-history copy quotes (`only 3 Sundays on record`): it answers "how
+     * many Sundays do you have?", which is a different — and, for that sentence, the right — question
+     * from "how many Sundays cleared the floor in this particular hour range".
+     */
+    fun daysOnRecord(dayIndex: Int): Int =
+        days.count { it.dayIndex == dayIndex && it.coverageHours.any { h -> h > 0.0 } }
+
+    /**
+     * Every single-hour occurrence across the whole record that cleared the floor — the population the
+     * **random-placement baseline** takes its median over (brief §8: "the random-placement baseline is
+     * `overall median rate × hours`").
+     *
+     * Read plainly: *"of all the hours you have actually worked, the middle one returned this."* That
+     * is exactly what placing hours without regard to when tends to get you, and it is measured from
+     * the driver's own record rather than assumed.
+     */
+    fun allHourRates(): List<Double> {
+        val out = ArrayList<Double>()
+        val floor = MIN_COVERAGE_FRACTION
+        for (day in days) {
+            for (h in 0 until EarningsHeatmap.HOURS) {
+                val coverage = day.coverageHours[h]
+                if (coverage >= floor && coverage > 0.0) out += day.netDollars[h] / coverage
+            }
+        }
+        return out
+    }
+
+    /** The median of [allHourRates], or null when the driver has no hour on record that cleared the floor. */
+    val overallMedianRate: Double? get() = median(allHourRates())
+
+    /** Total coverage hours recorded on [date] across `[startHour, endHourExclusive)` — the grading denominator. */
+    fun coverageOn(date: LocalDate, startHour: Int, endHourExclusive: Int): Double =
+        sumOn(date, startHour, endHourExclusive) { it.coverageHours }
+
+    /** Total net recorded on [date] across `[startHour, endHourExclusive)` — the grading numerator. */
+    fun netOn(date: LocalDate, startHour: Int, endHourExclusive: Int): Double =
+        sumOn(date, startHour, endHourExclusive) { it.netDollars }
+
+    private inline fun sumOn(
+        date: LocalDate,
+        startHour: Int,
+        endHourExclusive: Int,
+        pick: (SampledDay) -> List<Double>,
+    ): Double {
+        val day = days.firstOrNull { it.date == date } ?: return 0.0
+        val values = pick(day)
+        var sum = 0.0
+        for (h in startHour until endHourExclusive) {
+            if (h in 0 until EarningsHeatmap.HOURS) sum += values[h]
+        }
+        return sum
+    }
+
+    /** True once any hour anywhere cleared the floor — every surface states thin data instead when false. */
+    val hasData: Boolean get() = overallMedianRate != null
+
+    companion object {
+        /**
+         * An occurrence counts as a sample only once the driver was present for at least this fraction
+         * of the range asked about (half of it).
+         *
+         * At one hour this is `0.5` — deliberately byte-equal to
+         * [EarningsHeatmapCalculator.DEFAULT_MIN_COVERAGE_HOURS], so a cell the Patterns grid masks as
+         * "too little time" is the same cell this sampler refuses to sample. Scaling it by the range
+         * length keeps that meaning constant for a 2h or 4h window rather than letting a long window
+         * qualify on a single half-hour of presence.
+         */
+        const val MIN_COVERAGE_FRACTION = EarningsHeatmapCalculator.DEFAULT_MIN_COVERAGE_HOURS
+
+        /** Empty record — the pre-data state every surface must render honestly. */
+        val EMPTY = HourOfWeekSamples(emptyList())
+
+        /**
+         * The median of [values] (mean of the two middles when even), or null when empty.
+         *
+         * The ONE definition of "median" in this feature — the planner, the baseline and the evidence
+         * lines all call it, so the number on the screen and the number in a test can never come from
+         * two different formulas.
+         */
+        fun median(values: List<Double>): Double? {
+            if (values.isEmpty()) return null
+            val sorted = values.sorted()
+            val mid = sorted.size / 2
+            return if (sorted.size % 2 == 1) sorted[mid] else (sorted[mid - 1] + sorted[mid]) / 2.0
+        }
+    }
+}
+
+/**
+ * One calendar date's 24 coverage-hour and net-dollar buckets. [dayIndex] is 0=Monday..6=Sunday, the
+ * same indexing [EarningsHeatmap.cell] uses.
+ */
+data class SampledDay(
+    val date: LocalDate,
+    val dayIndex: Int,
+    /** Always 24 entries, hour 0..23: fractional hours of the driver's own recorded presence. */
+    val coverageHours: List<Double>,
+    /** Always 24 entries, hour 0..23: frozen net + cash tip of the drops completed in that hour. */
+    val netDollars: List<Double>,
+)
+
+/**
+ * Builds [HourOfWeekSamples] from the SAME two lifetime rows [EarningsHeatmapCalculator] consumes.
+ *
+ * Pure and total: spans/deliveries/zone in, buckets out. Guards are inherited from the heatmap
+ * calculator (empty or inverted spans and over-[MAX_SPAN_MILLIS] spans contribute nothing) because a
+ * corrupt row must not be able to spin this loop across half a million iterations.
+ */
+object HourOfWeekSampler {
+
+    private const val MILLIS_PER_HOUR = 3_600_000.0
+
+    /** Sanity cap on a single span (14 days) — the [EarningsHeatmapCalculator] value, same rationale. */
+    private const val MAX_SPAN_MILLIS = 14L * 24L * 3_600_000L
+
+    fun compute(
+        spans: List<SessionSpan>,
+        deliveries: List<DeliveryNet>,
+        zone: ZoneId,
+    ): HourOfWeekSamples {
+        val coverage = HashMap<LocalDate, DoubleArray>()
+        val net = HashMap<LocalDate, DoubleArray>()
+
+        for (span in unionOf(spans)) apportionSpan(span, zone, coverage)
+        for (d in deliveries) {
+            val zdt = Instant.ofEpochMilli(d.completedAtMillis).atZone(zone)
+            net.getOrPut(zdt.toLocalDate()) { DoubleArray(EarningsHeatmap.HOURS) }[zdt.hour] += d.netDollars
+        }
+
+        val dates = (coverage.keys + net.keys).sorted()
+        return HourOfWeekSamples(
+            days = dates.map { date ->
+                SampledDay(
+                    date = date,
+                    dayIndex = date.dayOfWeek.value - 1,
+                    coverageHours = (coverage[date] ?: DoubleArray(EarningsHeatmap.HOURS)).toList(),
+                    netDollars = (net[date] ?: DoubleArray(EarningsHeatmap.HOURS)).toList(),
+                )
+            },
+        )
+    }
+
+    /**
+     * Merge [spans] into a wall-clock union — the identical rule [EarningsHeatmapCalculator] applies,
+     * so two concurrent platform sessions contribute one hour of denominator, not two.
+     */
+    private fun unionOf(spans: List<SessionSpan>): List<SessionSpan> {
+        val valid = spans
+            .filter { it.endMillis > it.startMillis && it.endMillis - it.startMillis <= MAX_SPAN_MILLIS }
+            .sortedBy { it.startMillis }
+        if (valid.isEmpty()) return emptyList()
+        val merged = ArrayList<SessionSpan>(valid.size)
+        for (s in valid) {
+            val last = merged.lastOrNull()
+            if (last != null && s.startMillis <= last.endMillis) {
+                merged[merged.lastIndex] = SessionSpan(last.startMillis, maxOf(last.endMillis, s.endMillis))
+            } else {
+                merged.add(s)
+            }
+        }
+        return merged
+    }
+
+    /** Split one span's milliseconds across the (date, wall-clock hour) buckets it overlaps. */
+    private fun apportionSpan(span: SessionSpan, zone: ZoneId, coverage: HashMap<LocalDate, DoubleArray>) {
+        if (span.endMillis <= span.startMillis) return
+        var cellStart = Instant.ofEpochMilli(span.startMillis).atZone(zone).truncatedTo(ChronoUnit.HOURS)
+        while (true) {
+            val cellStartMillis = cellStart.toInstant().toEpochMilli()
+            if (cellStartMillis >= span.endMillis) break
+            val nextCell = cellStart.plusHours(1)
+            val segStart = maxOf(span.startMillis, cellStartMillis)
+            val segEnd = minOf(span.endMillis, nextCell.toInstant().toEpochMilli())
+            if (segEnd > segStart) {
+                coverage.getOrPut(cellStart.toLocalDate()) { DoubleArray(EarningsHeatmap.HOURS) }[cellStart.hour] +=
+                    (segEnd - segStart) / MILLIS_PER_HOUR
+            }
+            cellStart = nextCell
+        }
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SavedWeeklyPlan.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SavedWeeklyPlan.kt
@@ -1,0 +1,179 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.time.LocalDate
+
+/**
+ * A plan the driver pressed **Save this plan** on (#981 / brief §8 item 6) — the artifact the Home
+ * pointer row reads each morning and next Sunday's notification grades.
+ *
+ * **Frozen at save time, on purpose.** The windows carry the rate and projection the driver was
+ * actually looking at when they committed to the week. Re-deriving them later against a record that has
+ * since grown would grade them against a plan they were never shown — the same reasoning that freezes a
+ * `delivery_record`'s economics at projection time (CLAUDE.md §5). The record keeps moving; the
+ * commitment does not.
+ *
+ * **This is a user artifact, not analytics state.** It is not derivable from `app_events` and is
+ * therefore deliberately NOT stored in the read-model database, whose tables are a rebuildable
+ * projection that a `PROJECTOR_VERSION` bump wipes wholesale. It lives in its own single-concern
+ * DataStore instead (see `WeeklyPlanDataSource`), encoded by [WeeklyPlanCodec].
+ */
+data class SavedWeeklyPlan(
+    /** Monday of the week this plan is FOR — the identity a Home pointer and a grade both match on. */
+    val weekStart: LocalDate,
+    /** When the driver saved it (device clock at the save edge). */
+    val savedAtMillis: Long,
+    val target: PlanTarget,
+    val windows: List<SavedPlanWindow>,
+    /** The plan's projection, frozen: `Σ median rate × hours` as shown at save time. */
+    val projectedKept: Double,
+    /** The same hours placed at random, frozen; null when the record had no baseline to offer. */
+    val randomKept: Double?,
+) {
+    val totalHours: Int get() = windows.sumOf { it.lengthHours }
+
+    /** What the plan claimed to be worth over placing the same hours at random. Null with no baseline. */
+    val planWorth: Double? get() = randomKept?.let { projectedKept - it }
+
+    companion object {
+        /**
+         * How many saved plans are kept. Two: the week being worked and the week just graded. A plan
+         * older than that has no consumer, and unbounded growth in a preferences blob is a bug waiting
+         * to happen.
+         */
+        const val MAX_KEPT = 2
+
+        /** Freeze [plan] as the artifact for the week starting [weekStart]. */
+        fun from(plan: WeeklyPlan, weekStart: LocalDate, savedAtMillis: Long) = SavedWeeklyPlan(
+            weekStart = weekStart,
+            savedAtMillis = savedAtMillis,
+            target = plan.target,
+            windows = plan.windows.map {
+                SavedPlanWindow(
+                    dayIndex = it.dayIndex,
+                    startHour = it.startHour,
+                    endHourExclusive = it.endHourExclusive,
+                    dollarsPerHour = it.dollarsPerHour,
+                    sampleCount = it.sampleCount,
+                )
+            },
+            projectedKept = plan.projectedKept,
+            randomKept = plan.randomKept,
+        )
+    }
+}
+
+/** One frozen window of a [SavedWeeklyPlan]. [dayIndex] 0=Monday..6=Sunday. */
+data class SavedPlanWindow(
+    val dayIndex: Int,
+    val startHour: Int,
+    val endHourExclusive: Int,
+    val dollarsPerHour: Double?,
+    val sampleCount: Int,
+) {
+    val lengthHours: Int get() = endHourExclusive - startHour
+
+    /** `frozen median rate × hours` — what this window promised when it was saved. */
+    val projectedKept: Double get() = (dollarsPerHour ?: 0.0) * lengthHours
+}
+
+/**
+ * JSON codec for the saved-plan list, **fail-closed in both directions** (the `LegStateCodec` pattern,
+ * #688 phase B): a blob that does not decode is treated as *no saved plan* rather than throwing, so a
+ * corrupt or older-shaped preference can never crash the Home screen or the Sunday worker open.
+ *
+ * The wire shape is a private DTO layer, not the domain types: `LocalDate` and the [PlanTarget] sealed
+ * pair have no stable serial form of their own, and pinning the wire here means a later domain rename
+ * is not silently a data migration.
+ */
+object WeeklyPlanCodec {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    /** Hours-target discriminator on the wire. Do not rename — saved blobs carry it. */
+    private const val TARGET_HOURS = "hours"
+
+    /** Dollars-target discriminator on the wire. Do not rename — saved blobs carry it. */
+    private const val TARGET_DOLLARS = "dollars"
+
+    fun encode(plans: List<SavedWeeklyPlan>): String = json.encodeToString(
+        SavedPlansDto(plans.map { it.toDto() }),
+    )
+
+    /** Decode, or an empty list for null / blank / malformed / structurally impossible input. */
+    fun decode(raw: String?): List<SavedWeeklyPlan> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return try {
+            json.decodeFromString<SavedPlansDto>(raw).plans.mapNotNull { it.toDomain() }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    @Serializable
+    private data class SavedPlansDto(val plans: List<SavedPlanDto> = emptyList())
+
+    @Serializable
+    private data class SavedPlanDto(
+        val weekStartEpochDay: Long,
+        val savedAtMillis: Long,
+        val targetKind: String,
+        val targetValue: Double,
+        val windows: List<SavedWindowDto> = emptyList(),
+        val projectedKept: Double,
+        val randomKept: Double? = null,
+    )
+
+    @Serializable
+    private data class SavedWindowDto(
+        val dayIndex: Int,
+        val startHour: Int,
+        val endHourExclusive: Int,
+        val dollarsPerHour: Double? = null,
+        val sampleCount: Int = 0,
+    )
+
+    private fun SavedWeeklyPlan.toDto() = SavedPlanDto(
+        weekStartEpochDay = weekStart.toEpochDay(),
+        savedAtMillis = savedAtMillis,
+        targetKind = when (target) {
+            is PlanTarget.Hours -> TARGET_HOURS
+            is PlanTarget.Dollars -> TARGET_DOLLARS
+        },
+        targetValue = when (val t = target) {
+            is PlanTarget.Hours -> t.hours.toDouble()
+            is PlanTarget.Dollars -> t.amount
+        },
+        windows = windows.map {
+            SavedWindowDto(it.dayIndex, it.startHour, it.endHourExclusive, it.dollarsPerHour, it.sampleCount)
+        },
+        projectedKept = projectedKept,
+        randomKept = randomKept,
+    )
+
+    /** Null for a row whose shape is impossible — one bad entry is dropped, the rest survive. */
+    private fun SavedPlanDto.toDomain(): SavedWeeklyPlan? {
+        val target = when (targetKind) {
+            TARGET_HOURS -> PlanTarget.Hours(targetValue.toInt())
+            TARGET_DOLLARS -> PlanTarget.Dollars(targetValue)
+            else -> return null
+        }
+        val decoded = windows.mapNotNull { it.toDomain() }
+        return SavedWeeklyPlan(
+            weekStart = LocalDate.ofEpochDay(weekStartEpochDay),
+            savedAtMillis = savedAtMillis,
+            target = target,
+            windows = decoded,
+            projectedKept = projectedKept,
+            randomKept = randomKept,
+        )
+    }
+
+    private fun SavedWindowDto.toDomain(): SavedPlanWindow? {
+        if (dayIndex !in 0 until EarningsHeatmap.DAYS) return null
+        if (startHour !in 0 until EarningsHeatmap.HOURS) return null
+        if (endHourExclusive <= startHour || endHourExclusive > EarningsHeatmap.HOURS) return null
+        return SavedPlanWindow(dayIndex, startHour, endHourExclusive, dollarsPerHour, sampleCount.coerceAtLeast(0))
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlan.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlan.kt
@@ -1,0 +1,192 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * The Weekly Plan (#981 / brief §8) — a set of hour windows drawn from the driver's **own** record,
+ * with the value of following it stated next to the value of not bothering.
+ *
+ * Every number here is traceable to [HourOfWeekSamples]: a window's rate is the MEDIAN of the driver's
+ * own occurrence rates for exactly that weekday and hour range, its projection is `median × hours`,
+ * and the baseline is the median of every hour they have ever worked. Nothing is modelled, learned or
+ * assumed — which is why [WeeklyPlanner] can refuse to place a window at all and say why.
+ *
+ * **Not a promise.** The surface rendering this is required to say whose data it is and that it is a
+ * projection, on every state, including the thin ones (brief §9).
+ */
+data class WeeklyPlan(
+    val target: PlanTarget,
+    /** The picked windows, ordered by weekday then start hour (a week reads chronologically). */
+    val windows: List<PlannedWindow>,
+    /** Weekdays that hold NO picked window, each with the honest reason (brief §8's `NOT PICKED`). */
+    val notPicked: List<UnpickedDay>,
+    /**
+     * The median rate across every hour the driver has ever worked — the **random-placement baseline**.
+     * Null when nothing in the record clears the coverage floor, in which case the whole comparison is
+     * withheld rather than invented.
+     */
+    val randomPlacementRate: Double?,
+    /** The edits ([PlanEdit]) this plan was replayed with — kept so a save round-trips the driver's own arrangement. */
+    val edits: List<PlanEdit>,
+) {
+    /** Hours placed. */
+    val totalHours: Int get() = windows.sumOf { it.lengthHours }
+
+    /** Hours placed on a window the record can actually price (a moved window may have no history). */
+    val pricedHours: Int get() = windows.filter { it.dollarsPerHour != null }.sumOf { it.lengthHours }
+
+    /** True when some placed hour carries no evidence — the surface must say so instead of quietly under-projecting. */
+    val hasUnpricedHours: Boolean get() = pricedHours < totalHours
+
+    /** `Σ median rate × hours`, over the windows that have a rate. */
+    val projectedKept: Double get() = windows.sumOf { it.projectedKept }
+
+    /** The same hours placed without regard to when — `overall median × hours`. Null with no baseline. */
+    val randomKept: Double? get() = randomPlacementRate?.let { it * totalHours }
+
+    /**
+     * What the plan is worth: projected minus random. Null when there is no baseline to compare
+     * against. **Can be negative** and is shown as such — a plan that doesn't beat picking at random
+     * is information the driver is entitled to, not something to hide.
+     */
+    val planWorth: Double? get() = randomKept?.let { projectedKept - it }
+
+    /** True once the plan reaches what the driver asked for (hours placed, or dollars projected). */
+    val targetMet: Boolean
+        get() = when (target) {
+            is PlanTarget.Hours -> totalHours >= target.hours
+            is PlanTarget.Dollars -> projectedKept >= target.amount
+        }
+
+    /** Hours still unplaced against an hours target (0 for a dollars target, or when met). */
+    val shortfallHours: Int
+        get() = when (target) {
+            is PlanTarget.Hours -> (target.hours - totalHours).coerceAtLeast(0)
+            is PlanTarget.Dollars -> 0
+        }
+
+    /** True for the cell ([dayIndex] 0=Monday, [hour] 0..23) if a picked window covers it — the heatmap outline. */
+    fun covers(dayIndex: Int, hour: Int): Boolean =
+        windows.any { it.dayIndex == dayIndex && hour >= it.startHour && hour < it.endHourExclusive }
+
+    companion object {
+        /** The pre-data plan: nothing placed, nothing claimed. */
+        fun empty(target: PlanTarget) = WeeklyPlan(target, emptyList(), emptyList(), null, emptyList())
+    }
+}
+
+/**
+ * What the driver asked the planner for (brief §8 item 1: `8h · 12h · 20h · $ goal`).
+ *
+ * A sealed pair rather than a nullable-hours/nullable-dollars record (Principle 4): the two targets
+ * terminate the greedy fill on different conditions, and the type is what makes that unmissable.
+ */
+sealed interface PlanTarget {
+    data class Hours(val hours: Int) : PlanTarget
+    data class Dollars(val amount: Double) : PlanTarget
+
+    companion object {
+        /** The brief's three hour presets — the selector's options, in order. */
+        val HOUR_PRESETS = listOf(8, 12, 20)
+
+        /** The default when the screen first opens. */
+        val DEFAULT: PlanTarget = Hours(12)
+    }
+}
+
+/**
+ * One placed window: weekday, hour range, the driver's own median rate across it, and how many of
+ * their own days that median was taken over.
+ *
+ * [dollarsPerHour] and [sampleCount] are the **evidence line** (`your Fridays: $26.40/hr over 6
+ * Fridays`). A null rate means the driver moved this window somewhere they have no qualifying record —
+ * legal, but then the row says so and the window contributes nothing to the projection.
+ */
+data class PlannedWindow(
+    /** 0=Monday..6=Sunday. */
+    val dayIndex: Int,
+    val startHour: Int,
+    val endHourExclusive: Int,
+    /** MEDIAN of the driver's own occurrence rates for exactly this weekday+range; null ⇒ no qualifying history. */
+    val dollarsPerHour: Double?,
+    /** How many of the driver's own days that median was computed over — quoted verbatim in the evidence line. */
+    val sampleCount: Int,
+    /** True for the single highest-rate placed window — brief §8's `BEST` pill. */
+    val isBest: Boolean = false,
+    /** True once the driver has moved this window off where the planner put it. */
+    val moved: Boolean = false,
+) {
+    val lengthHours: Int get() = endHourExclusive - startHour
+
+    /** `median rate × hours`, or 0 when the range carries no qualifying history (never a guessed rate). */
+    val projectedKept: Double get() = (dollarsPerHour ?: 0.0) * lengthHours
+
+    /**
+     * True when this window's median rests on fewer days than [WeeklyPlanner.MIN_SAMPLE_DAYS].
+     *
+     * The planner never *places* such a window itself — but the driver can move one onto thinly-recorded
+     * hours, and when they do the row keeps its (weak) number and says how weak it is, rather than
+     * hiding either half.
+     */
+    val hasThinEvidence: Boolean get() = sampleCount < WeeklyPlanner.MIN_SAMPLE_DAYS
+
+    /** Overlap test in weekday+hour space — the greedy fill's non-collision rule. */
+    fun overlaps(other: PlannedWindow): Boolean =
+        dayIndex == other.dayIndex && startHour < other.endHourExclusive && other.startHour < endHourExclusive
+}
+
+/** A weekday with no placed window, and the reason — never a silent omission (brief §8, §9). */
+data class UnpickedDay(
+    val dayIndex: Int,
+    val reason: UnpickedReason,
+    /** Distinct dates of this weekday the driver was online at all — the `only 3 Sundays on record` figure. */
+    val daysOnRecord: Int,
+)
+
+/**
+ * Why a weekday holds no window. Every arm is a *measured* fact about the driver's record or about the
+ * target, never a judgement — the UI renders each as its own sentence.
+ */
+enum class UnpickedReason {
+    /** Nothing at all recorded on this weekday. */
+    NO_HISTORY,
+
+    /** Some record, but no hour has enough separate days behind it to trust a median. */
+    THIN_HISTORY,
+
+    /** Enough days, but the hours that qualify never line up into a run of [WeeklyPlanner.MIN_WINDOW_HOURS]. */
+    NO_CONTIGUOUS_RUN,
+
+    /** Measured, and the money isn't there — this weekday's qualifying hours don't clear $0 net. */
+    NO_POSITIVE_RATE,
+
+    /** A real candidate that simply lost: the target filled up with better-paying windows first. */
+    TARGET_ALREADY_MET,
+
+    /** The driver dropped this weekday's window themselves — their edit, stated as their edit. */
+    REMOVED_BY_YOU,
+}
+
+/**
+ * A driver edit replayed on top of the algorithm's own output.
+ *
+ * The plan is never mutated in place — the ViewModel holds an ordered list of these and the planner
+ * **replays** them over a freshly computed base (Principle 1: the derivation stays pure and the edits
+ * are the input). That is what lets a moved window re-derive its rate from the record at its NEW hours
+ * instead of carrying the old number somewhere it was never measured.
+ *
+ * Both arms address a window by the position it occupies *at the time the edit is replayed*, so the
+ * list is order-sensitive by construction and a replay is deterministic.
+ */
+sealed interface PlanEdit {
+    val dayIndex: Int
+    val startHour: Int
+
+    /** Drop the window at ([dayIndex], [startHour]); the greedy fill then re-fills from the next best. */
+    data class Drop(override val dayIndex: Int, override val startHour: Int) : PlanEdit
+
+    /** Shift the window at ([dayIndex], [startHour]) by [deltaHours] (negative = earlier). */
+    data class Shift(
+        override val dayIndex: Int,
+        override val startHour: Int,
+        val deltaHours: Int,
+    ) : PlanEdit
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanGrade.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanGrade.kt
@@ -1,0 +1,107 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import java.time.LocalDate
+
+/**
+ * How last week's plan actually went (#981 / brief §8 item 6) — "next Sunday's notification grades the
+ * previous plan (planned vs actual hours and dollars). That loop is what makes the notification worth
+ * keeping enabled."
+ *
+ * The grade is a **measurement, not a score**: no letter, no percentage-shaming, no "you failed". It
+ * states four numbers — hours planned vs hours actually worked in those windows, dollars projected vs
+ * dollars actually kept in those windows — and lets the driver draw their own conclusion. Both actual
+ * figures come from the driver's own record ([HourOfWeekSamples], i.e. the same session spans and
+ * frozen `delivery_records` net every other surface reads), restricted to the plan week's real dates.
+ *
+ * **Windows only.** [actualHours]/[actualKept] deliberately count only what happened *inside the
+ * planned windows*: the plan made a claim about those hours, so those hours are what it can be graded
+ * on. Work done outside them is real money and is reported separately as [keptOutsideWindows] rather
+ * than being folded in to flatter the plan.
+ */
+data class WeeklyPlanGrade(
+    val weekStart: LocalDate,
+    /** Hours the plan placed. */
+    val plannedHours: Int,
+    /** Hours the driver was actually online inside those windows. */
+    val actualHours: Double,
+    /** What the plan projected for those windows, frozen at save time. */
+    val projectedKept: Double,
+    /** What the driver actually kept (frozen net + cash) inside those windows. */
+    val actualKept: Double,
+    /** What they kept in the same week *outside* the planned windows — reported, never folded in. */
+    val keptOutsideWindows: Double,
+    /** Per-window detail, in the saved plan's own order. */
+    val windows: List<GradedWindow>,
+) {
+    /** True once the driver worked at least the hours they planned (inside the windows). */
+    val hoursMet: Boolean get() = actualHours + HOURS_EPSILON >= plannedHours
+
+    /** True once the windows returned at least what they were projected to. */
+    val moneyMet: Boolean get() = actualKept >= projectedKept
+
+    /** Everything kept that week, inside and outside the plan. */
+    val totalKept: Double get() = actualKept + keptOutsideWindows
+
+    /** True when the driver did not work any of their planned windows — the grade says so plainly. */
+    val unworked: Boolean get() = actualHours <= 0.0
+
+    companion object {
+        /** A few seconds of rounding slack, so 11.9998 planned-and-worked hours isn't reported as a miss. */
+        const val HOURS_EPSILON = 0.01
+    }
+}
+
+/** One planned window's outcome. */
+data class GradedWindow(
+    val window: SavedPlanWindow,
+    val actualHours: Double,
+    val actualKept: Double,
+) {
+    /** True when the driver was online for none of it. */
+    val skipped: Boolean get() = actualHours <= 0.0
+}
+
+/**
+ * Grades a [SavedWeeklyPlan] against the driver's own record. Pure and total (Principle 1): the record
+ * and the plan go in, the four numbers come out — no clock, no zone, no Android, so every arm (worked
+ * it exactly / skipped it / worked more / earned nothing) is a plain unit test.
+ */
+object WeeklyPlanGrader {
+
+    /**
+     * [samples] is the driver's whole record; only the plan week's own dates are read out of it, so the
+     * caller passes the same lifetime samples every other Weekly Plan surface uses — no second query and
+     * no week-scoped read to keep in sync with it.
+     */
+    fun grade(plan: SavedWeeklyPlan, samples: HourOfWeekSamples): WeeklyPlanGrade {
+        val graded = plan.windows.map { w ->
+            val date = plan.weekStart.plusDays(w.dayIndex.toLong())
+            GradedWindow(
+                window = w,
+                actualHours = samples.coverageOn(date, w.startHour, w.endHourExclusive),
+                actualKept = samples.netOn(date, w.startHour, w.endHourExclusive),
+            )
+        }
+        val insideKept = graded.sumOf { it.actualKept }
+
+        // The whole week's net, so what happened OUTSIDE the plan can be stated instead of vanishing.
+        var weekKept = 0.0
+        for (offset in 0L until DAYS_IN_WEEK) {
+            weekKept += samples.netOn(plan.weekStart.plusDays(offset), 0, EarningsHeatmap.HOURS)
+        }
+
+        return WeeklyPlanGrade(
+            weekStart = plan.weekStart,
+            plannedHours = plan.totalHours,
+            actualHours = graded.sumOf { it.actualHours },
+            projectedKept = plan.projectedKept,
+            actualKept = insideKept,
+            // Floored: overlapping windows can't exist in a plan (the fill forbids it), but a floor
+            // keeps a rounding artifact from ever rendering as negative money.
+            keptOutsideWindows = (weekKept - insideKept).coerceAtLeast(0.0),
+            windows = graded,
+        )
+    }
+
+    private const val DAYS_IN_WEEK = 7L
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanSchedule.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanSchedule.kt
@@ -1,0 +1,60 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * The Weekly Plan's calendar rules (#981 / brief §8's trigger): when the Sunday-evening nudge fires,
+ * which week a plan saved *now* is for, and which week next Sunday's notification grades.
+ *
+ * Pure time math with the clock passed in, so the Android-side worker holds none of it and every rule
+ * here is a plain unit test (DST weekends included — the trigger is computed as a *wall-clock* local
+ * time, not as "now + 7 × 24 h", so it lands at 6 pm local on both a 23-hour and a 25-hour Sunday).
+ *
+ * Monday-anchoring is not re-derived here: [AnalyticsWindows.current] owns where a week starts for the
+ * whole app (#970 / `PeriodBounds`), and this object delegates to it — a second definition of "Monday"
+ * is exactly the divergence Principle 5 exists to prevent.
+ */
+object WeeklyPlanSchedule {
+
+    /** Brief §8: "local notification, Sunday ~6 PM". */
+    const val TRIGGER_HOUR = 18
+
+    /** The next Sunday [TRIGGER_HOUR]:00 **strictly after** [nowMillis], as epoch millis in [zone]. */
+    fun nextTriggerMillis(nowMillis: Long, zone: ZoneId): Long {
+        val now = Instant.ofEpochMilli(nowMillis).atZone(zone)
+        var candidate = now.toLocalDate().atTime(LocalTime.of(TRIGGER_HOUR, 0)).atZone(zone)
+        // Walk forward a day at a time (never `plusWeeks` off a computed date): at most 7 steps, and it
+        // stays correct on the Sunday when 6 pm has already passed.
+        while (candidate.dayOfWeek != java.time.DayOfWeek.SUNDAY || !candidate.toInstant().isAfter(now.toInstant())) {
+            candidate = candidate.plusDays(1)
+        }
+        return candidate.toInstant().toEpochMilli()
+    }
+
+    /**
+     * Monday of the week a plan saved on [today] is FOR.
+     *
+     * Sunday is the planning day (that is when the notification arrives), so a plan saved on a Sunday
+     * targets the week that starts **tomorrow**. On any other day the driver is planning the week they
+     * are already in, so it targets the current Monday-anchored week.
+     */
+    fun planWeekStart(today: LocalDate): LocalDate =
+        if (today.dayOfWeek == java.time.DayOfWeek.SUNDAY) today.plusDays(1) else weekStartOf(today)
+
+    /**
+     * Monday of the week that is **ending** on [today] — the week next Sunday's notification grades.
+     *
+     * On the Sunday the worker fires, that is the current Monday-anchored week (Monday..this Sunday).
+     */
+    fun gradedWeekStart(today: LocalDate): LocalDate = weekStartOf(today)
+
+    /**
+     * Monday of [date]'s week, delegated to the app's one week-boundary owner. A WEEK window is
+     * bounded by construction, so the `startDate` is never null on this path.
+     */
+    fun weekStartOf(date: LocalDate): LocalDate =
+        AnalyticsWindows.current(WindowGranularity.WEEK, date).startDate ?: date
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanner.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanner.kt
@@ -1,0 +1,301 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * Builds a [WeeklyPlan] from the driver's own record (#981 / brief §8's algorithm, verbatim):
+ *
+ *  1. rank weekday×hour cells by the **median** realized net $/hr of the driver's own history;
+ *  2. require a minimum sample count per cell ([MIN_SAMPLE_DAYS] separate days);
+ *  3. merge adjacent qualifying cells into contiguous windows of at least [MIN_WINDOW_HOURS];
+ *  4. greedily take windows until the target is met;
+ *  5. project each window as `median rate × hours`;
+ *  6. the random-placement baseline is `overall median rate × hours`.
+ *
+ * "Every number on the screen must be traceable to that" is the governing constraint, so this object
+ * computes NOTHING it cannot point at: no smoothing, no extrapolation, no default rate for an hour with
+ * no record. Cells below the sample threshold are never picked, and the weekday they sit on is returned
+ * in [WeeklyPlan.notPicked] with the reason ([UnpickedReason]) rather than silently vanishing.
+ *
+ * Pure and deterministic (Principle 1). No clock, no zone, no Android: the caller passes
+ * [HourOfWeekSamples], which already carries the driver's record bucketed by weekday and hour. Every
+ * ordering is total — rate descending, then earliest weekday, earliest start, shortest window — so the
+ * same record and target always produce the same plan, byte for byte. A planner that reshuffled its own
+ * recommendation between two recompositions of identical data would be worse than no planner.
+ */
+object WeeklyPlanner {
+
+    /** A window shorter than this is an anecdote, not a plan — the same floor [DayPlanner] uses. */
+    const val MIN_WINDOW_HOURS = DayPlanner.MIN_WINDOW_HOURS
+
+    /**
+     * …and one longer than this stops being a *window* and becomes "work all day". Capping it also lets
+     * a 12h target spread across several weekdays instead of collapsing onto the one best run.
+     */
+    const val MAX_WINDOW_HOURS = DayPlanner.MAX_WINDOW_HOURS
+
+    /**
+     * The minimum number of **separate days** behind a median before the planner will place a window on
+     * it (brief §8's "minimum sample count per cell").
+     *
+     * Three, deliberately: a median over two points is the mean of two points and carries none of the
+     * robustness the brief asks a median for, while demanding five would refuse to plan anything for a
+     * driver with two months of history — the exact person this screen is for. The count is quoted to
+     * the driver on every row (`over N Fridays`), so the threshold is a floor on what gets *placed*,
+     * never a substitute for telling them how thin the evidence is.
+     */
+    const val MIN_SAMPLE_DAYS = 3
+
+    /**
+     * Hard cap on a plan's placed hours. Bounds the greedy loop for a `$` target (which otherwise
+     * terminates only on running out of candidates) and refuses to write a plan no human can work.
+     */
+    const val MAX_PLAN_HOURS = 40
+
+    /**
+     * Plan [target] against [samples], replaying the driver's [edits] on top.
+     *
+     * Edits are **replayed**, never applied to a stored plan: the base plan is recomputed from the
+     * record every time and each edit is re-applied in order, so a moved window re-derives its rate at
+     * its new hours from the record (never carrying a number measured somewhere else), and a dropped
+     * window's hours are re-filled from the next-best candidate that isn't in banned territory.
+     */
+    fun plan(
+        samples: HourOfWeekSamples,
+        target: PlanTarget,
+        edits: List<PlanEdit> = emptyList(),
+    ): WeeklyPlan {
+        val candidates = candidates(samples)
+        val banned = ArrayList<BannedRange>()
+        var selected = fill(emptyList(), candidates, target, banned)
+
+        for (edit in edits) {
+            selected = when (edit) {
+                is PlanEdit.Drop -> {
+                    val victim = selected.firstOrNull { it.dayIndex == edit.dayIndex && it.startHour == edit.startHour }
+                    if (victim == null) {
+                        selected
+                    } else {
+                        banned += BannedRange(victim.dayIndex, victim.startHour, victim.endHourExclusive)
+                        selected - victim
+                    }
+                }
+
+                is PlanEdit.Shift -> {
+                    val victim = selected.firstOrNull { it.dayIndex == edit.dayIndex && it.startHour == edit.startHour }
+                    if (victim == null) {
+                        selected
+                    } else {
+                        val moved = shifted(victim, edit.deltaHours, samples)
+                        // The vacated hours are banned too: re-filling the very slot the driver just
+                        // moved a window OUT of would read as the app arguing with them.
+                        banned += BannedRange(victim.dayIndex, victim.startHour, victim.endHourExclusive)
+                        selected - victim + moved
+                    }
+                }
+            }
+            selected = fill(selected, candidates, target, banned)
+        }
+
+        val ordered = selected.sortedWith(compareBy({ it.dayIndex }, { it.startHour }))
+        return WeeklyPlan(
+            target = target,
+            windows = markBest(ordered),
+            notPicked = unpicked(samples, candidates, ordered, banned),
+            randomPlacementRate = samples.overallMedianRate,
+            edits = edits,
+        )
+    }
+
+    // ── Candidate generation ────────────────────────────────────────────────
+
+    /** A weekday+hour range the record can stand behind, with the median it stands behind it with. */
+    private data class BannedRange(val dayIndex: Int, val startHour: Int, val endHourExclusive: Int)
+
+    /**
+     * Every window the record supports: for each weekday, the hours whose own median clears
+     * [MIN_SAMPLE_DAYS] samples and `> $0`, merged into contiguous runs, then every sub-range of a run
+     * with length [MIN_WINDOW_HOURS]..[MAX_WINDOW_HOURS] whose *own* occurrences also clear the sample
+     * floor.
+     *
+     * The window-level check is not redundant with the per-cell one: 5–9 pm can hold four well-sampled
+     * cells while no single day ever covered half of the block (an hour here, an hour there, on
+     * different weeks), and it is the whole block the plan is about to recommend. The coverage floor
+     * scales with the range asked about, so the longer the window, the more of it the driver must
+     * actually have worked before it can be placed.
+     */
+    private fun candidates(samples: HourOfWeekSamples): List<PlannedWindow> {
+        val out = ArrayList<PlannedWindow>()
+        for (day in 0 until EarningsHeatmap.DAYS) {
+            val qualifies = BooleanArray(EarningsHeatmap.HOURS) { hour ->
+                val rates = samples.occurrenceRates(day, hour, hour + 1)
+                val median = HourOfWeekSamples.median(rates)
+                rates.size >= MIN_SAMPLE_DAYS && median != null && median > 0.0
+            }
+            for (run in runsOf(qualifies)) {
+                for (start in run.first..run.last) {
+                    for (length in MIN_WINDOW_HOURS..MAX_WINDOW_HOURS) {
+                        val end = start + length
+                        if (end - 1 > run.last) break
+                        val rates = samples.occurrenceRates(day, start, end)
+                        val median = HourOfWeekSamples.median(rates)
+                        if (rates.size >= MIN_SAMPLE_DAYS && median != null && median > 0.0) {
+                            out += PlannedWindow(day, start, end, median, rates.size)
+                        }
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    /** Index ranges of consecutive `true` entries. */
+    private fun runsOf(flags: BooleanArray): List<IntRange> {
+        val runs = ArrayList<IntRange>()
+        var start = -1
+        for (i in flags.indices) {
+            if (flags[i]) {
+                if (start < 0) start = i
+            } else if (start >= 0) {
+                runs += start..(i - 1)
+                start = -1
+            }
+        }
+        if (start >= 0) runs += start..(flags.lastIndex)
+        return runs
+    }
+
+    // ── Greedy fill ─────────────────────────────────────────────────────────
+
+    /**
+     * Take candidates in rate order until the target is met, never overlapping an already-placed or
+     * banned range, never exceeding the remaining hour budget.
+     *
+     * Ties break to the **longest** window first, then the earliest weekday, then the earliest start —
+     * a total order, which is what makes the output deterministic.
+     *
+     * Longest-first is load-bearing, not cosmetic: a run of four equally-good hours yields sub-ranges
+     * that all share one median, and shortest-first would take 5–7 pm and then 7–9 pm and render brief
+     * §8's *merged contiguous window* as two rows the driver has to mentally staple back together.
+     * Preferring the longest is what actually performs the "merge adjacent qualifying cells" step.
+     */
+    private fun fill(
+        selected: List<PlannedWindow>,
+        candidates: List<PlannedWindow>,
+        target: PlanTarget,
+        banned: List<BannedRange>,
+    ): List<PlannedWindow> {
+        var current = selected
+        while (true) {
+            val placedHours = current.sumOf { it.lengthHours }
+            val projected = current.sumOf { it.projectedKept }
+            val remaining = when (target) {
+                is PlanTarget.Hours -> target.hours - placedHours
+                // A dollars target has no hour figure of its own, so the plan cap is its only budget.
+                is PlanTarget.Dollars -> if (projected >= target.amount) 0 else MAX_PLAN_HOURS - placedHours
+            }
+            if (remaining < MIN_WINDOW_HOURS) return current
+
+            val next = candidates
+                .filter { c ->
+                    c.lengthHours <= remaining &&
+                        current.none { it.overlaps(c) } &&
+                        banned.none { b -> b.dayIndex == c.dayIndex && b.startHour < c.endHourExclusive && c.startHour < b.endHourExclusive }
+                }
+                .sortedWith(
+                    compareByDescending<PlannedWindow> { it.dollarsPerHour ?: 0.0 }
+                        .thenByDescending { it.lengthHours }
+                        .thenBy { it.dayIndex }
+                        .thenBy { it.startHour },
+                )
+                .firstOrNull() ?: return current
+
+            current = current + next
+        }
+    }
+
+    // ── Edits ───────────────────────────────────────────────────────────────
+
+    /**
+     * Move [window] by [deltaHours], clamped inside the day, and **re-derive** its rate and sample count
+     * from the record at the new hours.
+     *
+     * A window moved somewhere the driver has never worked keeps its place in the plan (it is their
+     * plan) but gets a null rate: the row says there is no history for those hours and the projection
+     * counts nothing for it, rather than carrying over a number measured three hours earlier.
+     */
+    private fun shifted(window: PlannedWindow, deltaHours: Int, samples: HourOfWeekSamples): PlannedWindow {
+        val maxStart = EarningsHeatmap.HOURS - window.lengthHours
+        val start = (window.startHour + deltaHours).coerceIn(0, maxStart)
+        val end = start + window.lengthHours
+        val rates = samples.occurrenceRates(window.dayIndex, start, end)
+        return window.copy(
+            startHour = start,
+            endHourExclusive = end,
+            dollarsPerHour = HourOfWeekSamples.median(rates),
+            sampleCount = rates.size,
+            moved = true,
+        )
+    }
+
+    /** Flag the single highest-rate placed window (ties → earliest, the list is already ordered). */
+    private fun markBest(windows: List<PlannedWindow>): List<PlannedWindow> {
+        val best = windows.filter { it.dollarsPerHour != null }.maxByOrNull { it.dollarsPerHour!! } ?: return windows
+        var flagged = false
+        return windows.map {
+            if (!flagged && it === best) {
+                flagged = true
+                it.copy(isBest = true)
+            } else {
+                it
+            }
+        }
+    }
+
+    // ── "NOT PICKED", with the reason ───────────────────────────────────────
+
+    /**
+     * One row per weekday holding no placed window, each carrying the measured reason. This is brief
+     * §8's dimmed `NOT PICKED` list and §9's thin-data rule in the same object: a weekday that didn't
+     * make the plan is stated, with what the record actually says about it.
+     */
+    private fun unpicked(
+        samples: HourOfWeekSamples,
+        candidates: List<PlannedWindow>,
+        selected: List<PlannedWindow>,
+        banned: List<BannedRange>,
+    ): List<UnpickedDay> = (0 until EarningsHeatmap.DAYS)
+        .filter { day -> selected.none { it.dayIndex == day } }
+        .map { day ->
+            val onRecord = samples.daysOnRecord(day)
+            val dayCandidates = candidates.filter { it.dayIndex == day }
+            val available = dayCandidates.filter { c ->
+                banned.none { b -> b.dayIndex == day && b.startHour < c.endHourExclusive && c.startHour < b.endHourExclusive }
+            }
+            val reason = when {
+                // The driver's own removal comes first: attributing their edit to thin data would be a lie.
+                dayCandidates.isNotEmpty() && available.isEmpty() -> UnpickedReason.REMOVED_BY_YOU
+                available.isNotEmpty() -> UnpickedReason.TARGET_ALREADY_MET
+                onRecord == 0 -> UnpickedReason.NO_HISTORY
+                else -> structuralReason(samples, day)
+            }
+            UnpickedDay(dayIndex = day, reason = reason, daysOnRecord = onRecord)
+        }
+
+    /** Why a weekday with *some* record produced no candidate at all. */
+    private fun structuralReason(samples: HourOfWeekSamples, day: Int): UnpickedReason {
+        var sampledHours = 0
+        var positiveHours = 0
+        for (hour in 0 until EarningsHeatmap.HOURS) {
+            val rates = samples.occurrenceRates(day, hour, hour + 1)
+            if (rates.size < MIN_SAMPLE_DAYS) continue
+            sampledHours++
+            val median = HourOfWeekSamples.median(rates)
+            if (median != null && median > 0.0) positiveHours++
+        }
+        return when {
+            sampledHours == 0 -> UnpickedReason.THIN_HISTORY
+            positiveHours == 0 -> UnpickedReason.NO_POSITIVE_RATE
+            // Qualifying hours exist but never line up into a run the whole-window sample check accepts.
+            else -> UnpickedReason.NO_CONTIGUOUS_RUN
+        }
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanner.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanner.kt
@@ -81,14 +81,19 @@ object WeeklyPlanner {
 
                 is PlanEdit.Shift -> {
                     val victim = selected.firstOrNull { it.dayIndex == edit.dayIndex && it.startHour == edit.startHour }
-                    if (victim == null) {
-                        selected
-                    } else {
-                        val moved = shifted(victim, edit.deltaHours, samples)
-                        // The vacated hours are banned too: re-filling the very slot the driver just
-                        // moved a window OUT of would read as the app arguing with them.
-                        banned += BannedRange(victim.dayIndex, victim.startHour, victim.endHourExclusive)
-                        selected - victim + moved
+                    val moved = victim?.let { shifted(it, edit.deltaHours, samples) }
+                    when {
+                        victim == null || moved == null -> selected
+                        // A nudge onto a sibling window is refused, not merged: overlapping windows
+                        // would double-count their shared hours into `totalHours` and into the
+                        // projection, and a fabricated total is worse than a nudge that doesn't move.
+                        (selected - victim).any { it.overlaps(moved) } -> selected
+                        else -> {
+                            // The vacated hours are banned too: re-filling the very slot the driver
+                            // just moved a window OUT of would read as the app arguing with them.
+                            banned += BannedRange(victim.dayIndex, victim.startHour, victim.endHourExclusive)
+                            selected - victim + moved
+                        }
                     }
                 }
             }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/HourOfWeekSamplerTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/HourOfWeekSamplerTest.kt
@@ -1,0 +1,212 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/**
+ * #981 — the per-occurrence decomposition the Weekly Plan's medians are taken over (brief §7.7).
+ *
+ * The properties that matter: it inherits [EarningsHeatmapCalculator]'s apportionment and union rules
+ * exactly (so the plan and the Patterns grid can never disagree), it refuses to sample below the
+ * coverage floor, and its sample COUNT is the number of separate days — the figure the evidence line
+ * quotes.
+ */
+class HourOfWeekSamplerTest {
+
+    private val zone: ZoneId = ZoneId.of("America/Chicago")
+
+    private fun millis(date: String, hour: Int, minute: Int = 0): Long =
+        LocalDateTime.of(LocalDate.parse(date), java.time.LocalTime.of(hour, minute))
+            .atZone(zone).toInstant().toEpochMilli()
+
+    /** 2026-07-03 is a Friday, 07-10 / 07-17 / 07-24 the Fridays after it. */
+    private val fridays = listOf("2026-07-03", "2026-07-10", "2026-07-17", "2026-07-24")
+
+    private fun fullHourSpans(dates: List<String>, startHour: Int, endHour: Int) =
+        dates.map { SessionSpan(millis(it, startHour), millis(it, endHour)) }
+
+    @Test
+    fun `one occurrence per date, rate is that date's net over its coverage`() {
+        val samples = HourOfWeekSampler.compute(
+            spans = fullHourSpans(fridays.take(3), 17, 19),
+            deliveries = listOf(
+                DeliveryNet(millis("2026-07-03", 17, 30), 20.0),
+                DeliveryNet(millis("2026-07-10", 17, 30), 30.0),
+                DeliveryNet(millis("2026-07-17", 17, 30), 40.0),
+            ),
+            zone = zone,
+        )
+
+        // Friday = dayIndex 4. Each date: 1h of coverage in the 5pm bucket, one drop landing in it.
+        val rates = samples.occurrenceRates(dayIndex = 4, startHour = 17, endHourExclusive = 18)
+        assertEquals(listOf(20.0, 30.0, 40.0), rates)
+        assertEquals(30.0, HourOfWeekSamples.median(rates)!!, 1e-9)
+    }
+
+    @Test
+    fun `median is robust to an outlier the mean would follow`() {
+        val samples = HourOfWeekSampler.compute(
+            spans = fullHourSpans(fridays, 17, 18),
+            deliveries = listOf(
+                DeliveryNet(millis("2026-07-03", 17, 10), 20.0),
+                DeliveryNet(millis("2026-07-10", 17, 10), 22.0),
+                DeliveryNet(millis("2026-07-17", 17, 10), 24.0),
+                DeliveryNet(millis("2026-07-24", 17, 10), 200.0),
+            ),
+            zone = zone,
+        )
+        val rates = samples.occurrenceRates(4, 17, 18)
+        // Mean would be $66.50/hr — one freak night. The median stays with the typical Friday.
+        assertEquals(23.0, HourOfWeekSamples.median(rates)!!, 1e-9)
+    }
+
+    @Test
+    fun `an occurrence below the coverage floor is not a sample at all`() {
+        val samples = HourOfWeekSampler.compute(
+            // 12 minutes of presence, one $10 drop → a 50-an-hour artifact if it were sampled.
+            spans = listOf(SessionSpan(millis("2026-07-03", 17), millis("2026-07-03", 17, 12))),
+            deliveries = listOf(DeliveryNet(millis("2026-07-03", 17, 5), 10.0)),
+            zone = zone,
+        )
+        assertTrue(samples.occurrenceRates(4, 17, 18).isEmpty())
+        assertNull(samples.overallMedianRate)
+    }
+
+    @Test
+    fun `the floor scales with the window length`() {
+        // 5-9pm asked about; the driver was present 5-6:30pm only (1.5h of a 4h window = under half).
+        val samples = HourOfWeekSampler.compute(
+            spans = listOf(SessionSpan(millis("2026-07-03", 17), millis("2026-07-03", 18, 30))),
+            deliveries = listOf(DeliveryNet(millis("2026-07-03", 17, 30), 30.0)),
+            zone = zone,
+        )
+        assertTrue(samples.occurrenceRates(4, 17, 21).isEmpty())
+        // The 1-hour question it CAN answer is still answered.
+        assertEquals(1, samples.occurrenceRates(4, 17, 18).size)
+    }
+
+    @Test
+    fun `concurrent overlapping spans are unioned, never double-counted`() {
+        val samples = HourOfWeekSampler.compute(
+            spans = listOf(
+                SessionSpan(millis("2026-07-03", 17), millis("2026-07-03", 19)),
+                SessionSpan(millis("2026-07-03", 18), millis("2026-07-03", 20)),
+            ),
+            deliveries = emptyList(),
+            zone = zone,
+        )
+        val day = samples.days.single()
+        // Three wall-clock hours of presence, not four.
+        assertEquals(3.0, day.coverageHours.sum(), 1e-9)
+    }
+
+    @Test
+    fun `an inverted or absurd span contributes nothing`() {
+        val samples = HourOfWeekSampler.compute(
+            spans = listOf(
+                SessionSpan(millis("2026-07-03", 19), millis("2026-07-03", 17)),
+                SessionSpan(0L, millis("2026-07-03", 19)),
+            ),
+            deliveries = emptyList(),
+            zone = zone,
+        )
+        assertTrue(samples.days.all { it.coverageHours.sum() == 0.0 })
+    }
+
+    @Test
+    fun `daysOnRecord counts distinct dates the driver was online at all`() {
+        val samples = HourOfWeekSampler.compute(
+            spans = fullHourSpans(fridays.take(3), 11, 12) + fullHourSpans(listOf("2026-07-04"), 11, 12),
+            deliveries = emptyList(),
+            zone = zone,
+        )
+        assertEquals(3, samples.daysOnRecord(4)) // Fridays
+        assertEquals(1, samples.daysOnRecord(5)) // one Saturday
+        assertEquals(0, samples.daysOnRecord(0)) // no Mondays
+    }
+
+    @Test
+    fun `coverageOn and netOn read one real date, for grading`() {
+        val samples = HourOfWeekSampler.compute(
+            spans = listOf(SessionSpan(millis("2026-07-03", 17), millis("2026-07-03", 20))),
+            deliveries = listOf(
+                DeliveryNet(millis("2026-07-03", 17, 30), 25.0),
+                DeliveryNet(millis("2026-07-03", 21, 30), 99.0), // outside the graded window
+            ),
+            zone = zone,
+        )
+        val date = LocalDate.parse("2026-07-03")
+        assertEquals(2.0, samples.coverageOn(date, 17, 19), 1e-9)
+        assertEquals(25.0, samples.netOn(date, 17, 19), 1e-9)
+        assertEquals(0.0, samples.netOn(date.plusDays(1), 17, 19), 1e-9)
+    }
+
+    @Test
+    fun `net lands in the hour of completion, matching the heatmap's own rule`() {
+        val samples = HourOfWeekSampler.compute(
+            spans = listOf(SessionSpan(millis("2026-07-03", 17), millis("2026-07-03", 19))),
+            deliveries = listOf(DeliveryNet(millis("2026-07-03", 18, 5), 12.0)),
+            zone = zone,
+        )
+        val day = samples.days.single()
+        assertEquals(0.0, day.netDollars[17], 1e-9)
+        assertEquals(12.0, day.netDollars[18], 1e-9)
+    }
+
+    @Test
+    fun `the sampler and the heatmap agree on total coverage and total net`() {
+        val spans = fullHourSpans(fridays, 16, 21) + fullHourSpans(listOf("2026-07-04", "2026-07-11"), 10, 14)
+        val deliveries = listOf(
+            DeliveryNet(millis("2026-07-03", 17, 10), 18.0),
+            DeliveryNet(millis("2026-07-10", 18, 10), 22.0),
+            DeliveryNet(millis("2026-07-04", 11, 10), 9.0),
+        )
+        val samples = HourOfWeekSampler.compute(spans, deliveries, zone)
+        val heatmap = EarningsHeatmapCalculator.compute(spans, deliveries, zone)
+
+        assertEquals(
+            heatmap.cells.sumOf { it.coverageHours },
+            samples.days.sumOf { it.coverageHours.sum() },
+            1e-9,
+        )
+        assertEquals(
+            heatmap.cells.sumOf { it.netDollars },
+            samples.days.sumOf { it.netDollars.sum() },
+            1e-9,
+        )
+    }
+
+    @Test
+    fun `allHourRates spans every worked hour, and the overall median is their middle`() {
+        val samples = HourOfWeekSampler.compute(
+            spans = listOf(SessionSpan(millis("2026-07-03", 17), millis("2026-07-03", 20))),
+            deliveries = listOf(
+                DeliveryNet(millis("2026-07-03", 17, 10), 10.0),
+                DeliveryNet(millis("2026-07-03", 18, 10), 20.0),
+                DeliveryNet(millis("2026-07-03", 19, 10), 30.0),
+            ),
+            zone = zone,
+        )
+        assertEquals(listOf(10.0, 20.0, 30.0), samples.allHourRates())
+        assertEquals(20.0, samples.overallMedianRate!!, 1e-9)
+    }
+
+    @Test
+    fun `median of an even sample is the mean of the two middles, and empty is null`() {
+        assertEquals(15.0, HourOfWeekSamples.median(listOf(10.0, 20.0))!!, 1e-9)
+        assertNull(HourOfWeekSamples.median(emptyList()))
+    }
+
+    @Test
+    fun `empty record yields no days and no baseline`() {
+        val samples = HourOfWeekSampler.compute(emptyList(), emptyList(), zone)
+        assertTrue(samples.days.isEmpty())
+        assertNull(samples.overallMedianRate)
+        assertTrue(!samples.hasData)
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanGraderTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanGraderTest.kt
@@ -1,0 +1,134 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * #981 — grading last week's plan (brief §8 item 6): planned vs actual hours and dollars, measured
+ * against the driver's own record for the plan week's real dates.
+ *
+ * The grade must be a measurement, so the tests pin the arithmetic in both directions (worked it,
+ * skipped it, beat it) and pin the boundary rule: only what happened *inside* the planned windows can
+ * grade the plan, and everything else in the week is reported separately rather than folded in.
+ */
+class WeeklyPlanGraderTest {
+
+    private val weekStart: LocalDate = LocalDate.of(2026, 7, 27) // Monday
+
+    /** Friday of the plan week (dayIndex 4). */
+    private val friday: LocalDate = weekStart.plusDays(4)
+
+    private fun day(date: LocalDate, hours: Map<Int, Pair<Double, Double>>): SampledDay {
+        val coverage = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+        val net = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+        hours.forEach { (h, v) ->
+            coverage[h] = v.first
+            net[h] = v.second
+        }
+        return SampledDay(date, date.dayOfWeek.value - 1, coverage, net)
+    }
+
+    private fun savedPlan(vararg windows: SavedPlanWindow) = SavedWeeklyPlan(
+        weekStart = weekStart,
+        savedAtMillis = 0L,
+        target = PlanTarget.Hours(windows.sumOf { it.lengthHours }),
+        windows = windows.toList(),
+        projectedKept = windows.sumOf { it.projectedKept },
+        randomKept = null,
+    )
+
+    @Test
+    fun `a week worked exactly as planned grades as met on both axes`() {
+        val plan = savedPlan(SavedPlanWindow(4, 17, 19, 25.0, 5)) // Fri 5-7pm, projected $50
+        val samples = HourOfWeekSamples(listOf(day(friday, mapOf(17 to (1.0 to 30.0), 18 to (1.0 to 25.0)))))
+
+        val grade = WeeklyPlanGrader.grade(plan, samples)
+
+        assertEquals(2, grade.plannedHours)
+        assertEquals(2.0, grade.actualHours, 1e-9)
+        assertEquals(50.0, grade.projectedKept, 1e-9)
+        assertEquals(55.0, grade.actualKept, 1e-9)
+        assertTrue(grade.hoursMet)
+        assertTrue(grade.moneyMet)
+        assertFalse(grade.unworked)
+    }
+
+    @Test
+    fun `a skipped window grades honestly at zero and is marked skipped`() {
+        val plan = savedPlan(SavedPlanWindow(4, 17, 19, 25.0, 5), SavedPlanWindow(5, 11, 13, 20.0, 4))
+        val samples = HourOfWeekSamples(listOf(day(friday, mapOf(17 to (1.0 to 30.0), 18 to (1.0 to 30.0)))))
+
+        val grade = WeeklyPlanGrader.grade(plan, samples)
+
+        assertEquals(4, grade.plannedHours)
+        assertEquals(2.0, grade.actualHours, 1e-9)
+        assertFalse(grade.hoursMet)
+        assertTrue(grade.windows.first { it.window.dayIndex == 5 }.skipped)
+        assertFalse(grade.windows.first { it.window.dayIndex == 4 }.skipped)
+    }
+
+    @Test
+    fun `a week the driver never worked reports zero, not a missing grade`() {
+        val plan = savedPlan(SavedPlanWindow(4, 17, 19, 25.0, 5))
+        val grade = WeeklyPlanGrader.grade(plan, HourOfWeekSamples.EMPTY)
+
+        assertEquals(0.0, grade.actualHours, 1e-9)
+        assertEquals(0.0, grade.actualKept, 1e-9)
+        assertTrue(grade.unworked)
+        assertFalse(grade.hoursMet)
+    }
+
+    @Test
+    fun `money earned outside the planned windows is reported separately, never folded in`() {
+        val plan = savedPlan(SavedPlanWindow(4, 17, 19, 25.0, 5))
+        val samples = HourOfWeekSamples(
+            listOf(
+                day(friday, mapOf(17 to (1.0 to 20.0), 18 to (1.0 to 20.0), 22 to (1.0 to 45.0))),
+                day(weekStart, mapOf(9 to (1.0 to 15.0))),
+            ),
+        )
+
+        val grade = WeeklyPlanGrader.grade(plan, samples)
+
+        assertEquals(40.0, grade.actualKept, 1e-9)
+        assertEquals(60.0, grade.keptOutsideWindows, 1e-9)
+        assertEquals(100.0, grade.totalKept, 1e-9)
+        // The plan is graded on its own claim: the late-night run does not rescue it.
+        assertFalse(grade.moneyMet)
+    }
+
+    @Test
+    fun `a different week's identical weekday is not counted`() {
+        val plan = savedPlan(SavedPlanWindow(4, 17, 19, 25.0, 5))
+        val samples = HourOfWeekSamples(
+            listOf(day(friday.minusWeeks(1), mapOf(17 to (1.0 to 99.0), 18 to (1.0 to 99.0)))),
+        )
+
+        val grade = WeeklyPlanGrader.grade(plan, samples)
+
+        assertEquals(0.0, grade.actualHours, 1e-9)
+        assertEquals(0.0, grade.actualKept, 1e-9)
+    }
+
+    @Test
+    fun `partial presence inside a window counts as the partial hours it was`() {
+        val plan = savedPlan(SavedPlanWindow(4, 17, 21, 25.0, 5))
+        val samples = HourOfWeekSamples(listOf(day(friday, mapOf(17 to (0.5 to 10.0), 18 to (0.25 to 0.0)))))
+
+        val grade = WeeklyPlanGrader.grade(plan, samples)
+
+        assertEquals(0.75, grade.actualHours, 1e-9)
+        assertEquals(10.0, grade.actualKept, 1e-9)
+    }
+
+    @Test
+    fun `an empty plan grades as zero against zero rather than dividing by nothing`() {
+        val grade = WeeklyPlanGrader.grade(savedPlan(), HourOfWeekSamples.EMPTY)
+        assertEquals(0, grade.plannedHours)
+        assertEquals(0.0, grade.projectedKept, 1e-9)
+        assertTrue(grade.moneyMet) // 0 >= 0 — vacuously, and stated as such by the surface
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanScheduleTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanScheduleTest.kt
@@ -1,0 +1,102 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * #981 — the Sunday-evening trigger's calendar rules. Pure time math, so the DST weekends and the
+ * "6 pm has already passed" edge are plain tests rather than something only the field can find.
+ */
+class WeeklyPlanScheduleTest {
+
+    private val zone: ZoneId = ZoneId.of("America/Chicago")
+
+    private fun at(date: String, hour: Int, minute: Int = 0): Long =
+        LocalDateTime.of(LocalDate.parse(date), LocalTime.of(hour, minute)).atZone(zone).toInstant().toEpochMilli()
+
+    private fun local(millis: Long) = Instant.ofEpochMilli(millis).atZone(zone)
+
+    @Test
+    fun `from mid-week the next trigger is the coming Sunday at six`() {
+        // 2026-07-29 is a Wednesday; 2026-08-02 the Sunday after it.
+        val next = local(WeeklyPlanSchedule.nextTriggerMillis(at("2026-07-29", 9), zone))
+        assertEquals(LocalDate.parse("2026-08-02"), next.toLocalDate())
+        assertEquals(WeeklyPlanSchedule.TRIGGER_HOUR, next.hour)
+        assertEquals(DayOfWeek.SUNDAY, next.dayOfWeek)
+    }
+
+    @Test
+    fun `on a Sunday before six the trigger is today`() {
+        val next = local(WeeklyPlanSchedule.nextTriggerMillis(at("2026-08-02", 9), zone))
+        assertEquals(LocalDate.parse("2026-08-02"), next.toLocalDate())
+    }
+
+    @Test
+    fun `on a Sunday after six the trigger rolls to next Sunday, never to right now`() {
+        val now = at("2026-08-02", 18, 30)
+        val next = WeeklyPlanSchedule.nextTriggerMillis(now, zone)
+        assertTrue(next > now)
+        assertEquals(LocalDate.parse("2026-08-09"), local(next).toLocalDate())
+    }
+
+    @Test
+    fun `exactly at six the trigger rolls forward — strictly after, never a re-fire loop`() {
+        val now = at("2026-08-02", WeeklyPlanSchedule.TRIGGER_HOUR)
+        val next = WeeklyPlanSchedule.nextTriggerMillis(now, zone)
+        assertTrue(next > now)
+        assertEquals(LocalDate.parse("2026-08-09"), local(next).toLocalDate())
+    }
+
+    @Test
+    fun `the trigger stays at six local across a DST change, not at a fixed offset`() {
+        // US DST ends Sunday 2026-11-01; the Sunday before it is 10-25.
+        val next = local(WeeklyPlanSchedule.nextTriggerMillis(at("2026-10-26", 12), zone))
+        assertEquals(LocalDate.parse("2026-11-01"), next.toLocalDate())
+        assertEquals(WeeklyPlanSchedule.TRIGGER_HOUR, next.hour)
+    }
+
+    @Test
+    fun `a plan saved on a Sunday is for the week that starts tomorrow`() {
+        assertEquals(LocalDate.parse("2026-08-03"), WeeklyPlanSchedule.planWeekStart(LocalDate.parse("2026-08-02")))
+    }
+
+    @Test
+    fun `a plan saved mid-week is for the week the driver is already in`() {
+        // Wednesday 2026-07-29 → Monday 2026-07-27.
+        assertEquals(LocalDate.parse("2026-07-27"), WeeklyPlanSchedule.planWeekStart(LocalDate.parse("2026-07-29")))
+        // …including on the Monday itself.
+        assertEquals(LocalDate.parse("2026-07-27"), WeeklyPlanSchedule.planWeekStart(LocalDate.parse("2026-07-27")))
+    }
+
+    @Test
+    fun `the graded week is the one ending on the Sunday the worker fires`() {
+        assertEquals(LocalDate.parse("2026-07-27"), WeeklyPlanSchedule.gradedWeekStart(LocalDate.parse("2026-08-02")))
+    }
+
+    @Test
+    fun `the graded week and the week being planned are consecutive, never the same`() {
+        val sunday = LocalDate.parse("2026-08-02")
+        assertEquals(
+            WeeklyPlanSchedule.gradedWeekStart(sunday).plusWeeks(1),
+            WeeklyPlanSchedule.planWeekStart(sunday),
+        )
+    }
+
+    @Test
+    fun `week starts agree with the app's one week-boundary owner`() {
+        for (offset in 0L until 14L) {
+            val date = LocalDate.parse("2026-07-27").plusDays(offset)
+            assertEquals(
+                AnalyticsWindows.current(WindowGranularity.WEEK, date).startDate,
+                WeeklyPlanSchedule.weekStartOf(date),
+            )
+        }
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanStorageTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlanStorageTest.kt
@@ -1,0 +1,106 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * #981 — the saved-plan artifact and its codec: a plan the driver committed to must survive a process
+ * restart byte-for-byte, and a preference that has been corrupted must read as *no plan* rather than
+ * crashing the Home screen or the Sunday worker open (the `LegStateCodec` fail-closed discipline).
+ */
+class WeeklyPlanStorageTest {
+
+    private val weekStart: LocalDate = LocalDate.of(2026, 7, 27) // a Monday
+
+    private fun plan(target: PlanTarget = PlanTarget.Hours(12)) = SavedWeeklyPlan(
+        weekStart = weekStart,
+        savedAtMillis = 1_753_000_000_000L,
+        target = target,
+        windows = listOf(
+            SavedPlanWindow(4, 17, 21, 26.40, 6),
+            SavedPlanWindow(5, 11, 13, 19.05, 4),
+            SavedPlanWindow(1, 18, 20, null, 0),
+        ),
+        projectedKept = 143.70,
+        randomKept = 110.0,
+    )
+
+    @Test
+    fun `a saved plan round-trips through the codec unchanged`() {
+        val saved = listOf(plan())
+        assertEquals(saved, WeeklyPlanCodec.decode(WeeklyPlanCodec.encode(saved)))
+    }
+
+    @Test
+    fun `both target kinds round-trip`() {
+        val saved = listOf(plan(PlanTarget.Hours(20)), plan(PlanTarget.Dollars(325.50)).copy(weekStart = weekStart.minusWeeks(1)))
+        val decoded = WeeklyPlanCodec.decode(WeeklyPlanCodec.encode(saved))
+        assertEquals(PlanTarget.Hours(20), decoded[0].target)
+        assertEquals(PlanTarget.Dollars(325.50), decoded[1].target)
+    }
+
+    @Test
+    fun `a null, blank or malformed blob decodes as no saved plan`() {
+        assertTrue(WeeklyPlanCodec.decode(null).isEmpty())
+        assertTrue(WeeklyPlanCodec.decode("").isEmpty())
+        assertTrue(WeeklyPlanCodec.decode("   ").isEmpty())
+        assertTrue(WeeklyPlanCodec.decode("{not json").isEmpty())
+        assertTrue(WeeklyPlanCodec.decode("[]").isEmpty())
+    }
+
+    @Test
+    fun `an unknown target kind drops that entry rather than guessing one`() {
+        val raw = WeeklyPlanCodec.encode(listOf(plan())).replace("\"hours\"", "\"furlongs\"")
+        assertTrue(WeeklyPlanCodec.decode(raw).isEmpty())
+    }
+
+    @Test
+    fun `a structurally impossible window is dropped, and the rest of the plan survives`() {
+        val raw = WeeklyPlanCodec.encode(listOf(plan())).replace("\"dayIndex\":4", "\"dayIndex\":9")
+        val decoded = WeeklyPlanCodec.decode(raw).single()
+        assertEquals(2, decoded.windows.size)
+        assertTrue(decoded.windows.none { it.dayIndex == 9 })
+    }
+
+    @Test
+    fun `an inverted hour range is dropped`() {
+        val raw = WeeklyPlanCodec.encode(
+            listOf(plan().copy(windows = listOf(SavedPlanWindow(4, 17, 21, 20.0, 5)))),
+        ).replace("\"endHourExclusive\":21", "\"endHourExclusive\":17")
+        assertTrue(WeeklyPlanCodec.decode(raw).single().windows.isEmpty())
+    }
+
+    @Test
+    fun `derived totals come from the frozen windows`() {
+        val saved = plan()
+        assertEquals(8, saved.totalHours) // 4 + 2 + 2, including the unpriced one
+        assertEquals(33.70, saved.planWorth!!, 1e-9)
+    }
+
+    @Test
+    fun `freezing a plan keeps the numbers the driver was shown`() {
+        val samples = HourOfWeekSamples(
+            (0 until 4).map { occ ->
+                val coverage = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+                val net = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+                for (h in 17..18) {
+                    coverage[h] = 1.0
+                    net[h] = 30.0
+                }
+                SampledDay(LocalDate.of(2026, 1, 9).plusWeeks(occ.toLong()), 4, coverage, net)
+            },
+        )
+        val live = WeeklyPlanner.plan(samples, PlanTarget.Hours(2))
+        val frozen = SavedWeeklyPlan.from(live, weekStart, savedAtMillis = 42L)
+
+        assertEquals(weekStart, frozen.weekStart)
+        assertEquals(live.projectedKept, frozen.projectedKept, 1e-9)
+        assertEquals(live.randomKept!!, frozen.randomKept!!, 1e-9)
+        assertEquals(live.totalHours, frozen.totalHours)
+        assertEquals(live.windows.map { it.startHour }, frozen.windows.map { it.startHour })
+        // …and survives storage exactly as frozen.
+        assertEquals(listOf(frozen), WeeklyPlanCodec.decode(WeeklyPlanCodec.encode(listOf(frozen))))
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlannerTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlannerTest.kt
@@ -1,0 +1,460 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * #981 / brief §8 — the Weekly Plan algorithm, exhaustively.
+ *
+ * The planner is the one place in this feature that makes a claim about the driver's week, so every
+ * step of the brief's six-line algorithm gets its own test: ranking by median, the per-cell sample
+ * floor (with the stated reason when it bites), the adjacency merge, the ≥2h floor, the greedy fill,
+ * the projection math, the random baseline, and determinism.
+ *
+ * Records are built from explicit per-occurrence buckets rather than from timestamps: the apportionment
+ * itself is [HourOfWeekSamplerTest]'s subject, and mixing the two would make a planner failure read as
+ * a calendar failure.
+ */
+class WeeklyPlannerTest {
+
+    // ── Record builders ─────────────────────────────────────────────────────
+
+    /** A Monday, so `base.plusDays(dayIndex)` lands on the intended weekday. */
+    private val base: LocalDate = LocalDate.of(2026, 1, 5)
+
+    /**
+     * One weekday's record: [hourRates] maps an hour to its per-occurrence net, one entry per separate
+     * day the driver worked that hour. Coverage is a full hour on every listed occurrence, so the
+     * occurrence rate IS the listed net.
+     */
+    private fun weekday(dayIndex: Int, hourRates: Map<Int, List<Double>>): List<SampledDay> {
+        val occurrences = hourRates.values.maxOfOrNull { it.size } ?: 0
+        return (0 until occurrences).map { occ ->
+            val coverage = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+            val net = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+            hourRates.forEach { (hour, rates) ->
+                rates.getOrNull(occ)?.let {
+                    coverage[hour] = 1.0
+                    net[hour] = it
+                }
+            }
+            SampledDay(
+                date = base.plusDays((dayIndex + 7 * occ).toLong()),
+                dayIndex = dayIndex,
+                coverageHours = coverage,
+                netDollars = net,
+            )
+        }
+    }
+
+    /** A weekday worked at a flat [rate] across [hours], on [occurrences] separate days. */
+    private fun flat(dayIndex: Int, hours: IntRange, rate: Double, occurrences: Int): List<SampledDay> =
+        weekday(dayIndex, hours.associateWith { List(occurrences) { rate } })
+
+    private fun record(vararg days: List<SampledDay>) = HourOfWeekSamples(days.toList().flatten())
+
+    private fun reasonFor(plan: WeeklyPlan, dayIndex: Int): UnpickedReason? =
+        plan.notPicked.firstOrNull { it.dayIndex == dayIndex }?.reason
+
+    // ── 1. Ranking by median ────────────────────────────────────────────────
+
+    @Test
+    fun `the highest-median weekday is picked first and carries the BEST pill`() {
+        val samples = record(
+            flat(dayIndex = 4, hours = 17..20, rate = 30.0, occurrences = 4), // Friday, best
+            flat(dayIndex = 1, hours = 17..20, rate = 18.0, occurrences = 4), // Tuesday
+        )
+
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(4))
+
+        assertEquals(1, plan.windows.size)
+        assertEquals(4, plan.windows.single().dayIndex)
+        assertTrue(plan.windows.single().isBest)
+        assertEquals(30.0, plan.windows.single().dollarsPerHour!!, 1e-9)
+    }
+
+    @Test
+    fun `a cell's rate is the median of its occurrences, not their mean`() {
+        val samples = record(
+            weekday(4, mapOf(17 to listOf(20.0, 22.0, 24.0, 200.0), 18 to listOf(20.0, 22.0, 24.0, 200.0))),
+        )
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(2))
+        // Mean would be $66.50/hr; the median holds at the typical evening.
+        assertEquals(23.0, plan.windows.single().dollarsPerHour!!, 1e-9)
+    }
+
+    // ── 2. Minimum sample count, with the reason stated ─────────────────────
+
+    @Test
+    fun `a weekday with fewer than the minimum days behind it is never placed, and says why`() {
+        val samples = record(
+            flat(4, 17..20, 40.0, occurrences = WeeklyPlanner.MIN_SAMPLE_DAYS - 1), // rich but thin
+            flat(1, 17..20, 12.0, occurrences = 4),
+        )
+
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(8))
+
+        assertTrue(plan.windows.none { it.dayIndex == 4 })
+        assertEquals(UnpickedReason.THIN_HISTORY, reasonFor(plan, 4))
+        assertEquals(WeeklyPlanner.MIN_SAMPLE_DAYS - 1, plan.notPicked.first { it.dayIndex == 4 }.daysOnRecord)
+    }
+
+    @Test
+    fun `exactly the minimum number of days is enough`() {
+        val samples = record(flat(4, 17..20, 25.0, occurrences = WeeklyPlanner.MIN_SAMPLE_DAYS))
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(4))
+        assertEquals(1, plan.windows.size)
+        assertEquals(WeeklyPlanner.MIN_SAMPLE_DAYS, plan.windows.single().sampleCount)
+    }
+
+    @Test
+    fun `a long block the driver has never worked half of never becomes a window of that length`() {
+        // Hours 17..20 each have 4 separate days behind them — but never the SAME days: every date
+        // carries exactly one of the four hours. Each cell clears the per-cell floor, so a naive
+        // merge would happily recommend 5–9 pm; the window-level coverage floor (half of the range
+        // asked about — 2h of a 4h block) is what refuses, since no single day ever cleared it.
+        val days = (0 until 4).flatMap { occ ->
+            listOf(17, 18, 19, 20).mapIndexed { i, hour ->
+                val coverage = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+                val net = MutableList(EarningsHeatmap.HOURS) { 0.0 }
+                coverage[hour] = 1.0
+                net[hour] = 30.0
+                SampledDay(base.plusDays((4 + 7 * (occ * 4 + i)).toLong()), 4, coverage, net)
+            }
+        }
+        val plan = WeeklyPlanner.plan(HourOfWeekSamples(days), PlanTarget.Hours(WeeklyPlanner.MAX_WINDOW_HOURS))
+
+        assertTrue(plan.windows.none { it.lengthHours > WeeklyPlanner.MIN_WINDOW_HOURS })
+        assertTrue(plan.windows.isNotEmpty())
+    }
+
+    // ── 3. Adjacency merge + 4. the ≥2h floor ───────────────────────────────
+
+    @Test
+    fun `adjacent qualifying hours merge into ONE window, not several short ones`() {
+        val samples = record(flat(4, 17..20, 30.0, occurrences = 4)) // 4 contiguous hours
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(4))
+
+        assertEquals(1, plan.windows.size)
+        assertEquals(17, plan.windows.single().startHour)
+        assertEquals(21, plan.windows.single().endHourExclusive)
+    }
+
+    @Test
+    fun `a run longer than the cap becomes the capped window, not the whole day`() {
+        val samples = record(flat(4, 10..21, 30.0, occurrences = 4)) // 12 contiguous hours
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(WeeklyPlanner.MAX_WINDOW_HOURS))
+        assertEquals(WeeklyPlanner.MAX_WINDOW_HOURS, plan.windows.single().lengthHours)
+    }
+
+    @Test
+    fun `a lone qualifying hour is never a window`() {
+        val samples = record(
+            weekday(4, mapOf(17 to List(4) { 40.0 }, 19 to List(4) { 40.0 })), // isolated, 18 unworked
+        )
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(8))
+        assertTrue(plan.windows.isEmpty())
+        assertEquals(UnpickedReason.NO_CONTIGUOUS_RUN, reasonFor(plan, 4))
+    }
+
+    // ── 5. Greedy fill ──────────────────────────────────────────────────────
+
+    @Test
+    fun `the fill takes windows in rate order across weekdays until the target is met`() {
+        val samples = record(
+            flat(4, 17..18, 30.0, 4), // Fri 2h @ 30
+            flat(5, 17..18, 25.0, 4), // Sat 2h @ 25
+            flat(2, 17..18, 20.0, 4), // Wed 2h @ 20
+        )
+
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(4))
+
+        assertEquals(listOf(4, 5), plan.windows.map { it.dayIndex }.sorted())
+        assertEquals(4, plan.totalHours)
+        assertTrue(plan.targetMet)
+        // The one that lost says so, rather than disappearing.
+        assertEquals(UnpickedReason.TARGET_ALREADY_MET, reasonFor(plan, 2))
+    }
+
+    @Test
+    fun `the fill never overshoots the hour target and states the shortfall it cannot fill`() {
+        val samples = record(flat(4, 17..20, 30.0, 4)) // one 4h run only
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(12))
+
+        assertEquals(4, plan.totalHours)
+        assertFalse(plan.targetMet)
+        assertEquals(8, plan.shortfallHours)
+    }
+
+    @Test
+    fun `a target smaller than a window still fits by taking a shorter sub-range`() {
+        val samples = record(flat(4, 17..20, 30.0, 4))
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(2))
+        assertEquals(2, plan.totalHours)
+    }
+
+    @Test
+    fun `placed windows never overlap`() {
+        val samples = record(flat(4, 8..21, 30.0, 5), flat(5, 8..21, 29.0, 5))
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(20))
+        for (a in plan.windows.indices) {
+            for (b in a + 1 until plan.windows.size) {
+                assertFalse(plan.windows[a].overlaps(plan.windows[b]))
+            }
+        }
+    }
+
+    // ── 6. Projection math + 7. the random baseline ─────────────────────────
+
+    @Test
+    fun `projection is median rate times hours, and the baseline is the overall median times the same hours`() {
+        val samples = record(
+            flat(4, 17..18, 30.0, 4), // 8 Friday hour-samples at $30
+            flat(1, 17..18, 10.0, 4), // 8 Tuesday hour-samples at $10
+        )
+
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(2))
+
+        assertEquals(60.0, plan.projectedKept, 1e-9) // $30 × 2h
+        // Overall median across all 16 worked hours: 8 at $30, 8 at $10 → $20.
+        assertEquals(20.0, plan.randomPlacementRate!!, 1e-9)
+        assertEquals(40.0, plan.randomKept!!, 1e-9)
+        assertEquals(20.0, plan.planWorth!!, 1e-9)
+    }
+
+    @Test
+    fun `the comparison is withheld, not invented, when the record has no baseline`() {
+        val plan = WeeklyPlanner.plan(HourOfWeekSamples.EMPTY, PlanTarget.Hours(12))
+        assertNull(plan.randomPlacementRate)
+        assertNull(plan.randomKept)
+        assertNull(plan.planWorth)
+    }
+
+    @Test
+    fun `a plan that does not beat random placement reports a negative worth rather than hiding it`() {
+        // The only 2h-contiguous run is the weak one; the rich hours are isolated singles, so they
+        // lift the overall median without ever becoming a window.
+        val samples = record(
+            weekday(4, mapOf(17 to List(4) { 12.0 }, 18 to List(4) { 12.0 })),
+            weekday(1, mapOf(9 to List(4) { 60.0 }, 12 to List(4) { 60.0 }, 15 to List(4) { 60.0 })),
+        )
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(2))
+
+        assertEquals(4, plan.windows.single().dayIndex)
+        assertTrue(plan.planWorth!! < 0.0)
+    }
+
+    // ── Dollar targets ──────────────────────────────────────────────────────
+
+    @Test
+    fun `a dollar goal fills until the projection reaches it`() {
+        val samples = record(
+            flat(4, 17..18, 30.0, 4),
+            flat(5, 17..18, 30.0, 4),
+            flat(6, 17..18, 30.0, 4),
+        )
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Dollars(100.0))
+
+        assertTrue(plan.projectedKept >= 100.0)
+        assertTrue(plan.targetMet)
+        // …and stops as soon as it does: two windows ($120) rather than all three.
+        assertEquals(2, plan.windows.size)
+    }
+
+    @Test
+    fun `a dollar goal the record cannot reach stops at the plan cap`() {
+        val samples = record((0..6).map { flat(it, 0..23, 5.0, 4) }.flatten())
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Dollars(100_000.0))
+
+        assertFalse(plan.targetMet)
+        assertTrue(plan.totalHours <= WeeklyPlanner.MAX_PLAN_HOURS)
+    }
+
+    // ── "NOT PICKED", every reason ──────────────────────────────────────────
+
+    @Test
+    fun `an empty record places nothing and reports every weekday as unrecorded`() {
+        val plan = WeeklyPlanner.plan(HourOfWeekSamples.EMPTY, PlanTarget.Hours(12))
+
+        assertTrue(plan.windows.isEmpty())
+        assertEquals(EarningsHeatmap.DAYS, plan.notPicked.size)
+        assertTrue(plan.notPicked.all { it.reason == UnpickedReason.NO_HISTORY })
+        assertEquals(0.0, plan.projectedKept, 1e-9)
+    }
+
+    @Test
+    fun `a weekday measured at or below zero net is reported as measured, not as thin`() {
+        val samples = record(flat(4, 17..20, 0.0, 4))
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(8))
+        assertEquals(UnpickedReason.NO_POSITIVE_RATE, reasonFor(plan, 4))
+    }
+
+    @Test
+    fun `every weekday without a window appears exactly once in notPicked`() {
+        val samples = record(flat(4, 17..20, 30.0, 4))
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(4))
+
+        val covered = plan.windows.map { it.dayIndex }.toSet()
+        assertEquals(EarningsHeatmap.DAYS - covered.size, plan.notPicked.size)
+        assertEquals(plan.notPicked.size, plan.notPicked.map { it.dayIndex }.distinct().size)
+        assertTrue(plan.notPicked.none { it.dayIndex in covered })
+    }
+
+    // ── Edits: drop, re-fill, move ──────────────────────────────────────────
+
+    @Test
+    fun `dropping a window re-fills from the next best and never re-picks the dropped hours`() {
+        val samples = record(
+            flat(4, 17..18, 30.0, 4),
+            flat(5, 17..18, 25.0, 4),
+        )
+        val base = WeeklyPlanner.plan(samples, PlanTarget.Hours(2))
+        assertEquals(4, base.windows.single().dayIndex)
+
+        val edited = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Drop(4, 17)))
+
+        assertEquals(1, edited.windows.size)
+        assertEquals(5, edited.windows.single().dayIndex) // re-filled from the next best
+        assertEquals(UnpickedReason.REMOVED_BY_YOU, reasonFor(edited, 4))
+    }
+
+    @Test
+    fun `a drop bans the whole dropped range, not just its exact start`() {
+        val samples = record(flat(4, 17..20, 30.0, 4), flat(5, 17..18, 25.0, 4))
+        val edited = WeeklyPlanner.plan(samples, PlanTarget.Hours(4), listOf(PlanEdit.Drop(4, 17)))
+        // No sub-range of the dropped Friday block comes back.
+        assertTrue(edited.windows.none { it.dayIndex == 4 })
+    }
+
+    @Test
+    fun `dropping twice in a row drops two different windows`() {
+        val samples = record(
+            flat(4, 17..18, 30.0, 4),
+            flat(5, 17..18, 25.0, 4),
+            flat(6, 17..18, 20.0, 4),
+        )
+        val first = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Drop(4, 17)))
+        val second = WeeklyPlanner.plan(
+            samples,
+            PlanTarget.Hours(2),
+            listOf(PlanEdit.Drop(4, 17), PlanEdit.Drop(first.windows.single().dayIndex, 17)),
+        )
+        assertEquals(6, second.windows.single().dayIndex)
+    }
+
+    @Test
+    fun `a moved window re-derives its rate from the record at its NEW hours`() {
+        val samples = record(
+            weekday(
+                4,
+                mapOf(
+                    17 to List(4) { 30.0 }, 18 to List(4) { 30.0 },
+                    19 to List(4) { 10.0 }, 20 to List(4) { 10.0 },
+                ),
+            ),
+        )
+        val base = WeeklyPlanner.plan(samples, PlanTarget.Hours(2))
+        assertEquals(17, base.windows.single().startHour)
+
+        val moved = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Shift(4, 17, +2)))
+        val window = moved.windows.single { it.moved }
+
+        assertEquals(19, window.startHour)
+        assertEquals(10.0, window.dollarsPerHour!!, 1e-9) // the new hours' own median, not the old one
+        assertEquals(20.0, moved.projectedKept, 1e-9)
+    }
+
+    @Test
+    fun `a window moved onto hours with no record keeps its place, prices nothing, and is flagged`() {
+        val samples = record(flat(4, 17..18, 30.0, 4))
+        val moved = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Shift(4, 17, -8)))
+        val window = moved.windows.single()
+
+        assertEquals(9, window.startHour)
+        assertNull(window.dollarsPerHour)
+        assertEquals(0, window.sampleCount)
+        assertEquals(0.0, moved.projectedKept, 1e-9)
+        assertTrue(moved.hasUnpricedHours)
+        assertEquals(0, moved.pricedHours)
+    }
+
+    @Test
+    fun `a move is clamped inside the day rather than falling off either end`() {
+        val samples = record(flat(4, 21..22, 30.0, 4))
+        val late = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Shift(4, 21, +12)))
+        assertEquals(22, late.windows.single().startHour)
+        assertEquals(EarningsHeatmap.HOURS, late.windows.single().endHourExclusive)
+
+        val early = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Shift(4, 21, -30)))
+        assertEquals(0, early.windows.single().startHour)
+    }
+
+    @Test
+    fun `an edit naming a window that is not there is a no-op`() {
+        val samples = record(flat(4, 17..18, 30.0, 4))
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Drop(0, 3)))
+        assertEquals(1, plan.windows.size)
+        assertEquals(4, plan.windows.single().dayIndex)
+    }
+
+    @Test
+    fun `a window moved onto thinly-recorded hours is flagged as thin evidence`() {
+        val samples = record(
+            weekday(4, mapOf(17 to List(4) { 30.0 }, 18 to List(4) { 30.0 }, 19 to List(1) { 50.0 }, 20 to List(1) { 50.0 })),
+        )
+        val moved = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Shift(4, 17, +2)))
+        val window = moved.windows.single()
+        assertEquals(1, window.sampleCount)
+        assertTrue(window.hasThinEvidence)
+        assertEquals(50.0, window.dollarsPerHour!!, 1e-9)
+    }
+
+    // ── Determinism ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `the same record and target always produce an identical plan`() {
+        val samples = record(
+            flat(4, 15..21, 30.0, 4),
+            flat(5, 15..21, 30.0, 4), // deliberately identical rates, to exercise the tie-breaks
+            flat(1, 9..14, 30.0, 4),
+        )
+        val edits = listOf(PlanEdit.Drop(1, 9), PlanEdit.Shift(4, 15, 1))
+
+        val a = WeeklyPlanner.plan(samples, PlanTarget.Hours(12), edits)
+        val b = WeeklyPlanner.plan(samples, PlanTarget.Hours(12), edits)
+
+        assertEquals(a, b)
+        assertEquals(a.windows, b.windows)
+        assertEquals(a.notPicked, b.notPicked)
+    }
+
+    @Test
+    fun `windows are returned in weekday then hour order`() {
+        val samples = record(
+            flat(5, 17..18, 20.0, 4),
+            flat(1, 17..18, 30.0, 4),
+            flat(1, 9..10, 25.0, 4),
+        )
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(6))
+        val keys = plan.windows.map { it.dayIndex * 100 + it.startHour }
+        assertEquals(keys.sorted(), keys)
+        assertNotNull(plan.windows.firstOrNull { it.isBest })
+        assertEquals(1, plan.windows.count { it.isBest })
+    }
+
+    @Test
+    fun `covers reports exactly the placed hours, for the heatmap outline`() {
+        val samples = record(flat(4, 17..20, 30.0, 4))
+        val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(4))
+
+        assertTrue(plan.covers(4, 17))
+        assertTrue(plan.covers(4, 20))
+        assertFalse(plan.covers(4, 21))
+        assertFalse(plan.covers(3, 17))
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlannerTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WeeklyPlannerTest.kt
@@ -395,6 +395,36 @@ class WeeklyPlannerTest {
     }
 
     @Test
+    fun `a move onto a sibling window is refused, so hours are never double-counted`() {
+        // Two separate Friday runs (9-11am and 12-2pm) with a dead hour between them.
+        val samples = record(
+            weekday(
+                4,
+                mapOf(
+                    9 to List(4) { 30.0 }, 10 to List(4) { 30.0 },
+                    12 to List(4) { 28.0 }, 13 to List(4) { 28.0 },
+                ),
+            ),
+        )
+        val base = WeeklyPlanner.plan(samples, PlanTarget.Hours(4))
+        assertEquals(2, base.windows.size)
+        assertEquals(4, base.totalHours)
+
+        // Nudging the 12pm window back by one would put it at 11-1, straddling nothing — but two
+        // more nudges would walk it onto 9-11, which the guard refuses.
+        val edits = listOf(PlanEdit.Shift(4, 12, -1), PlanEdit.Shift(4, 11, -1), PlanEdit.Shift(4, 10, -1))
+        val edited = WeeklyPlanner.plan(samples, PlanTarget.Hours(4), edits)
+
+        assertEquals(2, edited.windows.size)
+        assertEquals(4, edited.totalHours)
+        for (a in edited.windows.indices) {
+            for (b in a + 1 until edited.windows.size) {
+                assertFalse(edited.windows[a].overlaps(edited.windows[b]))
+            }
+        }
+    }
+
+    @Test
     fun `an edit naming a window that is not there is a no-op`() {
         val samples = record(flat(4, 17..18, 30.0, 4))
         val plan = WeeklyPlanner.plan(samples, PlanTarget.Hours(2), listOf(PlanEdit.Drop(0, 3)))

--- a/feature/dashboard/src/main/java/cloud/trotter/dashbuddy/feature/dashboard/components/WeeklyPlanPointerRow.kt
+++ b/feature/dashboard/src/main/java/cloud/trotter/dashbuddy/feature/dashboard/components/WeeklyPlanPointerRow.kt
@@ -1,0 +1,76 @@
+package cloud.trotter.dashbuddy.feature.dashboard.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.SavedWeeklyPlan
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.feature.dashboard.R
+
+/**
+ * `Your week is planned · 12 target hours across 4 windows · $280 projected` — Home's pointer at the
+ * Weekly Plan (#981 / brief §2 row 3), filling the seam #977 left.
+ *
+ * **Only rendered when a plan exists** (the caller decides, so this composable never has to represent
+ * absence). The three figures come straight off the frozen [SavedWeeklyPlan] — the numbers the driver
+ * committed to, not a re-derivation that might have moved under them since — and "projected" is the
+ * word the row uses, never "you'll earn" (§9).
+ *
+ * Data in, lambda out; no Hilt, no repository — the feature-module contract.
+ */
+@Composable
+fun WeeklyPlanPointerRow(
+    plan: SavedWeeklyPlan,
+    onOpen: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val c = AppTheme.colors
+    AppCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(role = Role.Button, onClick = onOpen),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.dashboard_weekly_plan_pointer_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = c.text,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = stringResource(
+                        R.string.dashboard_weekly_plan_pointer_detail_format,
+                        plan.totalHours,
+                        plan.windows.size,
+                        Formats.money0(plan.projectedKept),
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.text3,
+                )
+            }
+            // A text affordance, not a chevron icon: this module deliberately carries no
+            // material-icons dependency (the honest-deps doctrine), and `Recap →` next door already
+            // set the vocabulary.
+            Text(
+                text = stringResource(R.string.dashboard_weekly_plan_pointer_action),
+                style = MaterialTheme.typography.labelLarge,
+                color = c.accent,
+            )
+        }
+    }
+}

--- a/feature/dashboard/src/main/res/values/strings.xml
+++ b/feature/dashboard/src/main/res/values/strings.xml
@@ -45,4 +45,9 @@
     <string name="dashboard_week_delta_from_nothing">Up from nothing last week</string>
     <string name="dashboard_week_delta_none">No earlier week to compare with yet</string>
     <string name="dashboard_week_frozen_note">Net is frozen at the costs in force when you accepted each offer.</string>
+
+    <!-- components/WeeklyPlanPointerRow.kt — Home's pointer at the Weekly Plan (#981, brief §2 row 3) -->
+    <string name="dashboard_weekly_plan_pointer_title">Your week is planned</string>
+    <string name="dashboard_weekly_plan_pointer_detail_format">%1$d target hours across %2$d windows · %3$s projected</string>
+    <string name="dashboard_weekly_plan_pointer_action">Plan →</string>
 </resources>


### PR DESCRIPTION
Closes #981. Refs #969 (redesign epic, stage 6 of 7).

Brief §8 in full + §7.7: the Weekly Plan — the redesign's new surface and its retention hook. A set of hour windows drawn from the driver's **own** record, with the value of following the plan stated next to the value of not bothering, saved as a commitment and graded a week later.

---

### The §7.7 question, resolved: medians vs the aggregate

Brief §8 asks the planner to rank weekday×hour cells by **median** realized net $/hr. `EarningsHeatmap` — the read stage 4 and stage 5 use — structurally cannot answer that: it is a **totals** grid, its cell rate is `Σnet ÷ Σcoverage` (a coverage-weighted **mean**), and the individual days were summed away before the object existed. No median, and no sample count, is recoverable from it.

Rather than substitute weighted rates, the honest minimum plumbing turned out to be small: **feed the same two lifetime DAO reads (`sessionSpans` + `deliveryNets`) to a new pure `:domain` `HourOfWeekSampler` that apportions them one calendar step earlier — into `(date, hour)` buckets instead of straight into `(weekday, hour)` totals.** A cell's samples are then its own separate days, and both the median and "over N Fridays" fall out.

- **No new query, no new column, no schema change, no `PROJECTOR_VERSION` bump.** `AnalyticsRepository.hourOfWeekSamples()` is `earningsHeatmap()` with a different pure calculator behind the same `combine`.
- It inherits the heatmap's rules **verbatim** (Principle 5): the wall-clock union of spans, fractional-hour apportionment, and net landing whole in the hour of `completedAt`. The plan and the Patterns grid cannot tell the driver two different stories.
- The coverage floor is the heatmap's own `DEFAULT_MIN_COVERAGE_HOURS` expressed as a **fraction** (half the range asked about), so a 4h window needs 2h of real presence before a day counts as a sample *of it* — the window-level gate is not redundant with the per-cell one.

So the brief's "median" intent is delivered as a real median over a real sample count, not approximated.

### The algorithm (`WeeklyPlanner`, pure, §8 verbatim)

Median ranking → `MIN_SAMPLE_DAYS`=3 separate days per cell → adjacency merge → ≥2h floor (4h cap, both shared with #977's `DayPlanner`) → greedy fill to target → `median × hours` projection → `overall median × hours` random baseline.

Two decisions worth naming:

- **The greedy tie-break is rate → longest → earliest day → earliest start.** *Longest*-first is what actually performs §8's "merge adjacent qualifying cells": a run of four equally-good hours yields sub-ranges that share one median, and shortest-first would render one 4h run as two stapled 2h rows.
- **Driver edits are replayed, never applied.** The ViewModel holds an ordered `List<PlanEdit>`; the base plan is recomputed from the record every emission and the edits re-applied. That is what makes a moved window re-derive its evidence *at its new hours* (or price nothing, visibly) instead of carrying a number measured three hours earlier, and what lets a dropped window's range be banned so the re-fill takes the next-best hours rather than the same ones back.

Every weekday holding no window is returned with a **measured** reason — `NO_HISTORY` / `THIN_HISTORY` / `NO_CONTIGUOUS_RUN` / `NO_POSITIVE_RATE` / `TARGET_ALREADY_MET` / `REMOVED_BY_YOU` — never silently omitted.

### Storage: a user artifact, not analytics state

A saved plan goes in its own single-concern **DataStore** (`weekly_plan`, the eighth), encoded by the fail-closed `WeeklyPlanCodec`, behind `WeeklyPlanRepository` (keep the last 2 weeks).

Why not a Room table: nothing in `app_events` implies a plan and nothing can rebuild one, while the analytics tables are explicitly a rebuildable projection that a `PROJECTOR_VERSION` bump **wipes**. Putting an unrebuildable artifact there would mean a routine projector bump silently deletes the driver's plan and the grade it was owed. The cost the other way is also real: a Room table for one small per-week record buys a schema bump, an `AutoMigration`, an exported-schema regeneration and a `MigrationTestHelper` case, for data whose only query is "give me the current one".

It is **frozen at save time** — the driver is graded against the plan they were shown, the `delivery_records` doctrine applied to a commitment.

### The Sunday loop

`WeeklyPlanWorker` is a **periodic 7-day** WorkManager job (WorkManager was already a dependency and already hosts `DailyGasPriceWorker`; it persists its own queue and re-schedules across reboot for free — no exact-alarm permission, no boot receiver). Its initial delay is computed to the next **Sunday 18:00 local** by the pure `WeeklyPlanSchedule`, and `schedule()` runs on every app start, which is also what corrects the ~1h DST drift a 7×24h interval accrues. Periodic rather than self-re-enqueuing one-time work: a one-time job re-arming its own unique name has to `REPLACE` work that is *currently running* — itself.

It grades the finished week (`WeeklyPlanGrader`, pure: planned vs actual hours and dollars **inside the planned windows only**; money earned outside is reported separately, never folded in to flatter the plan) and posts on a **new** channel.

**Channel decision:** `weekly_plan_channel` (notification id 104), deliberately **not** `app_notice_channel`. A channel name is the user's mute control, and these are different promises: `AppNoticeChannel` carries one-off Pledge-adjacent disclosures (locale boundary, recognition health) a driver would want even if they want nothing else; this is a recurring engagement nudge they are entitled to silence *without* losing those.

### The screen

Grade card (when there is one) · target selector (`8h · 12h · 20h · $ goal`) · headline **and** the plan-vs-random comparison · suggested windows · "where the plan came from" · locked growth rows · Save.

- **The comparison is never dropped.** With no baseline the card says so rather than showing the headline alone — a projection with nothing to compare it against invites being read as a promise.
- **"Where the plan came from" reuses the Patterns heat grid**, extracted to `HeatmapGrid` with an `outlined` hook (`PatternsTab` was 652 lines; the extraction also shrinks it). A lookalike grid would eventually drift from the one the driver recognises, and the recognition *is* the proof of derivation.
- **The growth rows carry no data at all** — dimmed to the brief's exact 60% / 45%, unclickable, each saying only what it would be and what it waits on. One fabricated neighbour would make every real figure on the screen suspect.
- **Home's pointer row** fills the seam #977 left, reading the plan for the week the driver is **in** (`weekStartOf`, not `planWeekStart` — on a Sunday those differ).

**Drag interaction — the one deliberate substitution.** "Drag to move a window" ships as **swipe-to-drop + `‹ ›` hour nudges**. Moving a window means moving it along a *time* axis; in a vertically-scrolling list of rows a drag gesture reads as *reordering the list*, which is the one thing it must not mean. The nudges are unambiguous, work one-handed while parked, and emit exactly the same `PlanEdit`. Swipe-to-drop is the brief's own gesture, unchanged.

### Tests

- `:domain` — `WeeklyPlannerTest` (31): ranking by median, the sample floor with its stated reason, adjacency merge, the ≥2h floor and the cap, greedy fill / no-overshoot / no-overlap, projection math, the random baseline (including a plan that legitimately **loses** to it), both target kinds, every `UnpickedReason`, the full edit-replay set (drop → re-fill, double drop, move re-derives, move onto no history, clamping, no-op), and determinism.
- `:domain` — `HourOfWeekSamplerTest` (13, incl. a cross-check that the sampler and `EarningsHeatmapCalculator` agree on total coverage and total net), `WeeklyPlanStorageTest` (8, round-trip + fail-closed), `WeeklyPlanGraderTest` (7), `WeeklyPlanScheduleTest` (10, incl. DST and the exactly-at-six edge).
- `:app` — `WeeklyPlanViewModelTest` (8) on the documented virtual-time pattern (`runCurrent()`, never `advanceUntilIdle()`; cancel `viewModelScope` before the body ends).
- Full `testDebugUnitTest :domain:test` green; `:app:lintVitalRelease` green.

---

### Design-goal review

1. **UDF.** The ViewModel holds only the driver's choices (target + an ordered edit list); the plan is recomputed by a pure function on every emission and can never drift from what the algorithm would produce. Intents up (`setTarget`/`moveWindow`/`dropWindow`/`undoLastEdit`/`savePlan`), immutable state down. The one wall-clock read (`savedAtMillis`) sits at the save edge, not inside the derivation.
2. **MAD.** Compose, Flow, Hilt, DataStore, WorkManager, version catalog — all pre-existing mechanisms, no new dependency of any kind.
3. **Single responsibility.** New files are small and single-purpose; `PatternsTab` (652 lines) got *smaller* via the `HeatmapGrid` extraction. One knowing exception: `AnalyticsRepository` (966 lines) gained ~15 lines, because `hourOfWeekSamples` must sit with the two DAO reads it shares with `earningsHeatmap` — splitting that repository is a separate refactor and putting the read anywhere else would have created the second owner Principle 5 forbids.
4. **Kotlin/Android practices.** Sealed `PlanTarget`/`PlanEdit` and an enumerated `UnpickedReason` over stringly-typed values; total orderings everywhere the output must be deterministic; `WhileSubscribed` sharing; immutability throughout.
5. **SSOT.** The heatmap's apportionment rules are inherited, not re-implemented; `HourOfWeekSamples.median` is the one median in the feature; `MIN_WINDOW_HOURS`/`MAX_WINDOW_HOURS` are `DayPlanner`'s, so Home and the plan cannot disagree about what a window is; Monday-anchoring delegates to `AnalyticsWindows`; the heat grid has one renderer; `PlanTarget.HOUR_PRESETS` owns the option set; money/duration/hour-range labels all go through the `:domain` format SSOT.
6. **Security & privacy.** Read-side only. Nothing here touches recognition, capture, effects or the network, and no new PII surface exists: every value is aggregate economics and hour-of-week counts. The notification carries counts and dollars only.
7. **Semantic, PII-safe logging.** Two new log sites, both `ERROR` under a stable `WeeklyPlan` tag, both message-only (a failed notification post; a failed weekly job). No INFO+ line carries any record-derived text. `TimberTagGuardTest` unaffected — no bare `Timber.*` added.
8. **Platform-agnostic core.** No `Platform` literal, wire string or package name anywhere in the diff. The plan is hour-of-week economics; platform never enters it.

**Reactive UI.** The record is a Room-invalidation Flow, so a dash folded while the screen is open re-plans it; the local-date flow re-anchors the plan week at midnight without a restart. No `rememberNow()` ticker, deliberately: nothing on a week's plan goes stale while it is being looked at (the #657/#977 reasoning), unlike the Home strip's current-hour dimming.

**Honesty rules (§9), rendered rather than assumed.** Every projection states whose data it is and that it is not a promise, on every state of the card. Sample counts are quoted in the unit the record can actually count (days, not dashes — the #977 hours-not-dashes discipline). Thin history is stated instead of smoothed. A plan that loses to random placement says so. A window with no record behind it prices nothing and says why. The locked rows carry no data. An empty record renders "no record to plan from yet" rather than an empty plan that would read as a bad week.

**Field validation:** checklist item added at `Confirmed: 0/2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
