### PR TITLE
feature(analytics): #983 — Time tab: while-working vs whole-shift, typical online hour, gap stats (redesign stage 7/7 — epic complete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -776,6 +776,52 @@ pointer row reads the plan for the week the driver is IN (`weekStartOf`, not `pl
 Sunday those differ). `PatternsTab`'s heat grid was extracted to `HeatmapGrid` so "where the plan came
 from" renders the SAME grid with the picked cells outlined — the derivation's proof is the driver
 recognising the picture, which a lookalike would eventually stop being.
+**Time tab: the two rates, the typical hour, gap stats (#983, stage 7/7 — the epic's last build):**
+the redesign's closing stage surfaces `docs/design/running-hourly-rate.md`, which is the **semantic
+SSOT** for hourly rates and which the UI had never rendered. Three additions, all read-side (no schema
+change, no `PROJECTOR_VERSION` bump, no economy dependency). (1) **The §7.8 gap fold.** `WorkGaps`
+(pure `:domain`) pairs each completed drop with the **next accepted offer in the same dash** and
+measures the span. Rules, all fail-null: never across dashes or days (a session-less "(No session)" row
+therefore contributes nothing — this is the ONE window aggregate with no null-session fallback, and
+that is the definition, not an oversight); "which accept came next" is a **`sequenceId`** question while
+"how long" is a **timestamp** question (#732 — order by sequence, measure from the rows' own domain
+timestamps); a dash's LAST drop is a **tail, not a gap** (its wait ran into the driver stopping); a
+pairing whose accept escapes the dash's own effective end (`COALESCE(endedAt, lastEventAt)`, the
+[sessionTotals]-shared definition) is incoherent and dropped. A gap ≥ `LONG_GAP_MILLIS` (2 h) is
+**counted and stated, never excluded** — the doc §3 names break-vs-dry-market as unresolvable
+on-device, so deleting the time would be a worse lie than reporting it unjudged. **Source: the
+read model, not `app_events`.** The brief points at the log, but `delivery_records.completedAt` /
+`offer_records.decidedAt` ARE those payloads' own domain timestamps and each row's PK IS its source
+event's `sequenceId`, so paging the log would re-decode JSON for identical numbers while
+re-implementing the session-anchored windowing (Principle 5). The accept side deliberately KEEPS a
+resolved orphan (#810 B2) unlike every other offer read: the row is not a count, it is the instant the
+driver stopped waiting, and dropping it would fuse two real gaps into one fabricated long one.
+(2) **The net/hr pair** (`NetPerHourPair`) is the doc §2a **active** / **scheduled** denominators under
+the brief's driver-facing labels *while working* / *whole shift* — the doc wins on definitions, the
+brief on wording. Whole-shift = Σ session durations (zero estimates, the doc's "Layer 0"); while-working
+= Σ per-delivery partition deltas **minus the measured gaps**, which is precisely why §7.8 feeds §6 (the
+delta already swallows the dry wait the doc excludes). Both residuals are one-sided and documented (a
+dash's pre-first-offer wait has no preceding completion, so it stays in the denominator), so the
+while-working rate is conservative by construction; the numerator is the window's own FROZEN net, shared
+with the recap hero. A missing denominator yields **null, never `$0.00/hr`** (#936 discipline).
+(3) **"Your typical online hour"** (`HourComposition`) splits the online span three ways: *at stops* = Σ
+pickup dwell (`confirmedAt−arrivedAt`) + Σ **door** dwell (`completedAt−arrivedAt`) — named "at stops"
+rather than the brief's "at store" because a doorstep is not a store; *waiting* = the §7.8 gaps (disjoint
+from dwell by construction — a gap runs completion→accept, a dwell sits inside a job); *the rest* = the
+residual, labelled "driving & other" and NEVER as pure driving, since it also holds the pre-first-offer
+wait, the post-last-drop tail, and every untimed stop. **Coverage is a field, not a footnote** (§9):
+`stopsTimed`/`stops` and `gapCount`/`completionsWithoutGap` ride the models, an untimed stop is never
+estimated from its neighbours (so at-stops is a floor), and the card states all three coverage
+states separately. The waiting leak is stated in dollars at the **while-working** rate (pricing it at the
+whole-shift rate would be circular — that rate already contains the idleness). Plumbing: `deliveryTimeTotals`
+gained door dwell + its coverage counters, new `pickupDwellTotals`/`completionEvents`/`acceptEvents`/
+`sessionEndBounds` DAO reads, `TimeEconomics` gained the dwell/stop fields (+ derived `atStopsMillis`/
+`stops`/`stopsTimed`), and `Percentiles.nearestRank` is now ONE owner for the #159 dwell p50/p95 and the
+new gap median/p90. **Stage-6 seam NOT backfilled:** brief §8's `NOT PICKED` "· gaps ran 14m" clause needs
+a **per-weekday, lifetime** gap median, while §7.8's stats are window-scoped — appending the one to the
+other would back a per-weekday claim with an all-week number (a §9 violation), and doing it properly needs
+a new grouped lifetime read plus a new `UnpickedDay` field and a `WeeklyPlanner` signature change. Left
+deliberately; the reason is recorded here rather than contorting stage 6.
 **The "(No session)" bucket (#660 piece 1):** `delivery_records` rows whose source event carried
 NO `sessionId` at all were already counted in net (`deliveryTotals`'s own-`completedAt` fallback, #655)
 but invisible to gross (`grossAndUnattributed`/`sessionGrossRows` iterate `session_records` only, so a

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -152,7 +152,13 @@ fun AnalyticsScreen(
                     )
                 }
 
-                AnalyticsTab.Time -> TimeTab(time = uiState.time, window = uiState.window)
+                AnalyticsTab.Time -> TimeTab(
+                    time = uiState.time,
+                    gaps = uiState.gaps,
+                    hourComposition = uiState.hourComposition,
+                    netPerHour = uiState.netPerHour,
+                    window = uiState.window,
+                )
 
                 // Patterns (H5) is LIFETIME-scoped (rate/pattern-based) — deliberately NO period selector.
                 AnalyticsTab.Patterns -> PatternsTab(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -11,6 +11,9 @@ import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
 import cloud.trotter.dashbuddy.domain.analytics.EstimateVsReality
+import cloud.trotter.dashbuddy.domain.analytics.GapStats
+import cloud.trotter.dashbuddy.domain.analytics.HourComposition
+import cloud.trotter.dashbuddy.domain.analytics.NetPerHourPair
 import cloud.trotter.dashbuddy.domain.analytics.OfferFilter
 import cloud.trotter.dashbuddy.domain.analytics.OfferListing
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
@@ -136,6 +139,22 @@ data class AnalyticsUiState(
     val estimateVsReality: EstimateVsReality = EstimateVsReality.EMPTY,
     /** Time / mileage economics for [window] — the Time tab (#315 H4, measured). */
     val time: TimeEconomics = TimeEconomics.EMPTY,
+    /**
+     * The window's between-job gaps (#983 / brief §7.8) — the Time tab's gap card. Measured from the
+     * read model's own domain timestamps, session-bounded (never across dashes).
+     */
+    val gaps: GapStats = GapStats.EMPTY,
+    /**
+     * "Your typical online hour" (#983 / brief §6) — composed at the ViewModel from [time] + [gaps],
+     * both of which describe this same window. Its KDoc is the authoritative derivation.
+     */
+    val hourComposition: HourComposition = HourComposition.EMPTY,
+    /**
+     * Net per hour **while working** vs **whole shift** (#983 / brief §6 `4c`) — the pair
+     * `docs/design/running-hourly-rate.md` §2a defines (its *active* / *scheduled* denominators).
+     * Composed at the ViewModel because its numerator is [economics]' frozen net, which has one owner.
+     */
+    val netPerHour: NetPerHourPair = NetPerHourPair.EMPTY,
     /**
      * Per-store report cards — the Patterns tab (#315 H5, #159), newest-visited first. **Lifetime-scoped**,
      * NOT period-filtered: the Patterns tab hides the period selector (it is rate/pattern-based).

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -13,6 +13,9 @@ import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.EstimateVsReality
+import cloud.trotter.dashbuddy.domain.analytics.GapStats
+import cloud.trotter.dashbuddy.domain.analytics.HourComposition
+import cloud.trotter.dashbuddy.domain.analytics.NetPerHourPair
 import cloud.trotter.dashbuddy.domain.analytics.OfferFilter
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
 import cloud.trotter.dashbuddy.domain.analytics.PayMix
@@ -104,7 +107,14 @@ class AnalyticsViewModel @Inject constructor(
                 analyticsRepository.periodEconomics(w),
                 analyticsRepository.perStoreEconomics(w),
                 analyticsRepository.decisionEconomics(w),
-                analyticsRepository.timeEconomics(w),
+                // The Time tab's two window reads travel as ONE slot: the "typical online hour"
+                // composition and the while-working denominator are BOTH (time × gaps), so a slot
+                // that could deliver one without the other would let the card render a composition
+                // against a different window's gaps for a frame (#983).
+                combine(
+                    analyticsRepository.timeEconomics(w),
+                    analyticsRepository.gapStats(w),
+                ) { time, gaps -> time to gaps },
                 // The typed `combine` tops out at 5 flows, so every remaining window-anchored read
                 // rides ONE nested pair of sub-combines into the 5th slot: the per-day chart + the
                 // "(No session)" orphan list (#660 piece 2) + the orphan-OFFER groups (#810 B2 Tier 2)
@@ -129,8 +139,8 @@ class AnalyticsViewModel @Inject constructor(
                 ) { (daily, orphans, offerGroups), (previous, payMixParts, platforms), estVsReality ->
                     WindowExtras(daily, orphans, offerGroups, previous, payMixParts, platforms, estVsReality)
                 },
-            ) { economics, stores, decisions, time, extras ->
-                WindowData(w, day, economics, stores, decisions, time, extras)
+            ) { economics, stores, decisions, timeAndGaps, extras ->
+                WindowData(w, day, economics, stores, decisions, timeAndGaps.first, timeAndGaps.second, extras)
             }
         },
         analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
@@ -158,6 +168,13 @@ class AnalyticsViewModel @Inject constructor(
             decisions = data.decisions,
             estimateVsReality = data.extras.estimateVsReality,
             time = data.time,
+            gaps = data.gaps,
+            // Composed HERE for the same reason the pay mix is (#973): both models need a value that
+            // already has an owner — the composition needs the window's measured time, the rate pair
+            // needs its FROZEN net — so composing at the read site is what keeps the Time tab
+            // reconciling with the hero above it instead of deriving a second total (Principle 5).
+            hourComposition = HourComposition.of(data.time, data.gaps),
+            netPerHour = NetPerHourPair.of(data.economics.netProfit, data.time, data.gaps),
             dailyEarnings = data.extras.dailyEarnings,
             noSessionDeliveries = data.extras.orphanDeliveries,
             orphanOfferGroups = data.extras.orphanOfferGroups,
@@ -390,6 +407,7 @@ class AnalyticsViewModel @Inject constructor(
         val stores: List<StoreEconomics>,
         val decisions: DecisionEconomics,
         val time: TimeEconomics,
+        val gaps: GapStats,
         val extras: WindowExtras,
     )
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeInsightCards.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeInsightCards.kt
@@ -1,0 +1,272 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppLegend
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegment
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStackBar
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.GapStats
+import cloud.trotter.dashbuddy.domain.analytics.HourComposition
+import cloud.trotter.dashbuddy.domain.analytics.NetPerHourPair
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatDuration
+
+/**
+ * The Time tab's #983 additions (brief §6 + §7.8) — the last stage of the #969 redesign, kept in their
+ * own file so `TimeTab.kt` stays the small host it was (Principle 3).
+ *
+ * Three cards, all pure data-in renderers over `:domain` models (Principle 1 — UDF), all MEASURED:
+ *
+ * 1. [NetPerHourPairCard] — the `while working` / `whole shift` pair that
+ *    `docs/design/running-hourly-rate.md` §2a defines and the app has never shown.
+ * 2. [TypicalOnlineHourCard] — where an online hour goes, with the waiting leak stated in dollars.
+ * 3. [GapsBetweenJobsCard] — the §7.8 gap distribution.
+ *
+ * **Honesty rules these cards implement (§9):** every derived figure states its population (how many
+ * stops were timed, how many gaps were measured, how many drops produced none), the residual segment
+ * is never labelled as pure driving, a long gap is counted but explicitly not judged as a break, and a
+ * figure with no measured denominator renders [EMPTY_VALUE] with a sentence saying so rather than a
+ * `$0.00` that would read as a measurement. Aggregate-only — durations, counts, dollars; no merchant
+ * or customer text (Principle 6). Every number routes through the [Formats] / [formatDuration] SSOT.
+ *
+ * Not a ticking surface: a review window's rates are fixed values, so no `rememberNow()` (same
+ * reasoning as the rest of the hub).
+ */
+@Composable
+fun NetPerHourPairCard(rates: NetPerHourPair, modifier: Modifier = Modifier) {
+    val c = AppTheme.colors
+    AppCard(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.time_tab_rate_pair_title),
+            style = MaterialTheme.typography.labelMedium,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(10.dp))
+
+        if (rates.onlineMillis <= 0L) {
+            EmptyRow(stringResource(R.string.time_tab_rate_none))
+            return@AppCard
+        }
+
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            AppStatTile(
+                label = stringResource(R.string.time_tab_rate_while_working),
+                value = rates.whileWorking?.let { "${Formats.money(it)}/hr" } ?: EMPTY_VALUE,
+                sub = rates.workingMillis.takeIf { it > 0L }?.let { formatDuration(it) },
+                modifier = Modifier.weight(1f),
+            )
+            AppStatTile(
+                label = stringResource(R.string.time_tab_rate_whole_shift),
+                value = rates.wholeShift?.let { "${Formats.money(it)}/hr" } ?: EMPTY_VALUE,
+                sub = formatDuration(rates.onlineMillis),
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+
+        // The doc's own distinction, in the brief's driver-facing words.
+        Caption(stringResource(R.string.time_tab_rate_distinction))
+
+        // How the working denominator was measured — including when no gap could be removed from it.
+        Spacer(Modifier.height(4.dp))
+        Caption(
+            if (rates.gapsSubtracted > 0) {
+                stringResource(
+                    R.string.time_tab_rate_gaps_note_format,
+                    Formats.commaInt(rates.gapsSubtracted),
+                    pluralGap(rates.gapsSubtracted),
+                )
+            } else {
+                stringResource(R.string.time_tab_rate_no_gaps_note)
+            },
+        )
+
+        if (rates.workingTimeUnmeasured) {
+            Spacer(Modifier.height(4.dp))
+            Caption(stringResource(R.string.time_tab_rate_working_unmeasured))
+        }
+
+        Spacer(Modifier.height(4.dp))
+        Caption(stringResource(R.string.time_tab_rate_frozen_note))
+    }
+}
+
+/**
+ * "Your typical online hour" (brief §6) — a 3-segment bar over the window's online time, scaled to one
+ * hour, plus the waiting leak in dollars.
+ *
+ * The segment labels follow [HourComposition]'s derivation, not the brief's shorthand: the brief says
+ * `driving / at store / waiting`, but the measured door dwell belongs with the store dwell (so the
+ * segment is "at stops") and the third segment is a residual that also holds unattributed time (so it
+ * is "driving & other", with a caption saying what else is in it). The alternative — labelling a
+ * residual "driving" — would be the one thing this surface must not do.
+ */
+@Composable
+fun TypicalOnlineHourCard(composition: HourComposition, rates: NetPerHourPair, modifier: Modifier = Modifier) {
+    val c = AppTheme.colors
+    AppCard(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.time_tab_typical_hour_title),
+            style = MaterialTheme.typography.labelMedium,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(10.dp))
+
+        if (!composition.hasData) {
+            EmptyRow(stringResource(R.string.time_tab_typical_hour_none))
+            return@AppCard
+        }
+
+        // Values are the shares scaled to one hour, so the bar IS the sentence "in a typical hour…".
+        val segments = listOf(
+            AppSegment(
+                label = stringResource(R.string.time_tab_segment_driving),
+                value = composition.restMillisPerHour.toFloat(),
+                color = c.neutral,
+                note = formatDuration(composition.restMillisPerHour),
+            ),
+            AppSegment(
+                label = stringResource(R.string.time_tab_segment_at_stops),
+                value = composition.atStopsMillisPerHour.toFloat(),
+                color = c.good,
+                note = formatDuration(composition.atStopsMillisPerHour),
+            ),
+            AppSegment(
+                label = stringResource(R.string.time_tab_segment_waiting),
+                value = composition.waitingMillisPerHour.toFloat(),
+                color = c.warn,
+                note = formatDuration(composition.waitingMillisPerHour),
+            ),
+        )
+        AppStackBar(segments, height = 14.dp)
+        Spacer(Modifier.height(10.dp))
+        AppLegend(segments)
+        Spacer(Modifier.height(12.dp))
+
+        // The leak, in dollars, priced at the while-working rate and scoped to this window (§9).
+        val leak = rates.valueOf(composition.waitingMillis)
+        Text(
+            text = if (leak == null) {
+                stringResource(R.string.time_tab_typical_hour_leak_unpriced)
+            } else {
+                stringResource(
+                    R.string.time_tab_typical_hour_leak_format,
+                    Formats.money(leak),
+                    formatDuration(composition.waitingMillis),
+                )
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = c.text,
+        )
+        Spacer(Modifier.height(8.dp))
+
+        Caption(stringResource(R.string.time_tab_typical_hour_derivation))
+        Spacer(Modifier.height(4.dp))
+        Caption(stopCoverageText(composition))
+    }
+}
+
+/** The §7.8 gap distribution — median / p90 / longest, with the population and the long-gap caveat. */
+@Composable
+fun GapsBetweenJobsCard(gaps: GapStats, modifier: Modifier = Modifier) {
+    val c = AppTheme.colors
+    AppCard(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.time_tab_gaps_title),
+            style = MaterialTheme.typography.labelMedium,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(10.dp))
+
+        if (!gaps.hasGaps) {
+            EmptyRow(stringResource(R.string.time_tab_gaps_none))
+            return@AppCard
+        }
+
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            AppStatTile(
+                label = stringResource(R.string.time_tab_gaps_median_label),
+                value = gaps.medianMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
+                modifier = Modifier.weight(1f),
+            )
+            AppStatTile(
+                label = stringResource(R.string.time_tab_gaps_p90_label),
+                value = gaps.p90Millis?.let { formatDuration(it) } ?: EMPTY_VALUE,
+                modifier = Modifier.weight(1f),
+            )
+            AppStatTile(
+                label = stringResource(R.string.time_tab_gaps_longest_label),
+                value = gaps.longestMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+
+        Caption(stringResource(R.string.time_tab_gaps_definition))
+        Spacer(Modifier.height(4.dp))
+        Caption(
+            stringResource(
+                R.string.time_tab_gaps_coverage_format,
+                Formats.commaInt(gaps.count),
+                pluralGap(gaps.count),
+                Formats.commaInt(gaps.completionsConsidered),
+            ),
+        )
+        if (gaps.longGapCount > 0) {
+            Spacer(Modifier.height(4.dp))
+            Caption(
+                stringResource(
+                    R.string.time_tab_gaps_long_format,
+                    Formats.commaInt(gaps.longGapCount),
+                    pluralGap(gaps.longGapCount),
+                ),
+            )
+        }
+    }
+}
+
+/**
+ * The at-stops coverage sentence — three states, because "we timed everything", "we timed most of it"
+ * and "we timed none of it" are three genuinely different claims and only the last one makes the
+ * segment meaningless (§9).
+ */
+@Composable
+private fun stopCoverageText(composition: HourComposition): String = when {
+    composition.stops == 0 -> stringResource(R.string.time_tab_typical_hour_no_stops)
+    composition.noStopsTimed -> stringResource(R.string.time_tab_typical_hour_no_stops_timed)
+    composition.allStopsTimed -> stringResource(
+        R.string.time_tab_typical_hour_all_timed_format,
+        Formats.commaInt(composition.stops),
+    )
+
+    else -> stringResource(
+        R.string.time_tab_typical_hour_coverage_format,
+        Formats.commaInt(composition.stopsTimed),
+        Formats.commaInt(composition.stops),
+    )
+}
+
+@Composable
+private fun pluralGap(count: Int): String =
+    if (count == 1) stringResource(R.string.time_tab_gap_singular)
+    else stringResource(R.string.time_tab_gap_plural)
+
+/** The tab's small explanatory line — one style, so every caption on these cards reads the same. */
+@Composable
+private fun Caption(text: String) {
+    Text(text = text, style = MaterialTheme.typography.bodySmall, color = AppTheme.colors.text3)
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -22,6 +22,9 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.text.EMPTY_VALUE
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsWindow
+import cloud.trotter.dashbuddy.domain.analytics.GapStats
+import cloud.trotter.dashbuddy.domain.analytics.HourComposition
+import cloud.trotter.dashbuddy.domain.analytics.NetPerHourPair
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.export.IrsMileage
 import cloud.trotter.dashbuddy.domain.format.Formats
@@ -32,9 +35,11 @@ import kotlin.math.roundToLong
 
 
 /**
- * Time tab (#315 H4): the measured time / mileage review for the selected period, top→bottom — the
- * online-time split (on-delivery vs unattributed), the deadhead ratio, the on-time gauge, and the
- * mileage-&-tax card. Pure data in ([TimeEconomics]), no side effects (Principle 1 — UDF).
+ * Time tab (#315 H4, extended by #983): the measured time / mileage review for the selected period,
+ * top→bottom — the online-time split (on-delivery vs unattributed), the #983 net/hr pair, "your
+ * typical online hour", the §7.8 gap distribution, the deadhead ratio, the on-time gauge, and the
+ * mileage-&-tax card. Pure data in ([TimeEconomics] / [GapStats] and the two models composed from
+ * them), no side effects (Principle 1 — UDF).
  *
  * **Everything here is MEASURED, not estimated** — session durations, per-delivery partition deltas,
  * odometer deltas — so there's no "est." qualifier and no economy dependency (this surface reports
@@ -47,11 +52,19 @@ import kotlin.math.roundToLong
 @Composable
 fun TimeTab(
     time: TimeEconomics,
+    gaps: GapStats,
+    hourComposition: HourComposition,
+    netPerHour: NetPerHourPair,
     window: AnalyticsWindow,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         TimeSplitCard(time)
+        // #983 (brief §6 + §7.8) — the running-hourly-rate doc's pair, where the hour goes, and the
+        // gaps that both of them are measured against. Rendered by `TimeInsightCards.kt`.
+        NetPerHourPairCard(netPerHour)
+        TypicalOnlineHourCard(hourComposition, netPerHour)
+        GapsBetweenJobsCard(gaps)
         DeadheadCard(time)
         OnTimeCard(time)
         MileageTaxCard(time, window)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,40 @@
     <string name="time_tab_delivery_plural">deliveries</string>
     <string name="time_tab_margin_early_format">typically %1$s early</string>
     <string name="time_tab_margin_late_format">typically %1$s late</string>
+    <!-- Time tab — #983 (brief §6 + §7.8): the running-hourly-rate pair, the typical online hour,
+         and the between-job gap distribution. Every line states its population; a residual is never
+         described as pure driving, and a long gap is counted, not judged (§9). -->
+    <string name="time_tab_rate_pair_title">NET PER HOUR</string>
+    <string name="time_tab_rate_while_working">While working</string>
+    <string name="time_tab_rate_whole_shift">Whole shift</string>
+    <string name="time_tab_rate_distinction">While working counts only the time you were on a delivery. Whole shift counts every minute you were online, including the dry gaps between offers.</string>
+    <string name="time_tab_rate_gaps_note_format">Working time is your delivery time minus %1$s measured %2$s between jobs.</string>
+    <string name="time_tab_rate_no_gaps_note">No gap was measured in this window, so working time still includes any waiting inside it — the while-working rate is if anything on the low side.</string>
+    <string name="time_tab_rate_working_unmeasured">No per-delivery time was measured here, so there is no while-working rate to show.</string>
+    <string name="time_tab_rate_frozen_note">Net is frozen at the costs that were in force when you accepted each offer.</string>
+    <string name="time_tab_rate_none">No online time in this window yet.</string>
+    <string name="time_tab_gap_singular">gap</string>
+    <string name="time_tab_gap_plural">gaps</string>
+    <string name="time_tab_typical_hour_title">YOUR TYPICAL ONLINE HOUR</string>
+    <string name="time_tab_typical_hour_none">No online time in this window yet.</string>
+    <string name="time_tab_segment_at_stops">At stops</string>
+    <string name="time_tab_segment_waiting">Waiting</string>
+    <string name="time_tab_segment_driving">Driving &amp; other</string>
+    <string name="time_tab_typical_hour_derivation">At stops is measured time parked at a store or at a door. Waiting is measured time between finishing a drop and taking your next offer. The rest is mostly driving — but it also holds the wait before your first offer, the tail after your last drop, and anything we could not time.</string>
+    <string name="time_tab_typical_hour_coverage_format">Timed %1$s of %2$s stops; the untimed ones sit in the rest.</string>
+    <string name="time_tab_typical_hour_all_timed_format">Timed all %1$s stops.</string>
+    <string name="time_tab_typical_hour_no_stops_timed">No stop in this window recorded an arrival, so at-stops time is unmeasured here — all of it sits in the rest.</string>
+    <string name="time_tab_typical_hour_no_stops">No stops in this window.</string>
+    <string name="time_tab_typical_hour_leak_format">Waiting cost you about %1$s in this window — %2$s at your while-working rate.</string>
+    <string name="time_tab_typical_hour_leak_unpriced">Waiting can\'t be priced here — no while-working rate was measured in this window.</string>
+    <string name="time_tab_gaps_title">GAPS BETWEEN JOBS</string>
+    <string name="time_tab_gaps_none">No gap measured in this window yet — a gap needs a completed drop and a later offer you took in the same dash.</string>
+    <string name="time_tab_gaps_median_label">Typical</string>
+    <string name="time_tab_gaps_p90_label">9 in 10 under</string>
+    <string name="time_tab_gaps_longest_label">Longest</string>
+    <string name="time_tab_gaps_definition">Measured from finishing a drop to accepting your next offer, inside the same dash.</string>
+    <string name="time_tab_gaps_coverage_format">%1$s %2$s measured across %3$s drops; the rest ended their dash, which is a tail rather than a gap.</string>
+    <string name="time_tab_gaps_long_format">%1$s %2$s ran 2 hours or longer. That could be a dry market or your own break — we can\'t tell which, so they are counted, not judged.</string>
     <string name="time_tab_mileage_tax_title">MILEAGE &amp; TAX</string>
     <string name="time_tab_mileage_tax_disclosure">standard-mileage method — not the app\'s operating-cost model; confirm with a tax preparer.</string>
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -10,6 +10,7 @@ import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
 import cloud.trotter.dashbuddy.domain.analytics.EstimateVsReality
+import cloud.trotter.dashbuddy.domain.analytics.GapStats
 import cloud.trotter.dashbuddy.domain.analytics.OfferFilter
 import cloud.trotter.dashbuddy.domain.analytics.OfferListing
 import cloud.trotter.dashbuddy.domain.analytics.OfferOutcome
@@ -93,6 +94,10 @@ class AnalyticsViewModelTest {
     private var payMixParts: PayMixParts = PayMixParts.EMPTY
     private var platformSplit: List<PlatformEconomics> = emptyList()
 
+    /** #983 — the Time tab's measured time + between-job gaps, served for every window. */
+    private var time: TimeEconomics = TimeEconomics.EMPTY
+    private var gaps: GapStats = GapStats.EMPTY
+
     /** #975 — the Offers tab's est-vs-realized comparison and its list feed, served for every window. */
     private var estimateVsReality: EstimateVsReality = EstimateVsReality.EMPTY
     private var offerListings: List<OfferListing> = emptyList()
@@ -121,7 +126,10 @@ class AnalyticsViewModelTest {
         whenever(analyticsRepository.decisionEconomics(any<AnalyticsWindow>(), any<ZoneId>()))
             .thenAnswer { flowOf(decisions) }
         whenever(analyticsRepository.timeEconomics(any<AnalyticsWindow>(), any<ZoneId>()))
-            .thenReturn(flowOf(TimeEconomics.EMPTY))
+            .thenAnswer { flowOf(time) }
+        // #983: the §7.8 gap read shares the Time tab's slot, so it must always be stubbed.
+        whenever(analyticsRepository.gapStats(any<AnalyticsWindow>(), any<ZoneId>()))
+            .thenAnswer { flowOf(gaps) }
         whenever(analyticsRepository.dailyEarnings(any<AnalyticsWindow>(), any<ZoneId>()))
             .thenAnswer { flowOf(dailyEarnings) }
         whenever(analyticsRepository.noSessionDeliveries(any<AnalyticsWindow>(), any<ZoneId>()))
@@ -463,6 +471,60 @@ class AnalyticsViewModelTest {
             assertEquals(5, ui.decisions.declined)
             assertEquals(0.3, ui.decisions.acceptanceRate!!, 1e-9)
             assertEquals(12.5, ui.decisions.declinedEstNet, 1e-9)
+        }
+    }
+
+    /**
+     * #983 — the Time tab's two composed models. The ViewModel is the composition site (the pay-mix
+     * precedent) because each needs a value that already has an owner: the hour composition needs the
+     * window's measured time, and the rate pair needs its FROZEN net. Asserting them here is what
+     * proves the Time tab reconciles with the hero above it rather than deriving a second total.
+     */
+    @Test
+    fun `time-tab insights compose the window's measured time, gaps and frozen net`() = runTest {
+        val hour = 3_600_000L
+        val minute = 60_000L
+        time = TimeEconomics(
+            sessions = 1,
+            onlineMillis = 4 * hour,
+            deliveryMinutes = 120.0,
+            miles = 40.0,
+            deliveryMiles = 30.0,
+            deliveriesWithDeadline = 0,
+            onTimeDeliveries = 0,
+            avgDeadlineMarginMillis = null,
+            deliveries = 4,
+            dropoffDwellMillis = 8 * minute,
+            dropoffsTimed = 4,
+            pickups = 4,
+            pickupDwellMillis = 22 * minute,
+            pickupsTimed = 3,
+        )
+        gaps = GapStats(
+            count = 3,
+            totalMillis = 24 * minute,
+            medianMillis = 8 * minute,
+            p90Millis = 12 * minute,
+            longestMillis = 12 * minute,
+            longGapCount = 0,
+            completionsWithoutGap = 1,
+        )
+        economicsByWindow[currentWeek()] = economics(net = 96.0, netPerHour = 24.0)
+
+        runWithViewModel { vm ->
+            val state = vm.uiState.value
+
+            assertEquals(gaps, state.gaps)
+            // At stops = 22m store + 8m door; waiting = the measured gaps.
+            assertEquals(30 * minute, state.hourComposition.atStopsMillis)
+            assertEquals(24 * minute, state.hourComposition.waitingMillis)
+            // 3 of 4 pickups + 4 of 4 drops timed, out of 8 stops — the coverage the card states.
+            assertEquals(7, state.hourComposition.stopsTimed)
+            assertEquals(8, state.hourComposition.stops)
+            // Working = 2h of delivery time − 24m of dry gaps = 1h36m; shift = the whole 4h online.
+            assertEquals(2 * hour - 24 * minute, state.netPerHour.workingMillis)
+            assertEquals(96.0 / 1.6, state.netPerHour.whileWorking!!, 1e-9)
+            assertEquals(24.0, state.netPerHour.wholeShift!!, 1e-9)
         }
     }
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -4,7 +4,9 @@ import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
 import cloud.trotter.dashbuddy.core.database.analytics.DeliveryTimeTotalsRow
 import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.OutcomeCountRow
+import cloud.trotter.dashbuddy.core.database.analytics.PickupDwellTotalsRow
 import cloud.trotter.dashbuddy.core.database.analytics.ScoreOutcomeRow
+import cloud.trotter.dashbuddy.core.database.analytics.SessionEventRow
 import cloud.trotter.dashbuddy.core.database.analytics.SessionTotalsRow
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
@@ -16,6 +18,7 @@ import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmapCalculator
 import cloud.trotter.dashbuddy.domain.analytics.EstimateVsReality
+import cloud.trotter.dashbuddy.domain.analytics.GapStats
 import cloud.trotter.dashbuddy.domain.analytics.HourOfWeekSampler
 import cloud.trotter.dashbuddy.domain.analytics.HourOfWeekSamples
 import cloud.trotter.dashbuddy.domain.analytics.OfferFilter
@@ -23,14 +26,17 @@ import cloud.trotter.dashbuddy.domain.analytics.OfferListing
 import cloud.trotter.dashbuddy.domain.analytics.OfferOutcome
 import cloud.trotter.dashbuddy.domain.analytics.PayMixParts
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.Percentiles
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.PlatformEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
+import cloud.trotter.dashbuddy.domain.analytics.SessionEvent
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.SessionSpan
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
+import cloud.trotter.dashbuddy.domain.analytics.WorkGaps
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferCandidate
 import cloud.trotter.dashbuddy.domain.analytics.OrphanOfferGroup
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
@@ -41,7 +47,6 @@ import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.StoreKeys
 import java.time.Instant
 import java.time.ZoneId
-import kotlin.math.ceil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -328,8 +333,10 @@ class AnalyticsRepository @Inject constructor(
                     gross = r.gross,
                     net = r.net,
                     avgDwellMillis = sorted.takeIf { it.isNotEmpty() }?.average(),
-                    p50DwellMillis = percentile(sorted, 0.50),
-                    p95DwellMillis = percentile(sorted, 0.95),
+                    // Nearest-rank, shared with the #983 gap percentiles (Principle 5 — one
+                    // percentile convention, two readers).
+                    p50DwellMillis = Percentiles.nearestRank(sorted, 0.50),
+                    p95DwellMillis = Percentiles.nearestRank(sorted, 0.95),
                     firstSeenAt = r.firstSeenAt,
                     lastSeenAt = r.lastSeenAt,
                 )
@@ -553,8 +560,56 @@ class AnalyticsRepository @Inject constructor(
             combine(
                 analyticsDao.sessionTotals(start, end),
                 analyticsDao.deliveryTimeTotals(start, end),
-            ) { s, d -> assembleTime(s, d) }
+                analyticsDao.pickupDwellTotals(start, end),
+            ) { s, d, p -> assembleTime(s, d, p) }
         }
+
+    /**
+     * The window's **between-job gaps** (#983 / brief §7.8) — how long the driver sat between finishing
+     * a drop and taking the next offer. Feeds the Time tab's gap card, the "typical online hour"
+     * waiting segment, and the while-working denominator of the net/hr pair.
+     *
+     * **Read-model, not the event log.** The brief points at `app_events`; the two facts the fold needs
+     * are already projected — `delivery_records.completedAt` and `offer_records.decidedAt` ARE those
+     * payloads' own domain timestamps, and each row's PK IS its source event's `sequenceId`. Paging the
+     * log would re-decode JSON for the same two numbers and re-implement the session-anchored windowing
+     * every other aggregate here shares, so the read model is both cheaper and the SSOT (Principle 5).
+     * The #732 ordering contract is honoured either way: the DAO orders by `sequenceId` and the pure
+     * [WorkGaps] fold measures durations from the domain timestamps.
+     *
+     * The pairing/clamping policy lives entirely in the pure `:domain` [WorkGaps] (never across dashes,
+     * the tail is not a gap, bounded by the dash's own effective end) — this repository only supplies
+     * rows. Off-main ([Dispatchers.Default]) like the heatmap folds, since a Lifetime window's row set
+     * is unbounded by construction; [distinctUntilChanged] suppresses re-emitting identical stats on an
+     * unrelated Room invalidation.
+     *
+     * No economy dependency, no new PII surface: timestamps, ids and counts only.
+     */
+    fun gapStats(
+        window: AnalyticsWindow,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Flow<GapStats> = gapStatsIn(flowOf(PeriodBounds.of(window, zone)))
+
+    /** Rolling-period variant of [gapStats] (the enum path, for parity with every other aggregate). */
+    fun gapStats(period: AnalyticsPeriod): Flow<GapStats> = gapStatsIn(periodBoundariesFlow(period))
+
+    private fun gapStatsIn(bounds: Flow<PeriodBounds.Bounds>): Flow<GapStats> =
+        bounds.flatMapLatest { (start, end) ->
+            combine(
+                analyticsDao.completionEvents(start, end),
+                analyticsDao.acceptEvents(start, end, OfferOutcome.ACCEPTED.eventTypeName),
+                analyticsDao.sessionEndBounds(start, end),
+            ) { completions, accepts, ends ->
+                WorkGaps.compute(
+                    completions = completions.map { it.toDomain() },
+                    accepts = accepts.map { it.toDomain() },
+                    sessionEndMillis = ends.associate { it.sessionId to it.endMillis },
+                )
+            }
+        }.flowOn(Dispatchers.Default).distinctUntilChanged()
+
+    private fun SessionEventRow.toDomain() =
+        SessionEvent(sessionId = sessionId, sequenceId = sequenceId, timestamp = timestamp)
 
     /**
      * Per-day earnings for [period] (#315 H6, Money-tab chart) — a **complete day axis**: one
@@ -939,20 +994,10 @@ class AnalyticsRepository @Inject constructor(
      * derived split ([TimeEconomics.unattributedMillis]/[TimeEconomics.unattributedMiles] etc.) is the
      * DTO's own coerce-≥0 helper, so this repository stores no second copy of that math (Principle 5).
      */
-    /**
-     * The [p]-th percentile of an ASCENDING-sorted dwell list (#159 store report card) — nearest-rank
-     * (SQLite has no native percentile and store visit counts are small, so an exact in-Kotlin nearest-
-     * rank is honest and cheap). Null on an empty list. `p ∈ [0,1]`.
-     */
-    private fun percentile(sorted: List<Long>, p: Double): Long? {
-        if (sorted.isEmpty()) return null
-        val rank = ceil(p * sorted.size).toInt().coerceIn(1, sorted.size)
-        return sorted[rank - 1]
-    }
-
     private fun assembleTime(
         session: SessionTotalsRow,
         delivery: DeliveryTimeTotalsRow,
+        pickup: PickupDwellTotalsRow,
     ): TimeEconomics = TimeEconomics(
         sessions = session.sessions,
         onlineMillis = session.onlineMillis,
@@ -962,6 +1007,12 @@ class AnalyticsRepository @Inject constructor(
         deliveriesWithDeadline = delivery.withDeadline,
         onTimeDeliveries = delivery.onTime,
         avgDeadlineMarginMillis = delivery.avgDeadlineMarginMillis,
+        deliveries = delivery.deliveries,
+        dropoffDwellMillis = delivery.dropoffDwellMillis,
+        dropoffsTimed = delivery.dropoffsTimed,
+        pickups = pickup.pickups,
+        pickupDwellMillis = pickup.dwellMillis,
+        pickupsTimed = pickup.timed,
     )
 
     /**

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsTimeInsightReadsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsTimeInsightReadsTest.kt
@@ -1,0 +1,357 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.PickupRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.OfferOutcome
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #983 / brief §6 + §7.8 — the Time-tab insight reads over an in-memory database. Proves:
+ *
+ *  - the §7.8 gap sources are **session-anchored** (#655) exactly like every other window aggregate,
+ *    and — uniquely — carry NO null-session fallback, because a dash-less row has no dash to sit
+ *    inside;
+ *  - the end-to-end `gapStats` fold measures a gap inside a dash, refuses one that would span two,
+ *    and counts a dash's last drop as a tail rather than a gap;
+ *  - the accept side deliberately KEEPS a resolved orphan (#810 B2), unlike the funnel reads, because
+ *    the row marks the instant the driver stopped waiting;
+ *  - dwell sums cover only the stops that stamped their timestamps, with the coverage counters that
+ *    let the surface say so;
+ *  - the whole thing composes into a [cloud.trotter.dashbuddy.domain.analytics.TimeEconomics] whose
+ *    at-stops total is the two dwell sums.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsTimeInsightReadsTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    private val base = 1_600_000_000_000L
+    private val minute = 60_000L
+    private val hour = 3_600_000L
+    private val day = 86_400_000L
+    private val accepted = OfferOutcome.ACCEPTED.eventTypeName
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao, db.appEventDao())
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    // ── fixtures ────────────────────────────────────────────────────────
+
+    private fun session(
+        id: String,
+        startedAt: Long,
+        onlineMillis: Long = 4 * hour,
+    ) = SessionRecordEntity(
+        sessionId = id,
+        platform = "doordash",
+        startedAt = startedAt,
+        endedAt = startedAt + onlineMillis,
+        lastEventAt = startedAt + onlineMillis,
+        endSource = "summary_screen",
+        startOdometer = 0.0,
+        lastOdometer = 20.0,
+        reportedEarnings = null,
+        reportedDurationMillis = onlineMillis,
+        offersReceived = 0,
+        offersAccepted = 0,
+        offersDeclined = 0,
+        offersTimeout = 0,
+        deliveries = 0,
+        jobsCompleted = 0,
+    )
+
+    private fun delivery(
+        seq: Long,
+        sessionId: String?,
+        completedAt: Long,
+        arrivedAt: Long? = null,
+        realizedMinutes: Double? = 20.0,
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = "doordash",
+        jobId = "job-$seq",
+        taskId = "task-$seq",
+        storeName = "Wendys",
+        customerHash = null,
+        addressHash = null,
+        phaseStartedAt = completedAt - 10 * minute,
+        arrivedAt = arrivedAt,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = 9.0,
+        payBasis = "DROP_SHARE",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = 3.0,
+        realizedMinutes = realizedMinutes,
+        frozenCostPerMile = null,
+        netProfit = 6.0,
+        costBasis = "NONE",
+    )
+
+    private fun offer(
+        seq: Long,
+        sessionId: String?,
+        decidedAt: Long,
+        outcome: String = accepted,
+        outcomeResolved: String? = null,
+    ) = OfferRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = "doordash",
+        offerHash = "hash-$seq",
+        outcome = outcome,
+        presentedAt = decidedAt - 20_000,
+        decidedAt = decidedAt,
+        payAmount = 9.0,
+        distanceMiles = 3.0,
+        itemCount = 1,
+        merchantName = "Wendys",
+        score = null,
+        action = null,
+        quality = null,
+        estNetPay = 7.0,
+        estDollarsPerHour = 21.0,
+        estDollarsPerMile = null,
+        estTimeMinutes = 20.0,
+        estOperatingCostPerMile = 0.3,
+        outcomeResolved = outcomeResolved,
+    )
+
+    private fun pickup(
+        seq: Long,
+        sessionId: String?,
+        phaseStartedAt: Long,
+        arrivedAt: Long?,
+        confirmedAt: Long?,
+    ) = PickupRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = "doordash",
+        jobId = "job-$seq",
+        taskId = "task-$seq",
+        storeName = "Wendys",
+        storeKey = null,
+        phaseStartedAt = phaseStartedAt,
+        arrivedAt = arrivedAt,
+        confirmedAt = confirmedAt,
+        deadlineMillis = null,
+        activity = null,
+    )
+
+    // ── §7.8 gap sources ────────────────────────────────────────────────
+
+    /** A dash that started yesterday keeps its rows out of today's window (session-anchored, #655). */
+    @Test
+    fun `gap sources are session-anchored, never bucketed by their own timestamp`() = runBlocking {
+        val todayStart = base
+        val sessionStart = todayStart - 10 * minute       // 23:50 yesterday
+        dao.upsertSession(session("Y", sessionStart))
+        dao.upsertDelivery(delivery(1, "Y", completedAt = todayStart + 10 * minute))
+        dao.upsertOffer(offer(2, "Y", decidedAt = todayStart + 20 * minute))
+
+        assertTrue(dao.completionEvents(todayStart, todayStart + day).first().isEmpty())
+        assertTrue(dao.acceptEvents(todayStart, todayStart + day, accepted).first().isEmpty())
+
+        val yesterday = dao.completionEvents(todayStart - day, todayStart).first()
+        assertEquals(1, yesterday.size)
+        assertEquals("Y", yesterday.first().sessionId)
+        assertEquals(1L, yesterday.first().sequenceId)
+        assertEquals(todayStart + 10 * minute, yesterday.first().timestamp)
+        assertEquals(1, dao.acceptEvents(todayStart - day, todayStart, accepted).first().size)
+    }
+
+    /** The one aggregate with NO null-session fallback: an orphan row has no dash to sit inside. */
+    @Test
+    fun `a session-less row contributes no gap source`() = runBlocking {
+        dao.upsertDelivery(delivery(1, sessionId = null, completedAt = base + hour))
+        dao.upsertOffer(offer(2, sessionId = null, decidedAt = base + 2 * hour))
+
+        assertTrue(dao.completionEvents(0, Long.MAX_VALUE).first().isEmpty())
+        assertTrue(dao.acceptEvents(0, Long.MAX_VALUE, accepted).first().isEmpty())
+        assertEquals(0, repo.gapStats(AnalyticsPeriod.LIFETIME).first().count)
+    }
+
+    /** Only accepted offers are "back to work"; a decline or a timeout is not. */
+    @Test
+    fun `only accepted offers are gap ends`() = runBlocking {
+        dao.upsertSession(session("A", base))
+        dao.upsertOffer(offer(2, "A", decidedAt = base + hour, outcome = "OFFER_DECLINED"))
+        dao.upsertOffer(offer(3, "A", decidedAt = base + hour, outcome = "OFFER_TIMEOUT"))
+        dao.upsertOffer(offer(4, "A", decidedAt = base + hour))
+
+        val rows = dao.acceptEvents(0, Long.MAX_VALUE, accepted).first()
+        assertEquals(1, rows.size)
+        assertEquals(4L, rows.first().sequenceId)
+    }
+
+    /**
+     * Documented divergence from every other offer read (#810 B2): a resolved orphan is EXCLUDED from
+     * the funnel counts but KEPT here, because it still marks the instant the driver stopped waiting.
+     * Dropping it would fuse two real gaps into one fabricated long one.
+     */
+    @Test
+    fun `a resolved orphan still ends its gap`() = runBlocking {
+        dao.upsertSession(session("A", base))
+        dao.upsertDelivery(delivery(1, "A", completedAt = base + hour))
+        dao.upsertOffer(offer(2, "A", decidedAt = base + hour + 7 * minute, outcomeResolved = "UNASSIGNED_ATTESTED"))
+        dao.upsertDelivery(delivery(3, "A", completedAt = base + 2 * hour))
+        dao.upsertOffer(offer(4, "A", decidedAt = base + 2 * hour + 5 * minute))
+
+        // The funnel read drops the orphan…
+        val outcomes = dao.offerOutcomes(0, Long.MAX_VALUE).first()
+        assertEquals(1, outcomes.sumOf { it.count })
+        // …the gap read keeps it, so both gaps are measured at their real length.
+        val stats = repo.gapStats(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(2, stats.count)
+        assertEquals(12 * minute, stats.totalMillis)
+    }
+
+    // ── the end-to-end fold ─────────────────────────────────────────────
+
+    @Test
+    fun `a dash measures its inner gaps and treats its last drop as a tail`() = runBlocking {
+        dao.upsertSession(session("A", base))
+        dao.upsertDelivery(delivery(1, "A", completedAt = base + hour))
+        dao.upsertOffer(offer(2, "A", decidedAt = base + hour + 9 * minute))
+        dao.upsertDelivery(delivery(3, "A", completedAt = base + 2 * hour))   // last drop of the dash
+
+        val stats = repo.gapStats(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(1, stats.count)
+        assertEquals(9 * minute, stats.totalMillis)
+        assertEquals(9 * minute, stats.medianMillis)
+        assertEquals(1, stats.completionsWithoutGap)
+        assertEquals(2, stats.completionsConsidered)
+    }
+
+    @Test
+    fun `a gap is never measured across two dashes`() = runBlocking {
+        dao.upsertSession(session("MON", base))
+        dao.upsertSession(session("TUE", base + day))
+        dao.upsertDelivery(delivery(1, "MON", completedAt = base + hour))
+        // The next accept the driver made was the following day, in a different dash.
+        dao.upsertOffer(offer(2, "TUE", decidedAt = base + day + 10 * minute))
+
+        val stats = repo.gapStats(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(0, stats.count)
+        assertEquals(1, stats.completionsWithoutGap)
+        assertFalse(stats.hasGaps)
+        assertNull(stats.medianMillis)
+    }
+
+    /** An accept stamped after its own dash's effective end is incoherent — dropped, not measured. */
+    @Test
+    fun `an accept past its dash's end is not a gap`() = runBlocking {
+        dao.upsertSession(session("A", base, onlineMillis = hour))
+        dao.upsertDelivery(delivery(1, "A", completedAt = base + 30 * minute))
+        dao.upsertOffer(offer(2, "A", decidedAt = base + 5 * hour))   // long after endedAt
+
+        assertEquals(0, repo.gapStats(AnalyticsPeriod.LIFETIME).first().count)
+    }
+
+    // ── dwell (the "at stops" segment) ──────────────────────────────────
+
+    @Test
+    fun `dwell sums only the stops that stamped their timestamps, and states coverage`() = runBlocking {
+        dao.upsertSession(session("A", base))
+        // Pickups: one timed (14m), one arrival-less, one never confirmed.
+        dao.upsertPickup(pickup(10, "A", base + hour, arrivedAt = base + hour, confirmedAt = base + hour + 14 * minute))
+        dao.upsertPickup(pickup(11, "A", base + 2 * hour, arrivedAt = null, confirmedAt = base + 2 * hour))
+        dao.upsertPickup(pickup(12, "A", base + 3 * hour, arrivedAt = base + 3 * hour, confirmedAt = null))
+        // Drops: one timed (6m), one with no arrival stamp.
+        dao.upsertDelivery(delivery(1, "A", completedAt = base + 90 * minute, arrivedAt = base + 84 * minute))
+        dao.upsertDelivery(delivery(2, "A", completedAt = base + 150 * minute, arrivedAt = null))
+
+        val pickups = dao.pickupDwellTotals(0, Long.MAX_VALUE).first()
+        assertEquals(14 * minute, pickups.dwellMillis)
+        assertEquals(1, pickups.timed)
+        assertEquals(3, pickups.pickups)
+
+        val drops = dao.deliveryTimeTotals(0, Long.MAX_VALUE).first()
+        assertEquals(6 * minute, drops.dropoffDwellMillis)
+        assertEquals(1, drops.dropoffsTimed)
+        assertEquals(2, drops.deliveries)
+
+        val time = repo.timeEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(20 * minute, time.atStopsMillis)   // 14 store + 6 door
+        assertEquals(2, time.stopsTimed)
+        assertEquals(5, time.stops)                     // 3 pickups + 2 drops
+    }
+
+    /** A pickup whose confirmation precedes its arrival is incoherent — dropped, never negative. */
+    @Test
+    fun `an incoherent dwell pair contributes nothing`() = runBlocking {
+        dao.upsertSession(session("A", base))
+        dao.upsertPickup(pickup(10, "A", base + hour, arrivedAt = base + hour, confirmedAt = base + hour - minute))
+        dao.upsertDelivery(delivery(1, "A", completedAt = base + hour, arrivedAt = base + hour + minute))
+
+        assertEquals(0L, dao.pickupDwellTotals(0, Long.MAX_VALUE).first().dwellMillis)
+        assertEquals(0, dao.pickupDwellTotals(0, Long.MAX_VALUE).first().timed)
+        assertEquals(0L, dao.deliveryTimeTotals(0, Long.MAX_VALUE).first().dropoffDwellMillis)
+    }
+
+    /** Pickup dwell is session-anchored, with the null-session fallback keyed on `phaseStartedAt`. */
+    @Test
+    fun `pickup dwell is session-anchored with a phaseStartedAt fallback`() = runBlocking {
+        val todayStart = base
+        dao.upsertSession(session("Y", todayStart - 10 * minute))
+        dao.upsertPickup(
+            pickup(10, "Y", todayStart + 10 * minute, arrivedAt = todayStart + 10 * minute, confirmedAt = todayStart + 15 * minute),
+        )
+        // A session-less pickup buckets by its own phaseStartedAt.
+        dao.upsertPickup(
+            pickup(11, null, todayStart + hour, arrivedAt = todayStart + hour, confirmedAt = todayStart + hour + 2 * minute),
+        )
+
+        val today = dao.pickupDwellTotals(todayStart, todayStart + day).first()
+        assertEquals(2 * minute, today.dwellMillis)   // the orphan only
+        assertEquals(1, today.pickups)
+
+        val yesterday = dao.pickupDwellTotals(todayStart - day, todayStart).first()
+        assertEquals(5 * minute, yesterday.dwellMillis)   // the session-anchored one only
+        assertEquals(1, yesterday.pickups)
+    }
+
+    @Test
+    fun `an empty window measures nothing rather than fabricating zeroes`() = runBlocking {
+        val stats = repo.gapStats(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(0, stats.count)
+        assertNull(stats.medianMillis)
+        assertNull(stats.p90Millis)
+        assertNull(stats.longestMillis)
+
+        val time = repo.timeEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(0L, time.atStopsMillis)
+        assertEquals(0, time.stops)
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -774,19 +774,130 @@ interface AnalyticsDao {
      * never counted as late), and [avgDeadlineMarginMillis] averages `deadline − completedAt` over just
      * those rows (positive = typically early; NULL when none carried a deadline — `AVG` skips the null
      * CASE arms).
+     *
+     * **Door dwell (#983 / brief §6):** [dropoffDwellMillis] sums `completedAt − arrivedAt` over the
+     * rows that stamped an arrival at all, and [dropoffsTimed] counts them, so the "your typical online
+     * hour" segment can state its coverage instead of implying every drop was timed (§9). The
+     * `completedAt >= arrivedAt` guard drops an incoherent pair rather than contributing a negative
+     * dwell. [deliveries] is the population's own COUNT — the coverage denominator, taken here rather
+     * than from another query so it can never describe a different set of rows than the dwell above it.
      */
     @Query(
         """SELECT SUM(realizedMinutes) AS deliveryMinutes,
                   SUM(realizedMiles) AS deliveryMiles,
                   COALESCE(SUM(CASE WHEN deadlineMillis IS NOT NULL THEN 1 ELSE 0 END), 0) AS withDeadline,
                   COALESCE(SUM(CASE WHEN deadlineMillis IS NOT NULL AND completedAt <= deadlineMillis THEN 1 ELSE 0 END), 0) AS onTime,
-                  AVG(CASE WHEN deadlineMillis IS NOT NULL THEN deadlineMillis - completedAt END) AS avgDeadlineMarginMillis
+                  AVG(CASE WHEN deadlineMillis IS NOT NULL THEN deadlineMillis - completedAt END) AS avgDeadlineMarginMillis,
+                  COUNT(*) AS deliveries,
+                  COALESCE(SUM(CASE WHEN arrivedAt IS NOT NULL AND completedAt >= arrivedAt
+                                    THEN completedAt - arrivedAt ELSE 0 END), 0) AS dropoffDwellMillis,
+                  COALESCE(SUM(CASE WHEN arrivedAt IS NOT NULL AND completedAt >= arrivedAt
+                                    THEN 1 ELSE 0 END), 0) AS dropoffsTimed
            FROM delivery_records
            WHERE sessionId IN (SELECT sessionId FROM session_records
                                WHERE startedAt >= :start AND startedAt < :end)
               OR (sessionId IS NULL AND completedAt >= :start AND completedAt < :end)"""
     )
     fun deliveryTimeTotals(start: Long, end: Long): Flow<DeliveryTimeTotalsRow>
+
+    /**
+     * Store dwell for the window's pickups (#983 / brief §6) — the other half of the "at stops"
+     * segment. Σ `confirmedAt − arrivedAt` over the pickups that stamped both, the count of those, and
+     * the population's own COUNT as the coverage denominator.
+     *
+     * Session-anchored like every other window aggregate (#655), with the null-session fallback keyed
+     * on [PickupRecordEntity.phaseStartedAt] — the pickup table's only non-null instant (its
+     * `confirmedAt` is nullable, so keying the fallback on it would silently exclude exactly the rows
+     * the coverage denominator exists to count).
+     *
+     * The same `confirmedAt >= arrivedAt` guard as [storeDwellSamples] — an incoherent pair is dropped,
+     * never summed as a negative dwell.
+     */
+    @Query(
+        """SELECT COALESCE(SUM(CASE WHEN arrivedAt IS NOT NULL AND confirmedAt IS NOT NULL
+                                         AND confirmedAt >= arrivedAt
+                                    THEN confirmedAt - arrivedAt ELSE 0 END), 0) AS dwellMillis,
+                  COALESCE(SUM(CASE WHEN arrivedAt IS NOT NULL AND confirmedAt IS NOT NULL
+                                         AND confirmedAt >= arrivedAt
+                                    THEN 1 ELSE 0 END), 0) AS timed,
+                  COUNT(*) AS pickups
+           FROM pickup_records
+           WHERE sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+              OR (sessionId IS NULL AND phaseStartedAt >= :start AND phaseStartedAt < :end)"""
+    )
+    fun pickupDwellTotals(start: Long, end: Long): Flow<PickupDwellTotalsRow>
+
+    // ── §7.8 gap sources (#983) ─────────────────────────────────────────
+
+    /**
+     * Every completed delivery of the window's dashes as a `(sessionId, sequenceId, completedAt)`
+     * triple — the "from" side of the §7.8 gap fold (#983).
+     *
+     * **Read-model, not the log.** Brief §7.8 says "the events exist in the log"; they also exist,
+     * already decoded and already bucketed, in `delivery_records` / `offer_records`, whose
+     * `completedAt` / `decidedAt` ARE the payloads' own domain timestamps and whose PK IS the source
+     * event's `sequenceId`. Paging `app_events` would re-decode JSON to recover the same two numbers
+     * while re-implementing the session-anchored windowing — strictly more work for an identical
+     * answer, so the read model wins (Principle 5).
+     *
+     * `ORDER BY sessionId, eventSequenceId` hands the pure fold rows already in **sequence** order,
+     * which is the authoritative order key (#732 — `occurredAt` may lag, `sequenceId` never does).
+     *
+     * **Session-scoped only, deliberately:** a `sessionId IS NULL` orphan has no dash to sit inside, so
+     * it contributes nothing (a gap that spans two dashes or an overnight is not a gap — see
+     * [cloud.trotter.dashbuddy.domain.analytics.WorkGaps]). This is the ONE window aggregate without a
+     * null-session fallback, and that is the definition, not an oversight.
+     */
+    @Query(
+        """SELECT sessionId, eventSequenceId AS sequenceId, completedAt AS timestamp
+           FROM delivery_records
+           WHERE sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+           ORDER BY sessionId, eventSequenceId"""
+    )
+    fun completionEvents(start: Long, end: Long): Flow<List<SessionEventRow>>
+
+    /**
+     * Every ACCEPTED offer of the window's dashes as a `(sessionId, sequenceId, decidedAt)` triple —
+     * the "to" side of the §7.8 gap fold (#983). Same session scoping and same sequence ordering as
+     * [completionEvents].
+     *
+     * **Includes resolved orphans, unlike every other offer read.** The funnel/list reads exclude
+     * `outcomeResolved IS NOT NULL` (#810 B2) because a resolved orphan never delivered and would
+     * inflate an outcome COUNT. Here the row is not a count — it is the *instant the driver stopped
+     * waiting*, which happened regardless of what became of the job. Excluding it would silently fuse
+     * two real gaps into one long fabricated one, which is a worse lie than counting an accept whose
+     * job later vanished. Documented divergence, deliberate.
+     *
+     * [acceptedOutcome] is passed in so the stored `AppEventType` name keeps one owner
+     * (`OfferOutcome.ACCEPTED.eventTypeName`) rather than being inlined as a literal (Principle 8).
+     */
+    @Query(
+        """SELECT sessionId, eventSequenceId AS sequenceId, decidedAt AS timestamp
+           FROM offer_records
+           WHERE outcome = :acceptedOutcome
+             AND sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+           ORDER BY sessionId, eventSequenceId"""
+    )
+    fun acceptEvents(start: Long, end: Long, acceptedOutcome: String): Flow<List<SessionEventRow>>
+
+    /**
+     * Each in-window dash's effective end (#983) — the §7.8 fold's bound: a pairing whose accept lands
+     * after its own dash ended is incoherent and is dropped rather than measured.
+     *
+     * `COALESCE(endedAt, lastEventAt)` is the SAME effective-end definition [sessionTotals] uses for
+     * online duration and [sessionSpans] for the heatmap, so a still-open dash is bounded by its last
+     * observed event rather than treated as running forever (Principle 5 — one definition of "when the
+     * dash ended", three readers).
+     */
+    @Query(
+        """SELECT sessionId, COALESCE(endedAt, lastEventAt) AS endMillis
+           FROM session_records
+           WHERE startedAt >= :start AND startedAt < :end"""
+    )
+    fun sessionEndBounds(start: Long, end: Long): Flow<List<SessionEndRow>>
 
     // ── Patterns-tab heatmap reads (#315 H5) ────────────────────────────
 

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -276,6 +276,47 @@ data class DeliveryTimeTotalsRow(
     val withDeadline: Int,
     val onTime: Int,
     val avgDeadlineMarginMillis: Double?,
+    /** COUNT of the population — the door-dwell coverage denominator (#983). */
+    val deliveries: Int = 0,
+    /** Σ `completedAt − arrivedAt` over arrival-stamped rows — measured door time (#983). */
+    val dropoffDwellMillis: Long = 0L,
+    /** How many rows carried a usable arrival stamp — the coverage numerator (#983). */
+    val dropoffsTimed: Int = 0,
+)
+
+/**
+ * Store-dwell aggregate for a window's pickups (#983 / brief §6) — Σ `confirmedAt − arrivedAt` over the
+ * pickups that stamped both, how many those were ([timed]), and the population's own COUNT ([pickups]).
+ *
+ * [timed] < [pickups] is the NORMAL case (a pickup that never stamped an arrival still happened), which
+ * is why the coverage counter travels with the sum: the "typical online hour" surface states it rather
+ * than implying every stop was measured (§9).
+ */
+data class PickupDwellTotalsRow(
+    val dwellMillis: Long,
+    val timed: Int,
+    val pickups: Int,
+)
+
+/**
+ * One session-scoped read-model row reduced to `(sessionId, sequenceId, timestamp)` — the §7.8 gap
+ * fold's input (#983), for both the completion side (`delivery_records.completedAt`) and the accept
+ * side (`offer_records.decidedAt`).
+ *
+ * [sequenceId] is the source event's `sequenceId` (each table's PK) and orders the fold; [timestamp] is
+ * the row's own domain timestamp and measures the duration — the #732 contract's two halves kept
+ * distinct all the way down to the DTO.
+ */
+data class SessionEventRow(
+    val sessionId: String,
+    val sequenceId: Long,
+    val timestamp: Long,
+)
+
+/** One in-window dash's effective end (`COALESCE(endedAt, lastEventAt)`) — the §7.8 fold's bound (#983). */
+data class SessionEndRow(
+    val sessionId: String,
+    val endMillis: Long,
 )
 
 /**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,29 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — #983 — Time tab: the two hourly rates, your typical online hour, gap stats
+  (redesign stage 7/7 — the epic's last build).** Analytics → **Time**, after a dash or two.
+  Four things to check.
+  (a) **NET PER HOUR** shows two tiles: *While working* and *Whole shift*, each with its own
+  duration underneath. **While working must never be lower than whole shift** — same money over a
+  smaller denominator. If they are identical, read the line under them: it should say no gap was
+  measured in this window (which is itself a finding — see (c)). The sentence between them explains
+  the difference; the last line must still say net is frozen at accept-time costs.
+  (b) **YOUR TYPICAL ONLINE HOUR** is a 3-segment bar (driving & other / at stops / waiting) whose
+  three chunks add up to one hour. Sanity-check it against the dash you just did: if you spent most
+  of an hour parked at a Walmart, *at stops* should be the fat segment. Under it, a dollar line —
+  `Waiting cost you about $X in this window` — and a coverage line saying how many of your stops
+  were timed. **The coverage line is the one to watch**: if it says "no stop recorded an arrival",
+  the arrival stamps aren't landing and the segment is meaningless (report it).
+  (c) **GAPS BETWEEN JOBS** — typical / 9-in-10-under / longest, plus `N gaps measured across M
+  drops`. Compare *typical* against your gut for that dash. Two failure shapes to catch: a gap that
+  looks like it spans **two different dashes** (impossible by design — the fold refuses it, so
+  seeing one means the session ids are wrong), and `0 gaps measured` on a dash where you clearly
+  waited between orders (means accepts or completions aren't being recorded in-session).
+  (d) **Page the window** (‹ ›) and confirm every figure on the tab moves together — no tile left
+  quoting last week's number under this week's label.
+  - Confirmed: 0/2
+
 - **🆕 NEW — #981 — Weekly Plan + the Sunday notification (redesign stage 6).** A whole new screen,
   reached two ways: the Sunday-evening notification, and (once you save a plan) a row on Home.
   Six things to check.

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/HourComposition.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/HourComposition.kt
@@ -1,0 +1,134 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import kotlin.math.roundToLong
+
+/**
+ * "Your typical online hour" (#983 / brief §6) — where an hour of being online actually went, split
+ * three ways: **at stops**, **waiting**, and **the rest** (driving and anything we could not attribute).
+ *
+ * ## The derivation, exactly
+ *
+ * The denominator is [TimeEconomics.onlineMillis] — Σ session durations, the one fully measured span
+ * on this surface. Two of the three segments are measured directly out of the read model and the
+ * third is what is left:
+ *
+ * - **At stops** = Σ pickup dwell (`pickup_records.confirmedAt − arrivedAt`) + Σ dropoff dwell
+ *   (`delivery_records.completedAt − arrivedAt`). Both are stamped by the state machine at real phase
+ *   boundaries, so this is time the driver was parked at a store or at a door. The brief calls this
+ *   segment `at store`; it is named "at stops" here because it deliberately includes the door — a
+ *   customer's doorstep is not a store, and mislabelling measured door time would be a small lie in
+ *   service of a shorter word.
+ * - **Waiting** = [GapStats.totalMillis], the §7.8 gaps between finishing a drop and accepting the
+ *   next offer. Disjoint from "at stops" by construction: a gap runs from a completion to an accept,
+ *   while every dwell sits *inside* a job (after an accept, before its completion).
+ * - **The rest** = `online − at stops − waiting`, floored at 0. Mostly driving, and honestly ALSO:
+ *   the wait before the dash's first offer (no completion precedes it, so §7.8 cannot see it), the
+ *   tail after the last drop, time spent reading an offer, and any stop whose arrival was never
+ *   stamped. The surface must therefore never label this segment as pure driving without saying what
+ *   else is in it (§9).
+ *
+ * ## Coverage, stated rather than smoothed
+ *
+ * [stopsTimed] / [stops] is the fraction of the window's stops that carried both timestamps. An
+ * untimed stop is not estimated from its neighbours — its time simply stays in [restMillis], which
+ * makes the composition **conservative about at-stops time** rather than speculative. [gapCount] and
+ * [completionsWithoutGap] do the same job for the waiting segment. A surface reading this model states
+ * both numbers; that is the §9 thin-data rule applied to a bar chart.
+ *
+ * The "typical hour" figures ([atStopsMillisPerHour] and friends) are the same shares scaled to
+ * 3 600 000 ms, so they always sum to one hour and the bar and the sentence can never disagree.
+ */
+data class HourComposition(
+    /** Σ session durations for the window — the denominator (measured). */
+    val onlineMillis: Long,
+    /** Σ pickup + dropoff dwell (measured). */
+    val atStopsMillis: Long,
+    /** Σ §7.8 between-job gaps (measured). */
+    val waitingMillis: Long,
+    /** Stops that carried both timestamps — the at-stops coverage numerator. */
+    val stopsTimed: Int,
+    /** Pickups + deliveries in the window — the at-stops coverage denominator. */
+    val stops: Int,
+    /** How many gaps the waiting segment is made of. */
+    val gapCount: Int,
+    /** Drops that produced no measurable gap — the waiting-segment coverage figure. */
+    val completionsWithoutGap: Int,
+) {
+    /** Online time left over once the measured segments are removed — driving + unattributed (≥ 0). */
+    val restMillis: Long
+        get() = (onlineMillis - atStopsMillis - waitingMillis).coerceAtLeast(0L)
+
+    /** True once there is an online span to describe; the surface renders its empty state otherwise. */
+    val hasData: Boolean get() = onlineMillis > 0L
+
+    /** True when every stop in the window carried both timestamps (no coverage caveat to state). */
+    val allStopsTimed: Boolean get() = stops > 0 && stopsTimed == stops
+
+    /** True when NO stop was timed — "at stops" is structurally 0 and must be stated as unmeasured. */
+    val noStopsTimed: Boolean get() = stopsTimed == 0
+
+    /**
+     * The span the three shares are taken over. Normally exactly [onlineMillis]; if the measured
+     * segments somehow exceed the online span (incoherent stamps), it widens to their sum so the
+     * three shares still partition ONE hour instead of adding up to more than one — the bar and the
+     * sentence stay consistent, and the excess shows up as a vanished "rest" rather than as a
+     * 70-minute hour.
+     */
+    private val accountedMillis: Long
+        get() = maxOf(onlineMillis, atStopsMillis + waitingMillis)
+
+    /** At-stops share of the online hour, `0.0` when nothing is online. */
+    val atStopsShare: Double get() = share(atStopsMillis)
+
+    /** Waiting share of the online hour. */
+    val waitingShare: Double get() = share(waitingMillis)
+
+    /** Rest ("driving & other") share of the online hour. */
+    val restShare: Double get() = share(restMillis)
+
+    /** The at-stops slice of one typical online hour. */
+    val atStopsMillisPerHour: Long get() = perHour(atStopsShare)
+
+    /** The waiting slice of one typical online hour. */
+    val waitingMillisPerHour: Long get() = perHour(waitingShare)
+
+    /** The rest slice of one typical online hour. */
+    val restMillisPerHour: Long get() = perHour(restShare)
+
+    private fun share(part: Long): Double =
+        accountedMillis.takeIf { it > 0L }?.let { part.toDouble() / it.toDouble() } ?: 0.0
+
+    private fun perHour(share: Double): Long = (share * HOUR_MILLIS).roundToLong()
+
+    companion object {
+        private const val HOUR_MILLIS = 3_600_000.0
+
+        val EMPTY = HourComposition(
+            onlineMillis = 0L,
+            atStopsMillis = 0L,
+            waitingMillis = 0L,
+            stopsTimed = 0,
+            stops = 0,
+            gapCount = 0,
+            completionsWithoutGap = 0,
+        )
+
+        /**
+         * Compose the window's measured time ([time]) with its measured gaps ([gaps]).
+         *
+         * Both inputs describe the SAME window and the same session-anchored population (#655) — the
+         * repository reads them off one bounds pair — so the segments are commensurable by
+         * construction. Nothing here re-derives a duration: it only adds up what the read model
+         * already measured.
+         */
+        fun of(time: TimeEconomics, gaps: GapStats): HourComposition = HourComposition(
+            onlineMillis = time.onlineMillis,
+            atStopsMillis = time.atStopsMillis,
+            waitingMillis = gaps.totalMillis,
+            stopsTimed = time.stopsTimed,
+            stops = time.stops,
+            gapCount = gaps.count,
+            completionsWithoutGap = gaps.completionsWithoutGap,
+        )
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/NetPerHourPair.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/NetPerHourPair.kt
@@ -1,0 +1,117 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * The window's net **per hour, both ways** (#983 / brief §6 `4c`) — the pair
+ * `docs/design/running-hourly-rate.md` §2a defines and the app has never surfaced.
+ *
+ * ## The two denominators (the doc is the SSOT)
+ *
+ * The doc names them **active $/hr** and **scheduled $/hr**; the redesign brief §6 asks for them under
+ * the driver-facing labels **while working** and **whole shift**. Same two denominators, two
+ * vocabularies — the doc's definitions govern what is computed here, the brief's words govern what the
+ * card says:
+ *
+ * - **[whileWorking] (the doc's *active*)** — net ÷ time spent *engaged* on deliveries: driving to and
+ *   from, waiting at the store, standing at the door. "The efficiency of the work itself."
+ * - **[wholeShift] (the doc's *scheduled*)** — net ÷ total clock time online, **including the dry gaps
+ *   between offers**. "What actually lands in your pocket per hour of your life spent dashing."
+ *
+ * The doc's guidance (§7) is that a driver needs both: the first says whether the work is worth doing,
+ * the second whether the market is worth being in.
+ *
+ * ## How each denominator is measured
+ *
+ * [wholeShift] is the easy one: [TimeEconomics.onlineMillis], Σ session durations — the doc's §5
+ * "Layer 0" number, which contains **zero estimates**.
+ *
+ * [whileWorking] is `Σ per-delivery partition deltas − Σ §7.8 gaps`. The partition delta already spans
+ * accept-to-completion work, but it *also* swallows the dry wait that preceded the job (the delta runs
+ * from the previous drop), which is exactly the term the doc excludes from active time — so the gap
+ * fold is what finally makes an active denominator measurable rather than approximate. That is why
+ * §7.8 is listed in the brief as feeding §6.
+ *
+ * **Known, one-sided residuals** (stated, per §9; each pushes [whileWorking] DOWN, never up):
+ *  - the wait before a dash's *first* offer has no preceding completion, so §7.8 cannot see it and it
+ *    stays inside the working denominator;
+ *  - a gap whose following job never completed is subtracted from a denominator that never contained
+ *    it — the subtraction is floored at 0 and the residual is at most that one gap.
+ * So [whileWorking] is conservative by construction: the real active rate is at least this.
+ *
+ * ## What the numerator is
+ *
+ * [netProfit] is the window's **frozen** net (Σ per-delivery `netProfit` + unattributed pay + cash, as
+ * assembled by the repository) — an economy edit never rewrites it, and nothing here re-costs it
+ * (Principle 5). Both rates therefore share one numerator with the recap hero, so the pair can never
+ * disagree with the headline above it.
+ *
+ * Null rather than zero wherever the denominator was never measured (#936 discipline): a `0.0/hr` on a
+ * window with no measured time would read as "you earned nothing", which is a different claim.
+ */
+data class NetPerHourPair(
+    /** The window's frozen net — the shared numerator. */
+    val netProfit: Double,
+    /** Engaged time: Σ per-delivery deltas minus the measured gaps (≥ 0). */
+    val workingMillis: Long,
+    /** Σ session durations — every minute online. */
+    val onlineMillis: Long,
+    /** How many measured gaps were removed from the working denominator — the coverage figure. */
+    val gapsSubtracted: Int,
+    /** True when the window measured no per-delivery time at all (so [whileWorking] is null). */
+    val workingTimeUnmeasured: Boolean,
+) {
+    /** Net ÷ engaged hours (the doc's *active $/hr*); null when no engaged time was measured. */
+    val whileWorking: Double? get() = rate(workingMillis)
+
+    /** Net ÷ online hours (the doc's *scheduled $/hr*); null when no online time was measured. */
+    val wholeShift: Double? get() = rate(onlineMillis)
+
+    /** True when both rates exist — the card renders the pair, otherwise it states what is missing. */
+    val hasPair: Boolean get() = whileWorking != null && wholeShift != null
+
+    /**
+     * What [millis] of time is worth at the **while-working** rate — the brief's "leak stated in
+     * dollars" (`waiting cost you ~$X`).
+     *
+     * Deliberately priced at the working rate, not the whole-shift one: the question the leak answers
+     * is "what would that time have been worth had it been spent working", and the whole-shift rate
+     * already has this very idleness baked into its denominator (pricing waiting at a rate that
+     * assumes waiting is circular). It is a factual restatement of measured time at a measured rate —
+     * never a promise that the time *could* have been filled, which depends on a market we do not and
+     * will not see (doc §4). Null when the working rate was never measured.
+     */
+    fun valueOf(millis: Long): Double? =
+        whileWorking?.let { rate -> if (millis <= 0L) 0.0 else rate * (millis.toDouble() / HOUR_MILLIS) }
+
+    private fun rate(denominatorMillis: Long): Double? =
+        if (denominatorMillis <= 0L) null else netProfit / (denominatorMillis.toDouble() / HOUR_MILLIS)
+
+    companion object {
+        private const val HOUR_MILLIS = 3_600_000.0
+
+        val EMPTY = NetPerHourPair(
+            netProfit = 0.0,
+            workingMillis = 0L,
+            onlineMillis = 0L,
+            gapsSubtracted = 0,
+            workingTimeUnmeasured = true,
+        )
+
+        /**
+         * Build the pair from the window's frozen [netProfit], its measured [time], and its measured
+         * [gaps] — all three read off the same window bounds, so the numerator and both denominators
+         * describe one population.
+         */
+        fun of(netProfit: Double, time: TimeEconomics, gaps: GapStats): NetPerHourPair {
+            val deliveryMillis = time.deliveryMillis
+            return NetPerHourPair(
+                netProfit = netProfit,
+                // Floored at 0: over-subtraction is possible only via the documented one-sided
+                // residual above, and a negative denominator must never become a rate.
+                workingMillis = ((deliveryMillis ?: 0L) - gaps.totalMillis).coerceAtLeast(0L),
+                onlineMillis = time.onlineMillis,
+                gapsSubtracted = gaps.count,
+                workingTimeUnmeasured = deliveryMillis == null,
+            )
+        }
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/Percentiles.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/Percentiles.kt
@@ -1,0 +1,29 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import kotlin.math.ceil
+
+/**
+ * Nearest-rank percentiles over a small ASCENDING-sorted sample (#983).
+ *
+ * SQLite has no native percentile and every population that needs one here is small (a store's visits,
+ * a window's between-job gaps), so an exact in-Kotlin nearest rank is both honest and cheap — no
+ * interpolation, so every value returned is a value the driver actually experienced.
+ *
+ * One owner (Principle 5): the #159 store report card's dwell p50/p95 and the #983 §7.8 gap median/p90
+ * are the same computation, and two copies of a percentile convention (nearest-rank vs interpolated,
+ * 0- vs 1-based rank) is exactly the sort of duplicate that silently disagrees at the edges.
+ */
+object Percentiles {
+
+    /**
+     * The [p]-th percentile of [sorted] (ascending), nearest-rank. `p ∈ [0,1]`; null on an empty list.
+     *
+     * Nearest rank = `ceil(p × N)`, clamped into `1..N`, read 0-based — so `p = 0.5` over 4 samples is
+     * the 2nd value (never the mean of the 2nd and 3rd), and `p = 1.0` is the maximum.
+     */
+    fun nearestRank(sorted: List<Long>, p: Double): Long? {
+        if (sorted.isEmpty()) return null
+        val rank = ceil(p * sorted.size).toInt().coerceIn(1, sorted.size)
+        return sorted[rank - 1]
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/TimeEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/TimeEconomics.kt
@@ -25,6 +25,12 @@ import kotlin.math.roundToLong
  * deliveries that carried a captured deadline; [onTimeDeliveries] and [onTimeRate] cover ONLY that
  * subset — a delivery without a captured deadline is excluded, never silently counted as late.
  *
+ * **Stop dwell is measured, and its coverage is a field** (#983): [pickupDwellMillis]/
+ * [dropoffDwellMillis] sum only the stops that stamped the timestamps a dwell needs, and
+ * [pickupsTimed]/[dropoffsTimed] state how many of [pickups]/[deliveries] those were. An untimed stop
+ * is never estimated from its neighbours — it simply contributes no dwell, which makes [atStopsMillis]
+ * a floor rather than a guess (the [HourComposition] consumer states the coverage).
+ *
  * Nullable where a source SUM/AVG had no measurable input (no fabricated zeros): [deliveryMinutes]/
  * [deliveryMiles] are null on an empty set, [onTimeRate] is null with no deadline-carrying delivery,
  * [avgDeadlineMarginMillis] is null when no delivery carried a deadline.
@@ -46,6 +52,20 @@ data class TimeEconomics(
     val onTimeDeliveries: Int,
     /** AVG(deadline − completedAt) over deadline-carrying deliveries; positive = typically early. */
     val avgDeadlineMarginMillis: Double?,
+
+    // ── Stop dwell (#983 / brief §6 — "your typical online hour") ────────────
+    /** Deliveries in the same session-anchored population — the dropoff-stop denominator. */
+    val deliveries: Int = 0,
+    /** Σ `completedAt − arrivedAt` over deliveries that stamped an arrival (measured door time). */
+    val dropoffDwellMillis: Long = 0L,
+    /** Deliveries that carried a usable arrival stamp — the dropoff-dwell coverage numerator. */
+    val dropoffsTimed: Int = 0,
+    /** Confirmed pickups in the window's dashes — the pickup-stop denominator. */
+    val pickups: Int = 0,
+    /** Σ `confirmedAt − arrivedAt` over pickups that stamped both (measured store time). */
+    val pickupDwellMillis: Long = 0L,
+    /** Pickups that carried both stamps — the pickup-dwell coverage numerator. */
+    val pickupsTimed: Int = 0,
 ) {
     /** On-time fraction over deadline-carrying deliveries, or `null` when none carried a deadline. */
     val onTimeRate: Double?
@@ -67,6 +87,22 @@ data class TimeEconomics(
     /** Average online time per dash (ms), or `null` when no dashes in the period. */
     val avgDashMillis: Long?
         get() = if (sessions == 0) null else onlineMillis / sessions
+
+    /**
+     * Measured time PARKED at a stop (#983) — store dwell + door dwell. The
+     * [HourComposition] "at stops" segment; see its KDoc for why the door is included in a segment
+     * the brief calls "at store".
+     */
+    val atStopsMillis: Long
+        get() = pickupDwellMillis + dropoffDwellMillis
+
+    /** Every stop in the window (pickups + deliveries) — the dwell-coverage denominator. */
+    val stops: Int
+        get() = pickups + deliveries
+
+    /** Stops that carried the timestamps a dwell needs — the dwell-coverage numerator (never estimated). */
+    val stopsTimed: Int
+        get() = pickupsTimed + dropoffsTimed
 
     companion object {
         val EMPTY = TimeEconomics(

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WorkGaps.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/WorkGaps.kt
@@ -1,0 +1,163 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * One session-scoped record row reduced to what a gap measurement needs (#983 / brief §7.8): which
+ * dash it belongs to, its **fold order**, and its own domain timestamp.
+ *
+ * [sequenceId] and [timestamp] are deliberately separate fields, because the `app_events` ordering
+ * contract (#732) says they can disagree: `sequenceId` is the authoritative order key while
+ * `occurredAt` may lag it, so "which accept came next" is a SEQUENCE question and "how long was the
+ * gap" is a TIMESTAMP question. The read side supplies each row's own domain timestamp — a delivery's
+ * `completedAt`, an offer's `decidedAt` — never the event's `occurredAt`.
+ */
+data class SessionEvent(
+    val sessionId: String,
+    /** The source event's `sequenceId` (the read-model row PK) — the authoritative ordering key (#732). */
+    val sequenceId: Long,
+    /** The row's own DOMAIN timestamp (`completedAt` / `decidedAt`), which is what a duration is measured from. */
+    val timestamp: Long,
+)
+
+/**
+ * The window's **between-job gaps** (#983 / brief §7.8) — how long the driver sat between finishing a
+ * delivery and taking the next offer, measured over the window's own dashes.
+ *
+ * Every figure is MEASURED wall-clock time from the read model; nothing is estimated or smoothed.
+ * [medianMillis] is the headline because it is robust to the one 90-minute lull that would drag a
+ * mean; [p90Millis] is the "bad day" figure beside it.
+ *
+ * **Coverage is a field, not a footnote** (§9): [completionsWithoutGap] counts the drops that produced
+ * no measurable gap at all — the last drop of a dash (its wait ran into the dash ending, which is a
+ * tail, not a gap), and any pair whose stamps were incoherent. A surface that quotes a median must be
+ * able to say how much of the window it covers.
+ *
+ * **Long gaps are STATED, never dropped.** [longGapCount] counts gaps at or over
+ * [WorkGaps.LONG_GAP_MILLIS], and they remain in [totalMillis] and in the percentiles, because they
+ * are real online minutes that earned nothing. What we genuinely cannot know is *why* — the
+ * running-hourly-rate doc §3 names break-vs-dry-market as an unresolvable ambiguity on-device — so the
+ * honest move is to count the time and let the surface say a break may be in there.
+ */
+data class GapStats(
+    /** How many gaps were measured. */
+    val count: Int,
+    /** Σ of every measured gap — the "waiting" input to [HourComposition]. */
+    val totalMillis: Long,
+    /** Median gap, nearest-rank; null when nothing was measured. */
+    val medianMillis: Long?,
+    /** 90th-percentile gap, nearest-rank; null when nothing was measured. */
+    val p90Millis: Long?,
+    /** The single longest measured gap; null when nothing was measured. */
+    val longestMillis: Long?,
+    /** Measured gaps at or over [WorkGaps.LONG_GAP_MILLIS] — included above, stated separately. */
+    val longGapCount: Int,
+    /** Drops that produced no measurable gap (dash tail, or incoherent stamps) — the coverage figure. */
+    val completionsWithoutGap: Int,
+) {
+    /** True when at least one gap was measured — the surface renders its empty state otherwise. */
+    val hasGaps: Boolean get() = count > 0
+
+    /** Drops considered = the ones that yielded a gap plus the ones that could not. */
+    val completionsConsidered: Int get() = count + completionsWithoutGap
+
+    companion object {
+        val EMPTY = GapStats(
+            count = 0,
+            totalMillis = 0L,
+            medianMillis = null,
+            p90Millis = null,
+            longestMillis = null,
+            longGapCount = 0,
+            completionsWithoutGap = 0,
+        )
+    }
+}
+
+/**
+ * The pure §7.8 gap fold (#983): pair each completed delivery with the next offer the driver accepted
+ * **in the same dash**, and measure the wall-clock time between them.
+ *
+ * Rules, all of them fail-null (a gap we cannot defend is not reported):
+ *
+ * 1. **Never across dashes or days.** A gap only exists between two rows of the SAME `sessionId`.
+ *    Everything else — the overnight span between Tuesday's last drop and Wednesday's first accept —
+ *    is not a gap in anyone's language, so a session-less row (the "(No session)" bucket) contributes
+ *    nothing at all: it has no dash to be inside.
+ * 2. **Order by sequence, measure by timestamp** (#732). "The next accept" is the first accept with a
+ *    greater `sequenceId`; the duration is `accept.timestamp − completion.timestamp`. Ordering by the
+ *    timestamps would put the fold at the mercy of exactly the lag the contract warns about.
+ * 3. **The tail is not a gap.** A drop with no following accept in its dash was followed by the dash
+ *    ENDING; treating "last drop → session end" as a gap would invent a waiting period out of the
+ *    driver's decision to stop. It counts toward [GapStats.completionsWithoutGap] instead.
+ * 4. **Bounded by the dash.** A pairing whose accept lands after the session's own effective end is
+ *    incoherent (a stale id, a mis-stamped row), so it is dropped rather than measured — the same
+ *    fail-null-beats-fail-wrong rule (#745) the rest of the read model runs on.
+ * 5. **Non-positive durations are dropped.** A zero/negative span is a stamp anomaly, not an instant
+ *    hand-off.
+ *
+ * Pure and deterministic: same rows in, same stats out, no clock read (Principle 1).
+ */
+object WorkGaps {
+
+    /**
+     * At or above this, a gap is *reported* as possibly-a-break (2h).
+     *
+     * Deliberately a REPORTING threshold, not an exclusion: the running-hourly-rate doc §3 lists
+     * "break vs. dry-market disambiguation" as something we cannot resolve on-device without an
+     * explicit break signal, so dropping long gaps would quietly delete real unpaid online time,
+     * while keeping them silently would let one lunch redefine a "typical" hour. Counting them and
+     * saying so is the only honest option (§9).
+     */
+    const val LONG_GAP_MILLIS = 2L * 60L * 60L * 1_000L
+
+    /**
+     * Fold [completions] and [accepts] into the window's [GapStats].
+     *
+     * @param completions one entry per completed delivery in the window's dashes (`completedAt`).
+     * @param accepts one entry per accepted offer in the window's dashes (`decidedAt`).
+     * @param sessionEndMillis each dash's effective end (`endedAt`, else its last observed event) —
+     *   the rule-4 bound. A session absent from the map is simply unbounded.
+     */
+    fun compute(
+        completions: List<SessionEvent>,
+        accepts: List<SessionEvent>,
+        sessionEndMillis: Map<String, Long>,
+    ): GapStats {
+        if (completions.isEmpty()) return GapStats.EMPTY
+
+        val acceptsBySession = accepts
+            .groupBy { it.sessionId }
+            .mapValues { (_, rows) -> rows.sortedBy { it.sequenceId } }
+
+        val durations = ArrayList<Long>(completions.size)
+        var withoutGap = 0
+
+        completions.groupBy { it.sessionId }.forEach { (sessionId, drops) ->
+            val sessionAccepts = acceptsBySession[sessionId].orEmpty()
+            val bound = sessionEndMillis[sessionId]
+            drops.forEach { drop ->
+                // Rule 2: the NEXT accept is a sequence fact, not a timestamp one (#732).
+                val next = sessionAccepts.firstOrNull { it.sequenceId > drop.sequenceId }
+                val duration = when {
+                    next == null -> null                                        // rule 3 — tail
+                    bound != null && next.timestamp > bound -> null             // rule 4 — out of its dash
+                    else -> (next.timestamp - drop.timestamp).takeIf { it > 0 } // rule 5
+                }
+                if (duration == null) withoutGap++ else durations += duration
+            }
+        }
+
+        if (durations.isEmpty()) {
+            return GapStats.EMPTY.copy(completionsWithoutGap = withoutGap)
+        }
+        val sorted = durations.sorted()
+        return GapStats(
+            count = sorted.size,
+            totalMillis = sorted.sum(),
+            medianMillis = Percentiles.nearestRank(sorted, 0.50),
+            p90Millis = Percentiles.nearestRank(sorted, 0.90),
+            longestMillis = sorted.last(),
+            longGapCount = sorted.count { it >= LONG_GAP_MILLIS },
+            completionsWithoutGap = withoutGap,
+        )
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/TimeInsightsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/TimeInsightsTest.kt
@@ -1,0 +1,223 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #983 / brief §6 — the two composed Time-tab models: "your typical online hour"
+ * ([HourComposition]) and the `docs/design/running-hourly-rate.md` §2a rate pair ([NetPerHourPair]).
+ *
+ * What matters here is the arithmetic that carries a claim:
+ *  - the three hour segments partition ONE hour, with the residual absorbing everything unmeasured;
+ *  - coverage is reported rather than smoothed (an untimed stop contributes no dwell, and the model
+ *    says how many stops that was);
+ *  - the doc's two denominators are what they say they are — engaged time excludes the dry gaps,
+ *    online time includes them — so `whileWorking ≥ wholeShift` always holds;
+ *  - a missing denominator yields null, never a `$0.00/hr` that would read as a measurement (#936).
+ */
+class TimeInsightsTest {
+
+    private val minute = 60_000L
+    private val hour = 60 * minute
+
+    private fun time(
+        onlineMillis: Long = 4 * hour,
+        deliveryMinutes: Double? = 120.0,
+        deliveries: Int = 6,
+        dropoffDwellMillis: Long = 12 * minute,
+        dropoffsTimed: Int = 6,
+        pickups: Int = 6,
+        pickupDwellMillis: Long = 30 * minute,
+        pickupsTimed: Int = 6,
+    ) = TimeEconomics(
+        sessions = 1,
+        onlineMillis = onlineMillis,
+        deliveryMinutes = deliveryMinutes,
+        miles = 40.0,
+        deliveryMiles = 30.0,
+        deliveriesWithDeadline = 0,
+        onTimeDeliveries = 0,
+        avgDeadlineMarginMillis = null,
+        deliveries = deliveries,
+        dropoffDwellMillis = dropoffDwellMillis,
+        dropoffsTimed = dropoffsTimed,
+        pickups = pickups,
+        pickupDwellMillis = pickupDwellMillis,
+        pickupsTimed = pickupsTimed,
+    )
+
+    private fun gaps(count: Int = 4, totalMillis: Long = 24 * minute, withoutGap: Int = 2) =
+        GapStats(
+            count = count,
+            totalMillis = totalMillis,
+            medianMillis = if (count == 0) null else totalMillis / count,
+            p90Millis = if (count == 0) null else totalMillis / count,
+            longestMillis = if (count == 0) null else totalMillis / count,
+            longGapCount = 0,
+            completionsWithoutGap = withoutGap,
+        )
+
+    // ── HourComposition ─────────────────────────────────────────────────
+
+    @Test
+    fun `at stops is pickup dwell plus door dwell, waiting is the measured gaps`() {
+        val composition = HourComposition.of(time(), gaps())
+
+        assertEquals(42 * minute, composition.atStopsMillis)   // 30 store + 12 door
+        assertEquals(24 * minute, composition.waitingMillis)
+        // Rest = 4h online − 42m − 24m
+        assertEquals(4 * hour - 42 * minute - 24 * minute, composition.restMillis)
+        assertTrue(composition.hasData)
+    }
+
+    @Test
+    fun `the three per-hour slices partition one hour`() {
+        val composition = HourComposition.of(time(), gaps())
+        val sum = composition.atStopsMillisPerHour + composition.waitingMillisPerHour +
+            composition.restMillisPerHour
+
+        // Rounding to whole millis can move the sum by at most 1 ms per segment.
+        assertTrue("sum was $sum", sum in (hour - 3)..(hour + 3))
+        assertEquals(1.0, composition.atStopsShare + composition.waitingShare + composition.restShare, 1e-9)
+    }
+
+    @Test
+    fun `an untimed stop contributes no dwell and is stated as coverage`() {
+        val composition = HourComposition.of(
+            time(dropoffsTimed = 2, dropoffDwellMillis = 4 * minute, pickupsTimed = 3, pickupDwellMillis = 15 * minute),
+            gaps(),
+        )
+
+        assertEquals(19 * minute, composition.atStopsMillis)  // only the timed stops
+        assertEquals(5, composition.stopsTimed)
+        assertEquals(12, composition.stops)
+        assertFalse(composition.allStopsTimed)
+        assertFalse(composition.noStopsTimed)
+    }
+
+    @Test
+    fun `no stop timed at all leaves at-stops structurally zero and flags it`() {
+        val composition = HourComposition.of(
+            time(dropoffsTimed = 0, dropoffDwellMillis = 0, pickupsTimed = 0, pickupDwellMillis = 0),
+            gaps(),
+        )
+
+        assertEquals(0L, composition.atStopsMillis)
+        assertTrue(composition.noStopsTimed)
+        // Everything unmeasured lands in the residual — never smoothed into the at-stops segment.
+        assertEquals(4 * hour - 24 * minute, composition.restMillis)
+    }
+
+    @Test
+    fun `measured segments exceeding the online span still partition one hour`() {
+        // Incoherent data: 3h of dwell + 1h of gaps inside a 2h online span.
+        val composition = HourComposition.of(
+            time(onlineMillis = 2 * hour, pickupDwellMillis = 3 * hour, dropoffDwellMillis = 0),
+            gaps(count = 1, totalMillis = hour),
+        )
+
+        assertEquals(0L, composition.restMillis)   // never negative
+        assertEquals(1.0, composition.atStopsShare + composition.waitingShare + composition.restShare, 1e-9)
+    }
+
+    @Test
+    fun `an empty window has no composition to render`() {
+        val composition = HourComposition.of(TimeEconomics.EMPTY, GapStats.EMPTY)
+
+        assertFalse(composition.hasData)
+        assertEquals(0.0, composition.atStopsShare, 1e-9)
+        assertEquals(0L, composition.restMillisPerHour)
+    }
+
+    // ── NetPerHourPair (the doc's active / scheduled denominators) ───────
+
+    @Test
+    fun `while working divides by engaged time, whole shift by every online minute`() {
+        // 4h online, 2h of delivery partition deltas, 24m of that was dry waiting.
+        val rates = NetPerHourPair.of(netProfit = 96.0, time = time(), gaps = gaps())
+
+        assertEquals(2 * hour - 24 * minute, rates.workingMillis)
+        assertEquals(4 * hour, rates.onlineMillis)
+        assertEquals(96.0 / 1.6, rates.whileWorking!!, 1e-9)   // 96 min engaged = 1.6h
+        assertEquals(24.0, rates.wholeShift!!, 1e-9)           // 96 / 4h
+        assertTrue(rates.hasPair)
+    }
+
+    /** The doc's whole point: the shift rate can never beat the working rate, because it is the same
+     *  money over a wider denominator. */
+    @Test
+    fun `while working is never below whole shift`() {
+        val rates = NetPerHourPair.of(120.0, time(), gaps())
+        assertTrue(rates.whileWorking!! >= rates.wholeShift!!)
+    }
+
+    @Test
+    fun `with no gaps measured the two rates differ only by the unattributed tail`() {
+        val rates = NetPerHourPair.of(80.0, time(), GapStats.EMPTY)
+
+        assertEquals(2 * hour, rates.workingMillis)   // nothing subtracted
+        assertEquals(0, rates.gapsSubtracted)
+        assertEquals(40.0, rates.whileWorking!!, 1e-9)
+        assertEquals(20.0, rates.wholeShift!!, 1e-9)
+    }
+
+    @Test
+    fun `gaps exceeding the measured delivery time floor the denominator instead of inverting it`() {
+        val rates = NetPerHourPair.of(50.0, time(deliveryMinutes = 10.0), gaps(count = 3, totalMillis = 2 * hour))
+
+        assertEquals(0L, rates.workingMillis)
+        assertNull(rates.whileWorking)      // no denominator ⇒ no rate (never a negative or infinite one)
+        assertEquals(12.5, rates.wholeShift!!, 1e-9)
+        assertFalse(rates.hasPair)
+    }
+
+    @Test
+    fun `unmeasured delivery time yields a null working rate, not zero`() {
+        val rates = NetPerHourPair.of(30.0, time(deliveryMinutes = null), gaps(count = 0, totalMillis = 0))
+
+        assertTrue(rates.workingTimeUnmeasured)
+        assertNull(rates.whileWorking)
+        assertEquals(7.5, rates.wholeShift!!, 1e-9)
+    }
+
+    @Test
+    fun `an empty window prices nothing`() {
+        val rates = NetPerHourPair.of(0.0, TimeEconomics.EMPTY, GapStats.EMPTY)
+
+        assertNull(rates.whileWorking)
+        assertNull(rates.wholeShift)
+        assertNull(rates.valueOf(30 * minute))
+    }
+
+    // ── the leak, in dollars ────────────────────────────────────────────
+
+    @Test
+    fun `the waiting leak is measured time priced at the while-working rate`() {
+        val rates = NetPerHourPair.of(96.0, time(), gaps())
+        val composition = HourComposition.of(time(), gaps())
+
+        // 24 minutes of waiting at the while-working rate (96 / 1.6h = $60/hr) = $24.
+        assertEquals(24.0, rates.valueOf(composition.waitingMillis)!!, 1e-9)
+    }
+
+    @Test
+    fun `no waiting costs nothing, rather than reading as unmeasured`() {
+        val rates = NetPerHourPair.of(96.0, time(), GapStats.EMPTY)
+        assertEquals(0.0, rates.valueOf(0L)!!, 1e-9)
+    }
+
+    // ── the shared percentile convention ────────────────────────────────
+
+    @Test
+    fun `nearest rank never interpolates and never invents a value`() {
+        val sorted = listOf(1L, 2L, 3L, 4L)
+
+        assertEquals(2L, Percentiles.nearestRank(sorted, 0.50))   // not 2.5
+        assertEquals(4L, Percentiles.nearestRank(sorted, 1.0))
+        assertEquals(1L, Percentiles.nearestRank(sorted, 0.0))    // rank clamped to 1
+        assertNull(Percentiles.nearestRank(emptyList(), 0.5))
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WorkGapsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/WorkGapsTest.kt
@@ -1,0 +1,211 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #983 / brief §7.8 — the pure between-job gap fold.
+ *
+ * The interesting properties are all about what does NOT count as a gap: a span across two dashes, the
+ * tail after a dash's last drop, a pairing that escapes its own session's end, an out-of-order stamp.
+ * Each of those, counted, would invent waiting time the driver never had — and the whole point of the
+ * card is that the number is measured.
+ *
+ * The ordering property is the #732 contract: "which accept came next" is a `sequenceId` question, so
+ * a fold that sorted by timestamp would pick a different accept whenever `occurredAt` lagged.
+ */
+class WorkGapsTest {
+
+    private val minute = 60_000L
+    private val hour = 60 * minute
+    private val base = 1_600_000_000_000L
+
+    private fun drop(session: String, seq: Long, at: Long) = SessionEvent(session, seq, at)
+    private fun accept(session: String, seq: Long, at: Long) = SessionEvent(session, seq, at)
+
+    // ── the happy path ──────────────────────────────────────────────────
+
+    @Test
+    fun `a completion followed by an accept in the same dash is a gap`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base)),
+            accepts = listOf(accept("A", 11, base + 8 * minute)),
+            sessionEndMillis = mapOf("A" to base + hour),
+        )
+
+        assertEquals(1, stats.count)
+        assertEquals(8 * minute, stats.totalMillis)
+        assertEquals(8 * minute, stats.medianMillis)
+        assertEquals(8 * minute, stats.p90Millis)
+        assertEquals(8 * minute, stats.longestMillis)
+        assertEquals(0, stats.completionsWithoutGap)
+        assertTrue(stats.hasGaps)
+    }
+
+    @Test
+    fun `the gap runs to the NEXT accept, not a later one`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base)),
+            accepts = listOf(
+                accept("A", 11, base + 5 * minute),
+                accept("A", 20, base + 40 * minute),
+            ),
+            sessionEndMillis = mapOf("A" to base + 2 * hour),
+        )
+
+        assertEquals(1, stats.count)
+        assertEquals(5 * minute, stats.totalMillis)
+    }
+
+    /** #732: sequence is the order key; a lagging timestamp must not re-pick which accept came next. */
+    @Test
+    fun `next accept is chosen by sequenceId, not by timestamp`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base)),
+            accepts = listOf(
+                // Listed out of order AND stamped out of order: seq 11 is the next accept even though
+                // seq 30 carries an earlier timestamp.
+                accept("A", 30, base + 3 * minute),
+                accept("A", 11, base + 9 * minute),
+            ),
+            sessionEndMillis = mapOf("A" to base + 2 * hour),
+        )
+
+        assertEquals(1, stats.count)
+        assertEquals(9 * minute, stats.totalMillis)
+    }
+
+    // ── what is NOT a gap ───────────────────────────────────────────────
+
+    @Test
+    fun `a gap never spans two dashes`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("MON", 10, base)),
+            // Next day's dash, next accept — 20 hours later, and emphatically not a gap.
+            accepts = listOf(accept("TUE", 11, base + 20 * hour)),
+            sessionEndMillis = mapOf("MON" to base + hour, "TUE" to base + 21 * hour),
+        )
+
+        assertEquals(0, stats.count)
+        assertEquals(0L, stats.totalMillis)
+        assertEquals(1, stats.completionsWithoutGap)
+        assertFalse(stats.hasGaps)
+        assertNull(stats.medianMillis)
+    }
+
+    @Test
+    fun `the last drop of a dash is a tail, not a gap`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base), drop("A", 30, base + 30 * minute)),
+            accepts = listOf(accept("A", 11, base + 6 * minute)),
+            sessionEndMillis = mapOf("A" to base + hour),
+        )
+
+        assertEquals(1, stats.count)               // only the first drop paired
+        assertEquals(6 * minute, stats.totalMillis)
+        assertEquals(1, stats.completionsWithoutGap) // the tail, counted as coverage
+        assertEquals(2, stats.completionsConsidered)
+    }
+
+    @Test
+    fun `an accept past its own dash's end is dropped, not measured`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base)),
+            accepts = listOf(accept("A", 11, base + 3 * hour)),   // after the dash ended
+            sessionEndMillis = mapOf("A" to base + hour),
+        )
+
+        assertEquals(0, stats.count)
+        assertEquals(1, stats.completionsWithoutGap)
+    }
+
+    @Test
+    fun `a session with no recorded end is simply unbounded`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base)),
+            accepts = listOf(accept("A", 11, base + 3 * hour)),
+            sessionEndMillis = emptyMap(),
+        )
+
+        assertEquals(1, stats.count)
+        assertEquals(3 * hour, stats.totalMillis)
+    }
+
+    @Test
+    fun `a non-positive span is a stamp anomaly and is not measured`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base + 5 * minute)),
+            accepts = listOf(accept("A", 11, base)),   // earlier than the drop it follows in sequence
+            sessionEndMillis = mapOf("A" to base + hour),
+        )
+
+        assertEquals(0, stats.count)
+        assertEquals(1, stats.completionsWithoutGap)
+    }
+
+    @Test
+    fun `no completions at all is empty, not a fabricated zero-gap`() {
+        val stats = WorkGaps.compute(
+            completions = emptyList(),
+            accepts = listOf(accept("A", 11, base)),
+            sessionEndMillis = mapOf("A" to base + hour),
+        )
+
+        assertEquals(GapStats.EMPTY, stats)
+    }
+
+    // ── the distribution ────────────────────────────────────────────────
+
+    @Test
+    fun `median and p90 are nearest-rank over every measured gap`() {
+        // Ten gaps of 1..10 minutes, laid out across one dash.
+        val completions = (0 until 10).map { drop("A", 10L + it * 10, base + it * hour) }
+        val accepts = (0 until 10).map { accept("A", 11L + it * 10, base + it * hour + (it + 1) * minute) }
+
+        val stats = WorkGaps.compute(completions, accepts, mapOf("A" to base + 24 * hour))
+
+        assertEquals(10, stats.count)
+        assertEquals((1..10).sumOf { it * minute }, stats.totalMillis)
+        assertEquals(5 * minute, stats.medianMillis)   // ceil(0.5 × 10) = 5th value
+        assertEquals(9 * minute, stats.p90Millis)      // ceil(0.9 × 10) = 9th value
+        assertEquals(10 * minute, stats.longestMillis)
+        assertEquals(0, stats.longGapCount)
+    }
+
+    /** A long gap is COUNTED (it is real unpaid online time) and reported, never silently dropped. */
+    @Test
+    fun `long gaps stay in the totals and are counted separately`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base), drop("A", 30, base + 5 * hour)),
+            accepts = listOf(
+                accept("A", 11, base + 10 * minute),
+                accept("A", 31, base + 5 * hour + WorkGaps.LONG_GAP_MILLIS),
+            ),
+            sessionEndMillis = mapOf("A" to base + 12 * hour),
+        )
+
+        assertEquals(2, stats.count)
+        assertEquals(10 * minute + WorkGaps.LONG_GAP_MILLIS, stats.totalMillis)
+        assertEquals(1, stats.longGapCount)
+        assertEquals(WorkGaps.LONG_GAP_MILLIS, stats.longestMillis)
+    }
+
+    @Test
+    fun `gaps from separate dashes are all measured, each inside its own`() {
+        val stats = WorkGaps.compute(
+            completions = listOf(drop("A", 10, base), drop("B", 50, base + 10 * hour)),
+            accepts = listOf(
+                accept("A", 11, base + 4 * minute),
+                accept("B", 51, base + 10 * hour + 12 * minute),
+            ),
+            sessionEndMillis = mapOf("A" to base + hour, "B" to base + 12 * hour),
+        )
+
+        assertEquals(2, stats.count)
+        assertEquals(16 * minute, stats.totalMillis)
+        assertEquals(4 * minute, stats.medianMillis)   // ceil(0.5 × 2) = 1st value
+    }
+}


### PR DESCRIPTION
Closes #983. Refs #969 (redesign epic — **stage 7 of 7; the build order is complete**).

The Time tab's two brief-§6 additions, plus the §7.8 plumbing they both stand on. Read-side only:
**no schema change, no `PROJECTOR_VERSION` bump, no economy dependency, DAO-only repository.**

`docs/design/running-hourly-rate.md` is the semantic SSOT here and it had never reached the UI.

## 1. §7.8 — the gap fold (`:domain WorkGaps`)

Per-gap durations between a completion and the next accept. Rules, all fail-null:

- **Never across dashes or days.** Same `sessionId` only — so a `sessionId IS NULL` "(No session)"
  row contributes nothing. This is the ONE window aggregate with no null-session fallback; a
  dash-less row has no dash to sit inside, which is the definition, not an oversight.
- **Order by sequence, measure by timestamp** (#732). "Which accept came next" is a `sequenceId`
  question; the duration comes from each row's own domain timestamp (`completedAt` / `decidedAt`).
  Sorting by timestamp would re-pick the accept exactly where `occurredAt` lags.
- **The tail is not a gap.** A dash's last drop was followed by the driver *stopping*; counting
  "last drop → session end" would invent waiting. It lands in `completionsWithoutGap` (coverage).
- **Bounded by the dash** — an accept past `COALESCE(endedAt, lastEventAt)` (the definition
  `sessionTotals`/`sessionSpans` already use) is incoherent → dropped. Non-positive spans too.
- **Long gaps (≥ 2 h) are counted and STATED, never excluded.** Doc §3 names break-vs-dry-market as
  unresolvable on-device, so deleting real unpaid online time would be the bigger lie; the card
  reports them unjudged (§9). Median/p90 are nearest-rank, so every figure is one the driver had.

**Source decision — read model, not `app_events`.** The brief says "the events exist in the log";
they also exist already decoded and already bucketed: `delivery_records.completedAt` /
`offer_records.decidedAt` ARE those payloads' own domain timestamps, and each row's PK IS its source
event's `sequenceId`. Paging the log would re-decode JSON for identical numbers while
re-implementing the session-anchored windowing every sibling aggregate shares (Principle 5). The
#732 contract is honoured either way — the DAO orders by `sequenceId`, the pure fold measures from
the domain timestamps.

One documented divergence: the accept side **keeps** a resolved orphan (#810 B2), unlike every other
offer read. Those reads exclude it because it would inflate an outcome COUNT; here the row is the
instant the driver stopped waiting, and dropping it would fuse two real gaps into one fabricated
long one. Test-pinned both ways.

## 2. While working vs whole shift (`NetPerHourPair`) — brief 4c

**Doc-vs-brief terms: the doc wins on definitions, the brief on wording.** The doc §2a calls them
**active** and **scheduled**; the brief §6 asks for **while working** / **whole shift**. Same two
denominators, so the pair is computed to the doc's definitions and labelled in the brief's words,
with the doc's distinction stated in one plain line on the card.

- *whole shift* = Σ session durations (the doc's Layer-0 number — zero estimates).
- *while working* = Σ per-delivery partition deltas **− the measured gaps**. The delta already
  swallows the dry wait the doc excludes from active time, which is exactly why §7.8 feeds §6.

Both residuals are one-sided and documented (a dash's pre-first-offer wait has no preceding
completion, so it stays in the denominator) ⇒ while-working is conservative by construction.
Numerator is the window's own FROZEN net, shared with the recap hero. Missing denominator ⇒ **null,
never `$0.00/hr`** (#936). Invariant `whileWorking ≥ wholeShift` is test-pinned.

## 3. "Your typical online hour" (`HourComposition`)

Three segments over the online span, scaled to one hour:

- **at stops** = Σ pickup dwell (`confirmedAt−arrivedAt`) + Σ **door** dwell
  (`completedAt−arrivedAt`). Named "at stops", not the brief's "at store" — a doorstep is not a
  store, and mislabelling measured door time for a shorter word is a small lie.
- **waiting** = the §7.8 gaps. Disjoint from dwell by construction (a gap runs completion→accept; a
  dwell sits inside a job).
- **the rest** = residual, labelled **"driving & other"** and never as pure driving: it also holds
  the pre-first-offer wait, the post-last-drop tail, and every untimed stop. The caption says so.

**Coverage is stated, not smoothed (§9).** `stopsTimed`/`stops` and `gapCount`/
`completionsWithoutGap` are model fields; an untimed stop is never estimated from its neighbours, so
at-stops is a floor and the untimed time falls into the residual. Three coverage states get three
different sentences (all timed / partly timed / none timed). Shares are taken over
`max(online, measured)` so the three slices always partition exactly one hour.

The leak is priced at the **while-working** rate (`Waiting cost you about $X in this window`) —
pricing it at the whole-shift rate would be circular, since that rate already contains the idleness.
Factual, window-scoped, and null-stated when no working rate was measured.

## Stage-6 seam: NOT backfilled (deliberate)

Brief §8's `NOT PICKED` "· gaps ran 14m" clause needs a **per-weekday, lifetime** gap median. §7.8's
stats are **window-scoped**, so appending one to the other would back a per-weekday claim with an
all-week number — a §9 violation. Doing it properly needs a new grouped lifetime read, a new
`UnpickedDay` field, and a `WeeklyPlanner` signature change: not a clean drop-in through existing
planner shapes, so stage 6 is left untouched and the reason is recorded in CLAUDE.md §5.

## Plumbing

- `deliveryTimeTotals` gained door dwell + coverage counters + the population COUNT (same
  byte-identical WHERE); new `pickupDwellTotals` / `completionEvents` / `acceptEvents` /
  `sessionEndBounds`.
- `TimeEconomics` gained the dwell/stop fields (defaults, so no call site churn) + derived
  `atStopsMillis`/`stops`/`stopsTimed`.
- `Percentiles.nearestRank` is now ONE owner for the #159 dwell p50/p95 and the new gap median/p90
  (the repository's private copy is gone).
- The Time tab's three new cards live in their own `TimeInsightCards.kt`; `TimeTab.kt` stays a host.

## Tests

- `:domain WorkGapsTest` — session bounding, #732 sequence ordering vs a lagging timestamp, tails,
  cross-dash refusal, out-of-dash accepts, non-positive spans, long-gap counting, nearest-rank.
- `:domain TimeInsightsTest` — the three slices partition one hour (incl. the incoherent-data case),
  coverage reported not smoothed, `whileWorking ≥ wholeShift`, null-not-zero denominators, the
  leak's dollar math, the percentile convention.
- `:core:data AnalyticsTimeInsightReadsTest` — session anchoring, the no-null-session rule, the
  resolved-orphan divergence (funnel drops it, gap read keeps it), dwell coverage + incoherent
  pairs, the end-to-end fold.
- `:app AnalyticsViewModelTest` — the composed models reach the Time tab's state.

Full `testDebugUnitTest :domain:test` **green**; `:app:lintVitalRelease` **green**.

## Field validation

Checklist item added to `docs/field-testing/README.md` (`Confirmed: 0/2`): the two rates' ordering,
the hour bar against a remembered dash, the gap figures (and the two failure shapes — a cross-dash
gap, or `0 gaps` on a dash with obvious waiting), and window-paging coherence.

### Design-goal review

1. **UDF** — read-side only. Pure `:domain` folds, repository serves Flows, the ViewModel composes
   into one immutable `AnalyticsUiState`, composables are data-in renderers. Nothing re-enters the
   state machine.
2. **MAD** — Kotlin/Compose/Flow throughout; the new read rides the existing `…In(boundsFlow)`
   pattern with `flowOn(Dispatchers.Default)` + `distinctUntilChanged` (the heatmap precedent).
3. **Single responsibility** — three small `:domain` files, one new `:app` card file so `TimeTab.kt`
   does not grow past being a host.
4. **Kotlin/Android practice** — data classes over tuples, derived properties over stored copies,
   nullable-where-unmeasured rather than sentinel zeros.
5. **SSOT** — gap facts come from the read model (not a second decode of the log); the rate pair's
   numerator is the repository's own frozen net; `Percentiles` replaces a private duplicate;
   `sessionEndBounds` reuses the existing effective-end definition; `TimeEconomics.atStopsMillis` is
   derived, not stored twice; all formatting through `Formats`/`formatDuration`.
6. **Security & privacy** — no new capture, network, or PII surface. The new reads carry timestamps,
   session ids, counts and durations only; no customer/merchant text enters these models or the
   cards. Bounded work: the row-level gap reads are window-scoped and folded off-main.
7. **Logging** — no log sites added.
8. **Platform-agnostic core** — no `Platform` literal anywhere in the diff; the accept-outcome string
   is passed in from `OfferOutcome.ACCEPTED.eventTypeName` rather than inlined.

**Reactive UI** — the Time tab is a review surface over a fixed window (no `rememberNow()`), and the
time+gaps reads share ONE combine slot so a card can never render a composition against a different
window's gaps.

**§9 honesty** — coverage stated on every derived figure, residual never called "driving", long gaps
counted but explicitly not judged, thin/absent denominators stated instead of rendered as `$0.00`,
dollar leak factual and window-scoped, frozen-net disclosure retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
